### PR TITLE
BST-5993: Updated registry-action to v1.2.0

### DIFF
--- a/.github/workflows/registry-scanner.yaml
+++ b/.github/workflows/registry-scanner.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Scan Registry
-        uses: boostsecurityio/scanner-registry-action@v1.2.0
+        uses: boostsecurityio/scanner-registry-action@5c99aa3ecf8dce442f705f738d3118a534ae5221 # v1.2.0
         with:
           api_endpoint: ${{ vars.BOOST_API_ENDPOINT }}
           api_token: ${{ secrets.BOOST_SYSTEM_API_KEY_REGISTRY }}

--- a/.github/workflows/registry-scanner.yaml
+++ b/.github/workflows/registry-scanner.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Scan Registry
-        uses: boostsecurityio/scanner-registry-action@v1.1.0
+        uses: boostsecurityio/scanner-registry-action@v1.2.0
         with:
           api_endpoint: ${{ vars.BOOST_API_ENDPOINT }}
           api_token: ${{ secrets.BOOST_SYSTEM_API_KEY_REGISTRY }}


### PR DESCRIPTION
Updated scanner-registry-action to [v1.2.0](https://github.com/boostsecurityio/scanner-registry-action/releases/tag/v1.2.0).

This version allows for automatic update detection for scanner imports.


## How this was tested
Testing was done in [my fork](https://github.com/ledo01/dev-registry), where I created a dummy scanner and rules-realm before updating the action version.
I then updated only the rule-realm and made sure that an upload was triggered for the dummy scanner, also confirmed that the data was correct in the rules-management backend.