### PR TITLE
BST-7278: add blackduck server-side module

### DIFF
--- a/server-side-scanners/boostsecurityio/blackduck/module.yaml
+++ b/server-side-scanners/boostsecurityio/blackduck/module.yaml
@@ -1,0 +1,2 @@
+name: BoostSecurity BlackDuck
+namespace: boostsecurityio/blackduck

--- a/server-side-scanners/boostsecurityio/blackduck/rules.yaml
+++ b/server-side-scanners/boostsecurityio/blackduck/rules.yaml
@@ -1,0 +1,2 @@
+import:
+  - boostsecurityio/sca-cve


### PR DESCRIPTION
Added BlackDuck as a server-side scanner using the sca-cwe rules.