### PR TITLE
BST-6033 - Fix OSV support

### DIFF
--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -32,14 +32,23 @@ config:
 setup:
   - name: Install OSV-Scanner
     environment:
-      VERSION: 1.1.0
-      LINUX_X86_64_SHA: 73b3b297f0a9a3fa28ea45fd45b3b9e74e5a0044ec1c03693a4e8aff0d169f86
-      LINUX_ARM64_SHA: fed5a1109f45410d8bcecba852aab48f1812b5254e3cfdd2950ef9330e9e29c2
-      MACOS_ARM64_SHA: 65fa9c435535fd58cc1fd6878a09009c44d608c749c41b8f7a7e4727cda0e6ee
+      VERSION: 1.3.5
+      MACOS_X86_64_SHA: 65001b8c97559ed6fb632ae3ee574f9f4b2fb05184d3049876fd56f7557fe915
+      MACOS_ARM64_SHA: 303c1a27843fef36fd7ec06fb972e92cb120380f32dbfdc1a0af2d565103cef4
+      LINUX_X86_64_SHA: 39fb4263afa493d6058e7ad9e1fe699ce070871b7b67b5f5f9eead358c7ab2ee
+      LINUX_ARM64_SHA: f71396c832d727fb90e1c072d912ece0b9a5359cae5df47d54e88ef712d99e41
     run: |
       BINARY_URL="https://github.com/google/osv-scanner/releases/download/v${VERSION}"
       ARCH=$(uname -m)
       case "$(uname -sm)" in
+        "Darwin x86_64")
+          BINARY_URL="${BINARY_URL}/osv-scanner_${VERSION}_darwin_amd64"
+          SHA="${MACOS_X86_64_SHA} osv-scanner"
+          ;;
+        "Darwin arm64")
+          BINARY_URL="${BINARY_URL}/osv-scanner_${VERSION}_darwin_arm64"
+          SHA="${MACOS_ARM64_SHA} osv-scanner"
+          ;;
         "Linux x86_64")
           BINARY_URL="${BINARY_URL}/osv-scanner_${VERSION}_linux_amd64"
           SHA="${LINUX_X86_64_SHA} osv-scanner"
@@ -47,10 +56,6 @@ setup:
         "Linux aarch64")
           BINARY_URL="${BINARY_URL}/osv-scanner_${VERSION}_linux_arm64"
           SHA="${LINUX_ARM64_SHA} osv-scanner"
-          ;;
-        "Darwin arm64")
-          BINARY_URL="${BINARY_URL}/osv-scanner_${VERSION}_darwin_arm64"
-          SHA="${MACOS_ARM64_SHA} osv-scanner"
           ;;
         *)
           echo "Unsupported machine: ${OPTARG}"
@@ -77,7 +82,7 @@ steps:
     format: sarif
     post-processor:
       docker:
-          image: public.ecr.aws/boostsecurityio/boost-converter-sca:0b7418a@sha256:231b8276beb9fb14258a77cf53d799bac1e77f35b89fd587ad1228d79df88984
+          image: public.ecr.aws/boostsecurityio/boost-converter-sca:884a076@sha256:760fce5307bc80d7d2a0d0dddcdd87696c4539b30695ffd25cae69ec3061c7e0
           command: process --scanner osv
           environment:
               PYTHONIOENCODING: utf-8

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -82,7 +82,7 @@ steps:
     format: sarif
     post-processor:
       docker:
-          image: public.ecr.aws/boostsecurityio/boost-converter-sca:884a076@sha256:760fce5307bc80d7d2a0d0dddcdd87696c4539b30695ffd25cae69ec3061c7e0
+          image: public.ecr.aws/boostsecurityio/boost-converter-sca:6caacc5@sha256:d1556a777d2e6ef1c721f489ec5f2c4a05b8a5960098dff41768e9527f558161
           command: process --scanner osv
           environment:
               PYTHONIOENCODING: utf-8


### PR DESCRIPTION
- Updating to latest version of OSV 1.3.5
- Fixed converter bug (see https://github.com/boostsecurityio/boostsec-converter-sca/pull/20)
- Added MacOS x64 support

-----

Updated hashes for 1.3.5
```
VERSION=1.3.5; for ARCH in MACOS_X86_64=darwin_amd64 MACOS_ARM64=darwin_arm64 LINUX_X86_64=linux_amd64 LINUX_ARM64=linux_arm64; do KEY=${ARCH%%=*}; VALUE=${ARCH#*=}; echo "${KEY}_SHA: $(curl -sSL https://github.com/google/osv-scanner/releases/download/v${VERSION}/osv-scanner_${VERSION}_${VALUE} | sha256sum | cut -d' ' -f1)"; done
```