### PR TITLE
Fix GHA workflow for PRs from forks

### DIFF
--- a/.github/workflows/registry-scanner.yaml
+++ b/.github/workflows/registry-scanner.yaml
@@ -4,12 +4,14 @@ on:
     branches:
       - main
 
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types:
       - opened
       - synchronize
+
+permissions: read-all
 
 jobs:
   scan_job:

--- a/.github/workflows/registry-scanner.yaml
+++ b/.github/workflows/registry-scanner.yaml
@@ -11,7 +11,8 @@ on:
       - opened
       - synchronize
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   scan_job:


### PR DESCRIPTION
Because we expect to receive PRs from forks (including our own `dev-registry`), we need to use `pull_request_target` because we need to use the `vars` (not necessarily the `secrets`) during the PR validation stage.

This is considered safe because the repo does not contain any execution content, the only action we run is maintained entirely by us and designed to consume untrusted data (`rules.yaml` and `module.yaml` in a way that is safe)