### PR TITLE
BST-5714 - Remove semgrep CWE allow list

### DIFF
--- a/scanners/boostsecurityio/semgrep/module.yaml
+++ b/scanners/boostsecurityio/semgrep/module.yaml
@@ -23,5 +23,5 @@ steps:
       format: sarif
       post-processor:
         docker:
-          image: public.ecr.aws/boostsecurityio/boost-scanner-semgrep:1a0c890@sha256:df731015e8a6c10aa185601dc19c0a772c3d9f3f4c76ba5e33ed959bec5fe8d6
+          image: public.ecr.aws/boostsecurityio/boost-scanner-semgrep:233743f@sha256:83611487e28b8727f1f6cda0889bc50e7322ea7841064c2324d80f3aaf1c4282
           command: process

--- a/scanners/boostsecurityio/semgrep/module.yaml
+++ b/scanners/boostsecurityio/semgrep/module.yaml
@@ -13,7 +13,7 @@ steps:
   - scan:
       command:
         docker:
-          image: returntocorp/semgrep:1.24.0@sha256:a99766f9ea158adede767dd69b5271636d400194d94748430eb1e68ab2efbc61
+          image: returntocorp/semgrep:1.27.0@sha256:7026020ebb6c1aa477431a2ba550df3ae4d080822e391d03bb816eeac700a36b
           command: semgrep scan --sarif --quiet --disable-version-check
           workdir: /src
           environment:
@@ -23,5 +23,5 @@ steps:
       format: sarif
       post-processor:
         docker:
-          image: public.ecr.aws/boostsecurityio/boost-scanner-semgrep:37a2507@sha256:23e93e66f3e91701a6af566c81b918fba459d1244205af4ab6e2c7fb14c08e69
+          image: public.ecr.aws/boostsecurityio/boost-scanner-semgrep:1a0c890@sha256:df731015e8a6c10aa185601dc19c0a772c3d9f3f4c76ba5e33ed959bec5fe8d6
           command: process


### PR DESCRIPTION
Depends on https://github.com/boostsecurityio/boostsec-scanner-semgrep/pull/16
Please approve that one first ^, so that we can pin the hash on the `main` branch there.

Tested using module tests
https://github.com/boost-sandbox/module-tests-semgrep/actions/runs/5291114081

`main` branch converter
https://app.circleci.com/pipelines/github/boostsecurityio/boostsec-scanner-semgrep/79/workflows/08786201-aceb-49ac-988c-b2523f382634/jobs/165?invite=true#step-116-7