### PR TITLE
BST-7524 Add semgrep pro

### DIFF
--- a/scanners/boostsecurityio/semgrep-pro/README.md
+++ b/scanners/boostsecurityio/semgrep-pro/README.md
@@ -1,0 +1,6 @@
+# SEMGREP
+
+## Environment
+
+- (Mandatory) `SEMGREP_APP_TOKEN` : The API key to authenticate to authenticate to Semgrep Pro
+- `SEMGREP_RULES` : The set of rules to use during the scan

--- a/scanners/boostsecurityio/semgrep-pro/module.yaml
+++ b/scanners/boostsecurityio/semgrep-pro/module.yaml
@@ -1,0 +1,47 @@
+api_version: 1.0
+
+id: boostsecurityio/semgrep-pro
+name: BoostSecurity semgrep Pro
+namespace: boostsecurityio/semgrep-pro
+scan_types:
+  - sast
+
+config:
+  support_diff_scan: true
+  require_full_repo: true
+  include_files:
+  - .semgrep/*
+
+setup:
+  - name: Validate Semgrep API Key
+    run: |
+      if [ -z "$SEMGREP_APP_TOKEN" ]; then
+        echo "Error: SEMGREP_APP_TOKEN environment variable is not set."
+        exit 1
+      fi
+  - name: Build Docker with Semgrep Pro pre-installed
+    run: |
+      export DOCKER_BUILDKIT=1
+      echo -n $SEMGREP_APP_TOKEN > ./semgrep_app_token.secret
+      echo "FROM returntocorp/semgrep:1.39.0@sha256:fd3d6ccd390677db83880d99a9f494500c003ec82177cc141f6ec37f71633a96" > Dockerfile
+      echo "RUN --mount=type=secret,id=semgrep_app_token /bin/sh -c 'SEMGREP_APP_TOKEN=\$(cat /run/secrets/semgrep_app_token) semgrep install-semgrep-pro'" >> Dockerfile
+      docker build --secret id=semgrep_app_token,src=./semgrep_app_token.secret -t semgrep-with-pro-engine:latest .
+      rm ./semgrep_app_token.secret
+
+steps:
+  - scan:
+      command:
+        docker:
+          image: semgrep-with-pro-engine:latest
+          command: semgrep scan --pro --sarif --quiet --disable-version-check
+          workdir: /src
+          environment:
+            XDG_CONFIG_HOME: /tmp
+            HOME: /tmp
+            SEMGREP_RULES: ${SEMGREP_RULES:-auto}
+            SEMGREP_APP_TOKEN: $SEMGREP_APP_TOKEN
+      format: sarif
+      post-processor:
+        docker:
+          image: public.ecr.aws/boostsecurityio/boost-scanner-semgrep:233743f@sha256:83611487e28b8727f1f6cda0889bc50e7322ea7841064c2324d80f3aaf1c4282
+          command: process

--- a/scanners/boostsecurityio/semgrep-pro/rules.yaml
+++ b/scanners/boostsecurityio/semgrep-pro/rules.yaml
@@ -1,0 +1,2 @@
+import:
+  - boostsecurityio/mitre-cwe

--- a/scanners/boostsecurityio/semgrep/module.yaml
+++ b/scanners/boostsecurityio/semgrep/module.yaml
@@ -15,7 +15,7 @@ steps:
   - scan:
       command:
         docker:
-          image: returntocorp/semgrep:1.27.0@sha256:7026020ebb6c1aa477431a2ba550df3ae4d080822e391d03bb816eeac700a36b
+          image: returntocorp/semgrep:1.39.0@sha256:fd3d6ccd390677db83880d99a9f494500c003ec82177cc141f6ec37f71633a96
           command: semgrep scan --sarif --quiet --disable-version-check
           workdir: /src
           environment:


### PR DESCRIPTION
- Declares semgrep-pro module
- Updated semgrep at the same time
- Installs semgrep pro, requires new mandatory API token parameter (`SEMGREP_APP_TOKEN`)
- Ran smoke tests https://github.com/boost-sandbox/module-tests-semgrep/actions/runs/6163218790/job/16726307889

Uses manifest digest for latest multi-arch semgrep Docker image
```
docker buildx imagetools inspect returntocorp/semgrep:1.39.0 | head -n3
Name:      docker.io/returntocorp/semgrep:1.39.0
MediaType: application/vnd.docker.distribution.manifest.list.v2+json
Digest:    sha256:fd3d6ccd390677db83880d99a9f494500c003ec82177cc141f6ec37f71633a96
```

