### PR TITLE
BST-7784 - Fix modules to properly support monorepo

### DIFF
--- a/scanners/boostsecurityio/semgrep-pro/module.yaml
+++ b/scanners/boostsecurityio/semgrep-pro/module.yaml
@@ -33,7 +33,7 @@ steps:
       command:
         docker:
           image: semgrep-with-pro-engine:latest
-          command: semgrep scan --pro --sarif --quiet --disable-version-check
+          command: semgrep scan --pro --sarif --quiet --disable-version-check .
           workdir: /src
           environment:
             XDG_CONFIG_HOME: /tmp

--- a/scanners/boostsecurityio/semgrep/module.yaml
+++ b/scanners/boostsecurityio/semgrep/module.yaml
@@ -16,7 +16,7 @@ steps:
       command:
         docker:
           image: returntocorp/semgrep:1.39.0@sha256:fd3d6ccd390677db83880d99a9f494500c003ec82177cc141f6ec37f71633a96
-          command: semgrep scan --sarif --quiet --disable-version-check
+          command: semgrep scan --sarif --quiet --disable-version-check .
           workdir: /src
           environment:
             XDG_CONFIG_HOME: /tmp


### PR DESCRIPTION
While working on semgrep pro module, discovered that existing semgrep module did not correctly support mono repo slices
Some months ago some modules (checkov and brakeman) had been updated https://github.com/boost-community/scanner-registry/commit/f7460e2e51a21d59b162b78e9d68faae72e95976 but not semgrep

<img width="2011" alt="image" src="https://github.com/boostsecurityio/dev-registry/assets/76956526/1b1cb5b5-522a-41ec-b371-ce6a88603412">

Smoke tested
https://github.com/boost-sandbox/module-tests-semgrep/actions/runs/6177943657/job/16770151890