### PR TITLE
BST-5714  - Update gosec to 2.16.0

### DIFF
--- a/scanners/boostsecurityio/gosec/module.yaml
+++ b/scanners/boostsecurityio/gosec/module.yaml
@@ -22,7 +22,7 @@ steps:
   - scan:
       command:
         docker:
-          image: securego/gosec:2.16.0@sha256:89fc4a05b5326fdd07cb432cb974a3d3390e46e4ff9e17de28a308fe718761c4
+          image: securego/gosec:2.16.0@sha256:c63f91e8d6af392313b24de92d1e35fb61306ddb8231ef0f112e3e4f0d8e96fc
           command: -fmt sarif -no-fail -track-suppressions ./...
           workdir: /app
           environment:

--- a/scanners/boostsecurityio/gosec/module.yaml
+++ b/scanners/boostsecurityio/gosec/module.yaml
@@ -22,7 +22,7 @@ steps:
   - scan:
       command:
         docker:
-          image: securego/gosec:2.14.0@sha256:73858f8b1b9b7372917677151ec6deeceeaa40c5b02753080bd647dede14e213
+          image: securego/gosec:2.16.0@sha256:89fc4a05b5326fdd07cb432cb974a3d3390e46e4ff9e17de28a308fe718761c4
           command: -fmt sarif -no-fail -track-suppressions ./...
           workdir: /app
           environment:


### PR DESCRIPTION
Updated from 2.14.0 to 2.16.0
https://github.com/securego/gosec/compare/v2.14.0...v2.16.0

---

Latest smoke tests run here
https://github.com/boost-sandbox/module-tests-gosec/actions/runs/5268108474

Using this feature branch
https://github.com/boost-sandbox/module-tests-gosec/actions/runs/5268108474/workflow

---

Results are very similar but it appears that on some target projects it produces a few less findings (ex. `osv-scanner` project gives 19 instead of 23 and `gitleaks` has 10 instead of 11)

Looks like those missing are all because of `G307` which indeed was literally omitted https://github.com/securego/gosec/commit/d5a9c737234eaf1ac0ac26fc299c6a5f5212730e , we will keep the stale rule in the `rules.yaml` as we never know if they bring it back....
