### PR TITLE
Add ability to re-trigger workflow

### DIFF
--- a/.github/workflows/registry-scanner.yaml
+++ b/.github/workflows/registry-scanner.yaml
@@ -9,6 +9,7 @@ on:
       - main
     types:
       - opened
+      - reopened
       - synchronize
 
 permissions:


### PR DESCRIPTION
Added `reopened` event for PR to ease this kind re-trigger in the future
We were missing step security action in community org and blocked the registry scan