### PR TITLE
BST-5714 - Update brakeman to v6.0.1

### DIFF
--- a/scanners/boostsecurityio/brakeman/module.yaml
+++ b/scanners/boostsecurityio/brakeman/module.yaml
@@ -12,7 +12,7 @@ steps:
   - scan:
       command:
         docker:
-          image: presidentbeef/brakeman:latest@sha256:7416e4cf46131d5f920be496485d30d55a9b9f00acec28847ae1e5f10ac837f4
+          image: presidentbeef/brakeman:v6.0.0.1@sha256:511c731712b4252d7056511e67051a498fe333b956ba89b19e1e938de363a94a
           command: --format json --quiet --no-pager --no-exit-on-warn --no-exit-on-error --force .
           workdir: /src
       format: sarif

--- a/scanners/boostsecurityio/brakeman/module.yaml
+++ b/scanners/boostsecurityio/brakeman/module.yaml
@@ -12,7 +12,7 @@ steps:
   - scan:
       command:
         docker:
-          image: presidentbeef/brakeman:v6.0.0.1@sha256:511c731712b4252d7056511e67051a498fe333b956ba89b19e1e938de363a94a
+          image: presidentbeef/brakeman:v6.0.0.1@sha256:78add476199155ef44d77509536ab6b0819a8d2fce7e11f2da1d22aa26c5e6b4
           command: --format json --quiet --no-pager --no-exit-on-warn --no-exit-on-error --force .
           workdir: /src
       format: sarif


### PR DESCRIPTION
Last successful smoke tests run  (with Docker manifest digest)
https://github.com/boost-sandbox/module-tests-brakeman/actions/runs/5262289129

With configuration against this feature branch
https://github.com/boost-sandbox/module-tests-brakeman/actions/runs/5262289129/workflow

Previous version vs latest outputs almost the same findings on the target projects, except that it gives 2 more findings for `railsgoat`, otherwise the same as before. For `postal` project it gives 2 more as CWE-1104 (unmaintained gems)
