### PR TITLE
Do not use pull_request_target (#36)

### DIFF
--- a/.github/workflows/registry-scanner.yaml
+++ b/.github/workflows/registry-scanner.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
 
-  pull_request_target:
+  pull_request:
     branches:
       - main
     types:
@@ -27,4 +27,3 @@ jobs:
         with:
           api_endpoint: ${{ vars.BOOST_API_ENDPOINT }}
           api_token: ${{ secrets.BOOST_SYSTEM_API_KEY_REGISTRY }}
-          docs_url: ${{ vars.BOOST_DOCS_URL }}


### PR DESCRIPTION
In the PR context, we don't really need the real docs var. We can use the default one, as we do not do 404 checks on it anyway