### PR TITLE
checkov: Remove rule prefix from pretty name

### DIFF
--- a/scanners/boostsecurityio/checkov-tf-plan/rules.yaml
+++ b/scanners/boostsecurityio/checkov-tf-plan/rules.yaml
@@ -8,7 +8,7 @@ rules:
     description: Check for unencrypted Ansible resources.
     group: cloud-unencrypted-resources
     name: CKV2_ANSIBLE_1
-    pretty_name: 'CKV2_ANSIBLE_1: Ensure that HTTPS url is used with uri'
+    pretty_name: 'Ensure that HTTPS url is used with uri'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_ANSIBLE_2:
     categories:
@@ -19,7 +19,7 @@ rules:
     description: Check for unencrypted Ansible resources.
     group: cloud-unencrypted-resources
     name: CKV2_ANSIBLE_2
-    pretty_name: 'CKV2_ANSIBLE_2: Ensure that HTTPS url is used with get_url'
+    pretty_name: 'Ensure that HTTPS url is used with get_url'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_ANSIBLE_3:
     categories:
@@ -30,7 +30,7 @@ rules:
     description: Check for misconfigurations in Ansible resources.
     group: cloud-weak-configuration
     name: CKV2_ANSIBLE_3
-    pretty_name: 'CKV2_ANSIBLE_3: Ensure block is handling task errors properly'
+    pretty_name: 'Ensure block is handling task errors properly'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_ANSIBLE_4:
     categories:
@@ -41,7 +41,7 @@ rules:
     description: Check for weak Ansible configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_ANSIBLE_4
-    pretty_name: 'CKV2_ANSIBLE_4: Ensure that packages with untrusted or missing GPG
+    pretty_name: 'Ensure that packages with untrusted or missing GPG
       signatures are not used by dnf'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_ANSIBLE_5:
@@ -53,7 +53,7 @@ rules:
     description: Check for weak Ansible configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_ANSIBLE_5
-    pretty_name: 'CKV2_ANSIBLE_5: Ensure that SSL validation isn''t disabled with
+    pretty_name: 'Ensure that SSL validation isn''t disabled with
       dnf'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_ANSIBLE_6:
@@ -65,7 +65,7 @@ rules:
     description: Check for weak Ansible configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_ANSIBLE_6
-    pretty_name: 'CKV2_ANSIBLE_6: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with dnf'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_1:
@@ -77,7 +77,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_1
-    pretty_name: 'CKV2_AWS_1: Ensure that all NACL are attached to subnets'
+    pretty_name: 'Ensure that all NACL are attached to subnets'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_10:
     categories:
@@ -87,7 +87,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_10
-    pretty_name: 'CKV2_AWS_10: Ensure CloudTrail trails are integrated with CloudWatch
+    pretty_name: 'Ensure CloudTrail trails are integrated with CloudWatch
       Logs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_11:
@@ -97,7 +97,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_11
-    pretty_name: 'CKV2_AWS_11: Ensure VPC flow logging is enabled in all VPCs'
+    pretty_name: 'Ensure VPC flow logging is enabled in all VPCs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_12:
     categories:
@@ -108,7 +108,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_12
-    pretty_name: 'CKV2_AWS_12: Ensure the default security group of every VPC restricts
+    pretty_name: 'Ensure the default security group of every VPC restricts
       all traffic'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_14:
@@ -120,7 +120,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV2_AWS_14
-    pretty_name: 'CKV2_AWS_14: Ensure that IAM groups includes at least one IAM user'
+    pretty_name: 'Ensure that IAM groups includes at least one IAM user'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_15:
     categories:
@@ -130,7 +130,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_15
-    pretty_name: 'CKV2_AWS_15: Ensure that auto Scaling groups that are associated
+    pretty_name: 'Ensure that auto Scaling groups that are associated
       with a load balancer, are using Elastic Load Balancing health checks.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_16:
@@ -141,7 +141,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_16
-    pretty_name: 'CKV2_AWS_16: Ensure that Auto Scaling is enabled on your DynamoDB
+    pretty_name: 'Ensure that Auto Scaling is enabled on your DynamoDB
       tables'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_18:
@@ -153,7 +153,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_18
-    pretty_name: 'CKV2_AWS_18: Ensure that Elastic File System (Amazon EFS) file systems
+    pretty_name: 'Ensure that Elastic File System (Amazon EFS) file systems
       are added in the backup plans of AWS Backup'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_19:
@@ -165,7 +165,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_19
-    pretty_name: 'CKV2_AWS_19: Ensure that all EIP addresses allocated to a VPC are
+    pretty_name: 'Ensure that all EIP addresses allocated to a VPC are
       attached to EC2 instances'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_2:
@@ -177,7 +177,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV2_AWS_2
-    pretty_name: 'CKV2_AWS_2: Ensure that only encrypted EBS volumes are attached
+    pretty_name: 'Ensure that only encrypted EBS volumes are attached
       to EC2 instances'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_20:
@@ -189,7 +189,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_20
-    pretty_name: 'CKV2_AWS_20: Ensure that ALB redirects HTTP requests into HTTPS
+    pretty_name: 'Ensure that ALB redirects HTTP requests into HTTPS
       ones'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_21:
@@ -201,7 +201,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV2_AWS_21
-    pretty_name: 'CKV2_AWS_21: Ensure that all IAM users are members of at least one
+    pretty_name: 'Ensure that all IAM users are members of at least one
       IAM group.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_22:
@@ -212,7 +212,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV2_AWS_22
-    pretty_name: 'CKV2_AWS_22: Ensure an IAM User does not have access to the console'
+    pretty_name: 'Ensure an IAM User does not have access to the console'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_23:
     categories:
@@ -222,7 +222,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_23
-    pretty_name: 'CKV2_AWS_23: Route53 A Record has Attached Resource'
+    pretty_name: 'Route53 A Record has Attached Resource'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_27:
     categories:
@@ -232,7 +232,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_27
-    pretty_name: 'CKV2_AWS_27: Ensure Postgres RDS as aws_rds_cluster has Query Logging
+    pretty_name: 'Ensure Postgres RDS as aws_rds_cluster has Query Logging
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_28:
@@ -242,7 +242,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_28
-    pretty_name: 'CKV2_AWS_28: Ensure public facing ALB are protected by WAF'
+    pretty_name: 'Ensure public facing ALB are protected by WAF'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_29:
     categories:
@@ -251,7 +251,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_29
-    pretty_name: 'CKV2_AWS_29: Ensure public API gateway are protected by WAF'
+    pretty_name: 'Ensure public API gateway are protected by WAF'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_3:
     categories:
@@ -260,7 +260,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_3
-    pretty_name: 'CKV2_AWS_3: Ensure GuardDuty is enabled to specific org/region'
+    pretty_name: 'Ensure GuardDuty is enabled to specific org/region'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_30:
     categories:
@@ -270,7 +270,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_30
-    pretty_name: 'CKV2_AWS_30: Ensure Postgres RDS as aws_db_instance has Query Logging
+    pretty_name: 'Ensure Postgres RDS as aws_db_instance has Query Logging
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_31:
@@ -280,7 +280,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_31
-    pretty_name: 'CKV2_AWS_31: Ensure WAF2 has a Logging Configuration'
+    pretty_name: 'Ensure WAF2 has a Logging Configuration'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_32:
     categories:
@@ -290,7 +290,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_32
-    pretty_name: 'CKV2_AWS_32: Ensure CloudFront distribution has a response headers
+    pretty_name: 'Ensure CloudFront distribution has a response headers
       policy attached'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_33:
@@ -300,7 +300,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_33
-    pretty_name: 'CKV2_AWS_33: Ensure AppSync is protected by WAF'
+    pretty_name: 'Ensure AppSync is protected by WAF'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_34:
     categories:
@@ -311,7 +311,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV2_AWS_34
-    pretty_name: 'CKV2_AWS_34: AWS SSM Parameter should be Encrypted'
+    pretty_name: 'AWS SSM Parameter should be Encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_35:
     categories:
@@ -321,7 +321,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_35
-    pretty_name: 'CKV2_AWS_35: AWS NAT Gateways should be utilized for the default
+    pretty_name: 'AWS NAT Gateways should be utilized for the default
       route'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_36:
@@ -333,7 +333,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV2_AWS_36
-    pretty_name: 'CKV2_AWS_36: Ensure terraform is not sending SSM secrets to untrusted
+    pretty_name: 'Ensure terraform is not sending SSM secrets to untrusted
       domains over HTTP'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_37:
@@ -345,7 +345,7 @@ rules:
     description: Check for weak AWS configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV2_AWS_37
-    pretty_name: 'CKV2_AWS_37: Ensure Codecommit associates an approval rule'
+    pretty_name: 'Ensure Codecommit associates an approval rule'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_38:
     categories:
@@ -356,7 +356,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_38
-    pretty_name: 'CKV2_AWS_38: Ensure Domain Name System Security Extensions (DNSSEC)
+    pretty_name: 'Ensure Domain Name System Security Extensions (DNSSEC)
       signing is enabled for Amazon Route 53 public hosted zones'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_39:
@@ -367,7 +367,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_39
-    pretty_name: 'CKV2_AWS_39: Ensure Domain Name System (DNS) query logging is enabled
+    pretty_name: 'Ensure Domain Name System (DNS) query logging is enabled
       for Amazon Route 53 hosted zones'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_4:
@@ -378,7 +378,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_4
-    pretty_name: 'CKV2_AWS_4: Ensure API Gateway stage have logging level defined
+    pretty_name: 'Ensure API Gateway stage have logging level defined
       as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_40:
@@ -390,7 +390,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV2_AWS_40
-    pretty_name: 'CKV2_AWS_40: Ensure AWS IAM policy does not allow full IAM privileges'
+    pretty_name: 'Ensure AWS IAM policy does not allow full IAM privileges'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_41:
     categories:
@@ -401,7 +401,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV2_AWS_41
-    pretty_name: 'CKV2_AWS_41: Ensure an IAM role is attached to EC2 instance'
+    pretty_name: 'Ensure an IAM role is attached to EC2 instance'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_42:
     categories:
@@ -412,7 +412,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV2_AWS_42
-    pretty_name: 'CKV2_AWS_42: Ensure AWS CloudFront distribution uses custom SSL
+    pretty_name: 'Ensure AWS CloudFront distribution uses custom SSL
       certificate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_43:
@@ -424,7 +424,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV2_AWS_43
-    pretty_name: 'CKV2_AWS_43: Ensure S3 Bucket does not allow access to all Authenticated
+    pretty_name: 'Ensure S3 Bucket does not allow access to all Authenticated
       users'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_44:
@@ -436,7 +436,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_44
-    pretty_name: 'CKV2_AWS_44: Ensure AWS route table with VPC peering does not contain
+    pretty_name: 'Ensure AWS route table with VPC peering does not contain
       routes overly permissive to all traffic'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_45:
@@ -448,7 +448,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_45
-    pretty_name: 'CKV2_AWS_45: Ensure AWS Config recorder is enabled to record all
+    pretty_name: 'Ensure AWS Config recorder is enabled to record all
       supported resources'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_46:
@@ -460,7 +460,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_46
-    pretty_name: 'CKV2_AWS_46: Ensure AWS Cloudfront Distribution with S3 have Origin
+    pretty_name: 'Ensure AWS Cloudfront Distribution with S3 have Origin
       Access set to enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_47:
@@ -472,7 +472,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_47
-    pretty_name: 'CKV2_AWS_47: Ensure AWS CloudFront attached WAFv2 WebACL is configured
+    pretty_name: 'Ensure AWS CloudFront attached WAFv2 WebACL is configured
       with AMR for Log4j Vulnerability'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_48:
@@ -484,7 +484,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_48
-    pretty_name: 'CKV2_AWS_48: Ensure AWS Config must record all possible resources'
+    pretty_name: 'Ensure AWS Config must record all possible resources'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_49:
     categories:
@@ -495,7 +495,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV2_AWS_49
-    pretty_name: 'CKV2_AWS_49: Ensure AWS Database Migration Service endpoints have
+    pretty_name: 'Ensure AWS Database Migration Service endpoints have
       SSL configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_5:
@@ -507,7 +507,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_5
-    pretty_name: 'CKV2_AWS_5: Ensure that Security Groups are attached to another
+    pretty_name: 'Ensure that Security Groups are attached to another
       resource'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_50:
@@ -519,7 +519,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_50
-    pretty_name: 'CKV2_AWS_50: Ensure AWS ElastiCache Redis cluster with Multi-AZ
+    pretty_name: 'Ensure AWS ElastiCache Redis cluster with Multi-AZ
       Automatic Failover feature set to enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_51:
@@ -531,7 +531,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_51
-    pretty_name: 'CKV2_AWS_51: Ensure AWS API Gateway endpoints uses client certificate
+    pretty_name: 'Ensure AWS API Gateway endpoints uses client certificate
       authentication'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_52:
@@ -543,7 +543,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV2_AWS_52
-    pretty_name: 'CKV2_AWS_52: Ensure AWS ElasticSearch/OpenSearch Fine-grained access
+    pretty_name: 'Ensure AWS ElasticSearch/OpenSearch Fine-grained access
       control is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_53:
@@ -555,7 +555,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_53
-    pretty_name: 'CKV2_AWS_53: Ensure AWS API gateway request is validated'
+    pretty_name: 'Ensure AWS API gateway request is validated'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_54:
     categories:
@@ -566,7 +566,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_54
-    pretty_name: 'CKV2_AWS_54: Ensure AWS CloudFront distribution is using secure
+    pretty_name: 'Ensure AWS CloudFront distribution is using secure
       SSL protocols for HTTPS communication'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_55:
@@ -578,7 +578,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_55
-    pretty_name: 'CKV2_AWS_55: Ensure AWS EMR cluster is configured with security
+    pretty_name: 'Ensure AWS EMR cluster is configured with security
       configuration'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_56:
@@ -590,7 +590,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV2_AWS_56
-    pretty_name: 'CKV2_AWS_56: Ensure AWS Managed IAMFullAccess IAM policy is not
+    pretty_name: 'Ensure AWS Managed IAMFullAccess IAM policy is not
       used.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_57:
@@ -602,7 +602,7 @@ rules:
     description: Check that ensures best practices in AWS secrets management.
     group: cloud-weak-secrets-management
     name: CKV2_AWS_57
-    pretty_name: 'CKV2_AWS_57: Ensure Secrets Manager secrets should have automatic
+    pretty_name: 'Ensure Secrets Manager secrets should have automatic
       rotation enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_58:
@@ -614,7 +614,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_58
-    pretty_name: 'CKV2_AWS_58: Ensure AWS Neptune cluster deletion protection is enabled'
+    pretty_name: 'Ensure AWS Neptune cluster deletion protection is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_59:
     categories:
@@ -625,7 +625,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_59
-    pretty_name: 'CKV2_AWS_59: Ensure ElasticSearch/OpenSearch has dedicated master
+    pretty_name: 'Ensure ElasticSearch/OpenSearch has dedicated master
       node enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_6:
@@ -637,7 +637,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV2_AWS_6
-    pretty_name: 'CKV2_AWS_6: Ensure that S3 bucket has a Public Access block'
+    pretty_name: 'Ensure that S3 bucket has a Public Access block'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_60:
     categories:
@@ -648,7 +648,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_60
-    pretty_name: 'CKV2_AWS_60: Ensure RDS instance with copy tags to snapshots is
+    pretty_name: 'Ensure RDS instance with copy tags to snapshots is
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_61:
@@ -660,7 +660,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_61
-    pretty_name: 'CKV2_AWS_61: Ensure that an S3 bucket has a lifecycle configuration'
+    pretty_name: 'Ensure that an S3 bucket has a lifecycle configuration'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_62:
     categories:
@@ -671,7 +671,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_62
-    pretty_name: 'CKV2_AWS_62: Ensure S3 buckets should have event notifications enabled'
+    pretty_name: 'Ensure S3 buckets should have event notifications enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_7:
     categories:
@@ -682,7 +682,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_7
-    pretty_name: 'CKV2_AWS_7: Ensure that Amazon EMR clusters'' security groups are
+    pretty_name: 'Ensure that Amazon EMR clusters'' security groups are
       not open to the world'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_8:
@@ -694,7 +694,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_8
-    pretty_name: 'CKV2_AWS_8: Ensure that RDS clusters has backup plan of AWS Backup'
+    pretty_name: 'Ensure that RDS clusters has backup plan of AWS Backup'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_9:
     categories:
@@ -705,7 +705,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_9
-    pretty_name: 'CKV2_AWS_9: Ensure that EBS are added in the backup plans of AWS
+    pretty_name: 'Ensure that EBS are added in the backup plans of AWS
       Backup'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_1:
@@ -715,7 +715,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_1
-    pretty_name: 'CKV2_AZURE_1: Ensure storage for critical data are encrypted with
+    pretty_name: 'Ensure storage for critical data are encrypted with
       Customer Managed Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_10:
@@ -727,7 +727,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_10
-    pretty_name: 'CKV2_AZURE_10: Ensure that Microsoft Antimalware is configured to
+    pretty_name: 'Ensure that Microsoft Antimalware is configured to
       automatically updates for Virtual Machines'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_11:
@@ -737,7 +737,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_11
-    pretty_name: 'CKV2_AZURE_11: Ensure that Azure Data Explorer encryption at rest
+    pretty_name: 'Ensure that Azure Data Explorer encryption at rest
       uses a customer-managed key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_12:
@@ -748,7 +748,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_12
-    pretty_name: 'CKV2_AZURE_12: Ensure that virtual machines are backed up using
+    pretty_name: 'Ensure that virtual machines are backed up using
       Azure Backup'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_13:
@@ -760,7 +760,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_13
-    pretty_name: 'CKV2_AZURE_13: Ensure that sql servers enables data security policy'
+    pretty_name: 'Ensure that sql servers enables data security policy'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_14:
     categories:
@@ -771,7 +771,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_14
-    pretty_name: 'CKV2_AZURE_14: Ensure that Unattached disks are encrypted'
+    pretty_name: 'Ensure that Unattached disks are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_15:
     categories:
@@ -780,7 +780,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_15
-    pretty_name: 'CKV2_AZURE_15: Ensure that Azure data factories are encrypted with
+    pretty_name: 'Ensure that Azure data factories are encrypted with
       a customer-managed key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_16:
@@ -790,7 +790,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_16
-    pretty_name: 'CKV2_AZURE_16: Ensure that MySQL server enables customer-managed
+    pretty_name: 'Ensure that MySQL server enables customer-managed
       key for encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_17:
@@ -800,7 +800,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_17
-    pretty_name: 'CKV2_AZURE_17: Ensure that PostgreSQL server enables customer-managed
+    pretty_name: 'Ensure that PostgreSQL server enables customer-managed
       key for encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_18:
@@ -810,7 +810,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_18
-    pretty_name: 'CKV2_AZURE_18: Ensure that Storage Accounts use customer-managed
+    pretty_name: 'Ensure that Storage Accounts use customer-managed
       key for encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_19:
@@ -822,7 +822,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_19
-    pretty_name: 'CKV2_AZURE_19: Ensure that Azure Synapse workspaces have no IP firewall
+    pretty_name: 'Ensure that Azure Synapse workspaces have no IP firewall
       rules attached'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_2:
@@ -834,7 +834,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_2
-    pretty_name: 'CKV2_AZURE_2: Ensure that Vulnerability Assessment (VA) is enabled
+    pretty_name: 'Ensure that Vulnerability Assessment (VA) is enabled
       on a SQL server by setting a Storage Account'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_20:
@@ -845,7 +845,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_20
-    pretty_name: 'CKV2_AZURE_20: Ensure Storage logging is enabled for Table service
+    pretty_name: 'Ensure Storage logging is enabled for Table service
       for read requests'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_21:
@@ -856,7 +856,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_21
-    pretty_name: 'CKV2_AZURE_21: Ensure Storage logging is enabled for Blob service
+    pretty_name: 'Ensure Storage logging is enabled for Blob service
       for read requests'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_22:
@@ -866,7 +866,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_22
-    pretty_name: 'CKV2_AZURE_22: Ensure that Cognitive Services enables customer-managed
+    pretty_name: 'Ensure that Cognitive Services enables customer-managed
       key for encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_23:
@@ -878,7 +878,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_23
-    pretty_name: 'CKV2_AZURE_23: Ensure Azure spring cloud is configured with Virtual
+    pretty_name: 'Ensure Azure spring cloud is configured with Virtual
       network (Vnet)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_24:
@@ -890,7 +890,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_24
-    pretty_name: 'CKV2_AZURE_24: Ensure Azure automation account does NOT have overly
+    pretty_name: 'Ensure Azure automation account does NOT have overly
       permissive network access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_25:
@@ -902,7 +902,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_25
-    pretty_name: 'CKV2_AZURE_25: Ensure Azure SQL database Transparent Data Encryption
+    pretty_name: 'Ensure Azure SQL database Transparent Data Encryption
       (TDE) is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_26:
@@ -914,7 +914,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_26
-    pretty_name: 'CKV2_AZURE_26: Ensure Azure PostgreSQL Flexible server is not configured
+    pretty_name: 'Ensure Azure PostgreSQL Flexible server is not configured
       with overly permissive network access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_27:
@@ -926,7 +926,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV2_AZURE_27
-    pretty_name: 'CKV2_AZURE_27: Ensure Azure AD authentication is enabled for Azure
+    pretty_name: 'Ensure Azure AD authentication is enabled for Azure
       SQL (MSSQL)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_28:
@@ -938,7 +938,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV2_AZURE_28
-    pretty_name: 'CKV2_AZURE_28: Ensure Container Instance is configured with managed
+    pretty_name: 'Ensure Container Instance is configured with managed
       identity'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_29:
@@ -950,7 +950,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_29
-    pretty_name: 'CKV2_AZURE_29: Ensure AKS cluster has Azure CNI networking enabled'
+    pretty_name: 'Ensure AKS cluster has Azure CNI networking enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_3:
     categories:
@@ -961,7 +961,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_3
-    pretty_name: 'CKV2_AZURE_3: Ensure that VA setting Periodic Recurring Scans is
+    pretty_name: 'Ensure that VA setting Periodic Recurring Scans is
       enabled on a SQL server'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_30:
@@ -973,7 +973,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_30
-    pretty_name: 'CKV2_AZURE_30: Ensure Azure Container Registry (ACR) has HTTPS enabled
+    pretty_name: 'Ensure Azure Container Registry (ACR) has HTTPS enabled
       for webhook'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_31:
@@ -985,7 +985,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_31
-    pretty_name: 'CKV2_AZURE_31: Ensure VNET subnet is configured with a Network Security
+    pretty_name: 'Ensure VNET subnet is configured with a Network Security
       Group (NSG)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_32:
@@ -997,7 +997,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_32
-    pretty_name: 'CKV2_AZURE_32: Ensure private endpoint is configured to key vault'
+    pretty_name: 'Ensure private endpoint is configured to key vault'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_33:
     categories:
@@ -1008,7 +1008,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_33
-    pretty_name: 'CKV2_AZURE_33: Ensure storage account is configured with private
+    pretty_name: 'Ensure storage account is configured with private
       endpoint'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_4:
@@ -1020,7 +1020,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_4
-    pretty_name: 'CKV2_AZURE_4: Ensure Azure SQL server ADS VA Send scan reports to
+    pretty_name: 'Ensure Azure SQL server ADS VA Send scan reports to
       is configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_5:
@@ -1030,7 +1030,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_5
-    pretty_name: 'CKV2_AZURE_5: Ensure that VA setting ''Also send email notifications
+    pretty_name: 'Ensure that VA setting ''Also send email notifications
       to admins and subscription owners'' is set for a SQL server'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_6:
@@ -1042,7 +1042,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_6
-    pretty_name: 'CKV2_AZURE_6: Ensure ''Allow access to Azure services'' for PostgreSQL
+    pretty_name: 'Ensure ''Allow access to Azure services'' for PostgreSQL
       Database Server is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_7:
@@ -1054,7 +1054,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_7
-    pretty_name: 'CKV2_AZURE_7: Ensure that Azure Active Directory Admin is configured'
+    pretty_name: 'Ensure that Azure Active Directory Admin is configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_8:
     categories:
@@ -1065,7 +1065,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV2_AZURE_8
-    pretty_name: 'CKV2_AZURE_8: Ensure the storage container storing the activity
+    pretty_name: 'Ensure the storage container storing the activity
       logs is not publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_9:
@@ -1077,7 +1077,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_9
-    pretty_name: 'CKV2_AZURE_9: Ensure Virtual Machines are utilizing Managed Disks'
+    pretty_name: 'Ensure Virtual Machines are utilizing Managed Disks'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_1:
     categories:
@@ -1088,7 +1088,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV2_DOCKER_1
-    pretty_name: 'CKV2_DOCKER_1: Ensure that sudo isn''t used'
+    pretty_name: 'Ensure that sudo isn''t used'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_10:
     categories:
@@ -1099,7 +1099,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_10
-    pretty_name: 'CKV2_DOCKER_10: Ensure that packages with untrusted or missing signatures
+    pretty_name: 'Ensure that packages with untrusted or missing signatures
       are not used by rpm via the ''--nodigest'', ''--nosignature'', ''--noverify'',
       or ''--nofiledigest'' options'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
@@ -1112,7 +1112,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_11
-    pretty_name: 'CKV2_DOCKER_11: Ensure that the ''--force-yes'' option is not used,
+    pretty_name: 'Ensure that the ''--force-yes'' option is not used,
       as it disables signature validation and allows packages to be downgraded which
       can leave the system in a broken or inconsistent state'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
@@ -1125,7 +1125,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_12
-    pretty_name: 'CKV2_DOCKER_12: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       for npm via the ''NPM_CONFIG_STRICT_SSL'' environmnet variable'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_13:
@@ -1137,7 +1137,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_13
-    pretty_name: 'CKV2_DOCKER_13: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       for npm or yarn by setting the option strict-ssl to false'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_14:
@@ -1149,7 +1149,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_14
-    pretty_name: 'CKV2_DOCKER_14: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       for git by setting the environment variable ''GIT_SSL_NO_VERIFY'' to any value'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_15:
@@ -1161,7 +1161,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_15
-    pretty_name: 'CKV2_DOCKER_15: Ensure that the yum and dnf package managers are
+    pretty_name: 'Ensure that the yum and dnf package managers are
       not configured to disable SSL certificate validation via the ''sslverify'' configuration
       option'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
@@ -1174,7 +1174,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_16
-    pretty_name: 'CKV2_DOCKER_16: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with pip via the ''PIP_TRUSTED_HOST'' environment variable'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_2:
@@ -1186,7 +1186,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_2
-    pretty_name: 'CKV2_DOCKER_2: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with curl'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_3:
@@ -1198,7 +1198,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_3
-    pretty_name: 'CKV2_DOCKER_3: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with wget'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_4:
@@ -1210,7 +1210,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_4
-    pretty_name: 'CKV2_DOCKER_4: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with the pip ''--trusted-host'' option'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_5:
@@ -1222,7 +1222,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_5
-    pretty_name: 'CKV2_DOCKER_5: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with the PYTHONHTTPSVERIFY environmnet variable'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_6:
@@ -1234,7 +1234,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_6
-    pretty_name: 'CKV2_DOCKER_6: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with the NODE_TLS_REJECT_UNAUTHORIZED environmnet variable'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_7:
@@ -1246,7 +1246,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_7
-    pretty_name: 'CKV2_DOCKER_7: Ensure that packages with untrusted or missing signatures
+    pretty_name: 'Ensure that packages with untrusted or missing signatures
       are not used by apk via the ''--allow-untrusted'' option'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_8:
@@ -1258,7 +1258,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_8
-    pretty_name: 'CKV2_DOCKER_8: Ensure that packages with untrusted or missing signatures
+    pretty_name: 'Ensure that packages with untrusted or missing signatures
       are not used by apt-get via the ''--allow-unauthenticated'' option'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_9:
@@ -1270,7 +1270,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_9
-    pretty_name: 'CKV2_DOCKER_9: Ensure that packages with untrusted or missing GPG
+    pretty_name: 'Ensure that packages with untrusted or missing GPG
       signatures are not used by dnf, tdnf, or yum via the ''--nogpgcheck'' option'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_1:
@@ -1282,7 +1282,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV2_GCP_1
-    pretty_name: 'CKV2_GCP_1: Ensure GKE clusters are not running using the Compute
+    pretty_name: 'Ensure GKE clusters are not running using the Compute
       Engine default service account '
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_10:
@@ -1294,7 +1294,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_10
-    pretty_name: 'CKV2_GCP_10: Ensure GCP Cloud Function HTTP trigger is secured'
+    pretty_name: 'Ensure GCP Cloud Function HTTP trigger is secured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_11:
     categories:
@@ -1305,7 +1305,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_11
-    pretty_name: 'CKV2_GCP_11: Ensure GCP GCR Container Vulnerability Scanning is
+    pretty_name: 'Ensure GCP GCR Container Vulnerability Scanning is
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_12:
@@ -1317,7 +1317,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_12
-    pretty_name: 'CKV2_GCP_12: Ensure GCP compute firewall ingress does not allow
+    pretty_name: 'Ensure GCP compute firewall ingress does not allow
       unrestricted access to all ports'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_13:
@@ -1329,7 +1329,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_13
-    pretty_name: 'CKV2_GCP_13: Ensure PostgreSQL database flag ''log_duration'' is
+    pretty_name: 'Ensure PostgreSQL database flag ''log_duration'' is
       set to ''on'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_14:
@@ -1341,7 +1341,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_14
-    pretty_name: 'CKV2_GCP_14: Ensure PostgreSQL database flag ''log_executor_stats''
+    pretty_name: 'Ensure PostgreSQL database flag ''log_executor_stats''
       is set to ''off'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_15:
@@ -1353,7 +1353,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_15
-    pretty_name: 'CKV2_GCP_15: Ensure PostgreSQL database flag ''log_parser_stats''
+    pretty_name: 'Ensure PostgreSQL database flag ''log_parser_stats''
       is set to ''off'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_16:
@@ -1365,7 +1365,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_16
-    pretty_name: 'CKV2_GCP_16: Ensure PostgreSQL database flag ''log_planner_stats''
+    pretty_name: 'Ensure PostgreSQL database flag ''log_planner_stats''
       is set to ''off'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_17:
@@ -1377,7 +1377,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_17
-    pretty_name: 'CKV2_GCP_17: Ensure PostgreSQL database flag ''log_statement_stats''
+    pretty_name: 'Ensure PostgreSQL database flag ''log_statement_stats''
       is set to ''off'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_18:
@@ -1389,7 +1389,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_18
-    pretty_name: 'CKV2_GCP_18: Ensure GCP network defines a firewall and does not
+    pretty_name: 'Ensure GCP network defines a firewall and does not
       use the default firewall'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_19:
@@ -1401,7 +1401,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_19
-    pretty_name: 'CKV2_GCP_19: Ensure GCP Kubernetes engine clusters have ''alpha
+    pretty_name: 'Ensure GCP Kubernetes engine clusters have ''alpha
       cluster'' feature disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_2:
@@ -1413,7 +1413,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_2
-    pretty_name: 'CKV2_GCP_2: Ensure legacy networks do not exist for a project'
+    pretty_name: 'Ensure legacy networks do not exist for a project'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_20:
     categories:
@@ -1424,7 +1424,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_20
-    pretty_name: 'CKV2_GCP_20: Ensure MySQL DB instance has point-in-time recovery
+    pretty_name: 'Ensure MySQL DB instance has point-in-time recovery
       backup configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_3:
@@ -1436,7 +1436,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV2_GCP_3
-    pretty_name: 'CKV2_GCP_3: Ensure that there are only GCP-managed service account
+    pretty_name: 'Ensure that there are only GCP-managed service account
       keys for each service account'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_4:
@@ -1447,7 +1447,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_4
-    pretty_name: 'CKV2_GCP_4: Ensure that retention policies on log buckets are configured
+    pretty_name: 'Ensure that retention policies on log buckets are configured
       using Bucket Lock'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_5:
@@ -1459,7 +1459,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_5
-    pretty_name: 'CKV2_GCP_5: Ensure that Cloud Audit Logging is configured properly
+    pretty_name: 'Ensure that Cloud Audit Logging is configured properly
       across all services and all users from a project'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_6:
@@ -1471,7 +1471,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV2_GCP_6
-    pretty_name: 'CKV2_GCP_6: Ensure that Cloud KMS cryptokeys are not anonymously
+    pretty_name: 'Ensure that Cloud KMS cryptokeys are not anonymously
       or publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_7:
@@ -1483,7 +1483,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_7
-    pretty_name: 'CKV2_GCP_7: Ensure that a MySQL database instance does not allow
+    pretty_name: 'Ensure that a MySQL database instance does not allow
       anyone to connect with administrative privileges'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_8:
@@ -1495,7 +1495,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV2_GCP_8
-    pretty_name: 'CKV2_GCP_8: Ensure that Cloud KMS Key Rings are not anonymously
+    pretty_name: 'Ensure that Cloud KMS Key Rings are not anonymously
       or publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_9:
@@ -1507,7 +1507,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV2_GCP_9
-    pretty_name: 'CKV2_GCP_9: Ensure that Container Registry repositories are not
+    pretty_name: 'Ensure that Container Registry repositories are not
       anonymously or publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GHA_1:
@@ -1519,7 +1519,7 @@ rules:
     description: Check for weak GitHub Action configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_GHA_1
-    pretty_name: 'CKV2_GHA_1: Ensure top-level permissions are not set to write-all'
+    pretty_name: 'Ensure top-level permissions are not set to write-all'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_K8S_1:
     categories:
@@ -1530,7 +1530,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV2_K8S_1
-    pretty_name: 'CKV2_K8S_1: RoleBinding should not allow privilege escalation to
+    pretty_name: 'RoleBinding should not allow privilege escalation to
       a ServiceAccount or Node on other RoleBinding'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_K8S_2:
@@ -1542,7 +1542,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV2_K8S_2
-    pretty_name: 'CKV2_K8S_2: Granting `create` permissions to `nodes/proxy` or `pods/exec`
+    pretty_name: 'Granting `create` permissions to `nodes/proxy` or `pods/exec`
       sub resources allows potential privilege escalation'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_K8S_3:
@@ -1554,7 +1554,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV2_K8S_3
-    pretty_name: 'CKV2_K8S_3: No ServiceAccount/Node should have `impersonate` permissions
+    pretty_name: 'No ServiceAccount/Node should have `impersonate` permissions
       for groups/users/service-accounts'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_K8S_4:
@@ -1566,7 +1566,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV2_K8S_4
-    pretty_name: 'CKV2_K8S_4: ServiceAccounts and nodes that can modify services/status
+    pretty_name: 'ServiceAccounts and nodes that can modify services/status
       may set the `status.loadBalancer.ingress.ip` field to exploit the unfixed CVE-2020-8554
       and launch MiTM attacks against the cluster.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
@@ -1579,7 +1579,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV2_K8S_5
-    pretty_name: 'CKV2_K8S_5: No ServiceAccount/Node should be able to read all secrets'
+    pretty_name: 'No ServiceAccount/Node should be able to read all secrets'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_K8S_6:
     categories:
@@ -1590,7 +1590,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV2_K8S_6
-    pretty_name: 'CKV2_K8S_6: Minimize the admission of pods which lack an associated
+    pretty_name: 'Minimize the admission of pods which lack an associated
       NetworkPolicy'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_1:
@@ -1602,7 +1602,7 @@ rules:
     description: Check for publicly accessible Alibaba Cloud resources.
     group: cloud-resources-public-access
     name: CKV_ALI_1
-    pretty_name: 'CKV_ALI_1: Alibaba Cloud OSS bucket accessible to public'
+    pretty_name: 'Alibaba Cloud OSS bucket accessible to public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_10:
     categories:
@@ -1611,7 +1611,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_10
-    pretty_name: 'CKV_ALI_10: Ensure OSS bucket has versioning enabled'
+    pretty_name: 'Ensure OSS bucket has versioning enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_11:
     categories:
@@ -1620,7 +1620,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_11
-    pretty_name: 'CKV_ALI_11: Ensure OSS bucket has transfer Acceleration enabled'
+    pretty_name: 'Ensure OSS bucket has transfer Acceleration enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_12:
     categories:
@@ -1631,7 +1631,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_12
-    pretty_name: 'CKV_ALI_12: Ensure the OSS bucket has access logging enabled'
+    pretty_name: 'Ensure the OSS bucket has access logging enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_13:
     categories:
@@ -1642,7 +1642,7 @@ rules:
     description: Check for weak Alibaba Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_ALI_13
-    pretty_name: 'CKV_ALI_13: Ensure RAM password policy requires minimum length of
+    pretty_name: 'Ensure RAM password policy requires minimum length of
       14 or greater'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_14:
@@ -1652,7 +1652,7 @@ rules:
     description: Check for weak Alibaba Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_ALI_14
-    pretty_name: 'CKV_ALI_14: Ensure RAM password policy requires at least one number'
+    pretty_name: 'Ensure RAM password policy requires at least one number'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_15:
     categories:
@@ -1661,7 +1661,7 @@ rules:
     description: Check for weak Alibaba Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_ALI_15
-    pretty_name: 'CKV_ALI_15: Ensure RAM password policy requires at least one symbol'
+    pretty_name: 'Ensure RAM password policy requires at least one symbol'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_16:
     categories:
@@ -1670,7 +1670,7 @@ rules:
     description: Check for weak Alibaba Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_ALI_16
-    pretty_name: 'CKV_ALI_16: Ensure RAM password policy expires passwords within
+    pretty_name: 'Ensure RAM password policy expires passwords within
       90 days or less'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_17:
@@ -1680,7 +1680,7 @@ rules:
     description: Check for weak Alibaba Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_ALI_17
-    pretty_name: 'CKV_ALI_17: Ensure RAM password policy requires at least one lowercase
+    pretty_name: 'Ensure RAM password policy requires at least one lowercase
       letter'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_18:
@@ -1692,7 +1692,7 @@ rules:
     description: Check for weak Alibaba Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_ALI_18
-    pretty_name: 'CKV_ALI_18: Ensure RAM password policy prevents password reuse'
+    pretty_name: 'Ensure RAM password policy prevents password reuse'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_19:
     categories:
@@ -1701,7 +1701,7 @@ rules:
     description: Check for weak Alibaba Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_ALI_19
-    pretty_name: 'CKV_ALI_19: Ensure RAM password policy requires at least one uppercase
+    pretty_name: 'Ensure RAM password policy requires at least one uppercase
       letter'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_2:
@@ -1713,7 +1713,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_2
-    pretty_name: 'CKV_ALI_2: Ensure no security groups allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security groups allow ingress from 0.0.0.0:0
       to port 22'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_20:
@@ -1725,7 +1725,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_20
-    pretty_name: 'CKV_ALI_20: Ensure RDS instance uses SSL'
+    pretty_name: 'Ensure RDS instance uses SSL'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_21:
     categories:
@@ -1736,7 +1736,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_21
-    pretty_name: 'CKV_ALI_21: Ensure API Gateway API Protocol HTTPS'
+    pretty_name: 'Ensure API Gateway API Protocol HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_22:
     categories:
@@ -1747,7 +1747,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_22
-    pretty_name: 'CKV_ALI_22: Ensure Transparent Data Encryption is Enabled on instance'
+    pretty_name: 'Ensure Transparent Data Encryption is Enabled on instance'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_23:
     categories:
@@ -1756,7 +1756,7 @@ rules:
     description: Check for weak Alibaba Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_ALI_23
-    pretty_name: 'CKV_ALI_23: Ensure Ram Account Password Policy Max Login Attempts
+    pretty_name: 'Ensure Ram Account Password Policy Max Login Attempts
       not > 5'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_24:
@@ -1768,7 +1768,7 @@ rules:
     description: Check for weak Alibaba Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_ALI_24
-    pretty_name: 'CKV_ALI_24: Ensure RAM enforces MFA'
+    pretty_name: 'Ensure RAM enforces MFA'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_25:
     categories:
@@ -1778,7 +1778,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_25
-    pretty_name: 'CKV_ALI_25: Ensure RDS Instance SQL Collector Retention Period should
+    pretty_name: 'Ensure RDS Instance SQL Collector Retention Period should
       be greater than 180'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_26:
@@ -1788,7 +1788,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_26
-    pretty_name: 'CKV_ALI_26: Ensure Kubernetes installs plugin Terway or Flannel
+    pretty_name: 'Ensure Kubernetes installs plugin Terway or Flannel
       to support standard policies'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_27:
@@ -1800,7 +1800,7 @@ rules:
     description: Check that ensures best practices in Alibaba Cloud secrets management.
     group: cloud-weak-secrets-management
     name: CKV_ALI_27
-    pretty_name: 'CKV_ALI_27: Ensure KMS Key Rotation is enabled'
+    pretty_name: 'Ensure KMS Key Rotation is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_28:
     categories:
@@ -1811,7 +1811,7 @@ rules:
     description: Check that ensures best practices in Alibaba Cloud secrets management.
     group: cloud-weak-secrets-management
     name: CKV_ALI_28
-    pretty_name: 'CKV_ALI_28: Ensure KMS Keys are enabled'
+    pretty_name: 'Ensure KMS Keys are enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_29:
     categories:
@@ -1820,7 +1820,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_29
-    pretty_name: 'CKV_ALI_29: Alibaba ALB ACL does not restrict Access'
+    pretty_name: 'Alibaba ALB ACL does not restrict Access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_3:
     categories:
@@ -1829,7 +1829,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_3
-    pretty_name: 'CKV_ALI_3: Ensure no security groups allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security groups allow ingress from 0.0.0.0:0
       to port 3389'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_30:
@@ -1839,7 +1839,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_30
-    pretty_name: 'CKV_ALI_30: Ensure RDS instance auto upgrades for minor versions'
+    pretty_name: 'Ensure RDS instance auto upgrades for minor versions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_31:
     categories:
@@ -1848,7 +1848,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_31
-    pretty_name: 'CKV_ALI_31: Ensure K8s nodepools are set to auto repair'
+    pretty_name: 'Ensure K8s nodepools are set to auto repair'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_32:
     categories:
@@ -1857,7 +1857,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_32
-    pretty_name: 'CKV_ALI_32: Ensure launch template data disks are encrypted'
+    pretty_name: 'Ensure launch template data disks are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_33:
     categories:
@@ -1866,7 +1866,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_33
-    pretty_name: 'CKV_ALI_33: Alibaba Cloud Cypher Policy are secure'
+    pretty_name: 'Alibaba Cloud Cypher Policy are secure'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_35:
     categories:
@@ -1875,7 +1875,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_35
-    pretty_name: 'CKV_ALI_35: Ensure RDS instance has log_duration enabled'
+    pretty_name: 'Ensure RDS instance has log_duration enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_36:
     categories:
@@ -1884,7 +1884,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_36
-    pretty_name: 'CKV_ALI_36: Ensure RDS instance has log_disconnections enabled'
+    pretty_name: 'Ensure RDS instance has log_disconnections enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_37:
     categories:
@@ -1893,7 +1893,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_37
-    pretty_name: 'CKV_ALI_37: Ensure RDS instance has log_connections enabled'
+    pretty_name: 'Ensure RDS instance has log_connections enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_38:
     categories:
@@ -1902,7 +1902,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_38
-    pretty_name: 'CKV_ALI_38: Ensure log audit is enabled for RDS'
+    pretty_name: 'Ensure log audit is enabled for RDS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_4:
     categories:
@@ -1911,7 +1911,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_4
-    pretty_name: 'CKV_ALI_4: Ensure Action Trail Logging for all regions'
+    pretty_name: 'Ensure Action Trail Logging for all regions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_41:
     categories:
@@ -1920,7 +1920,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_41
-    pretty_name: 'CKV_ALI_41: Ensure MongoDB is deployed inside a VPC'
+    pretty_name: 'Ensure MongoDB is deployed inside a VPC'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_42:
     categories:
@@ -1929,7 +1929,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_42
-    pretty_name: 'CKV_ALI_42: Ensure Mongodb instance uses SSL'
+    pretty_name: 'Ensure Mongodb instance uses SSL'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_43:
     categories:
@@ -1938,7 +1938,7 @@ rules:
     description: Check for publicly accessible Alibaba Cloud resources.
     group: cloud-resources-public-access
     name: CKV_ALI_43
-    pretty_name: 'CKV_ALI_43: Ensure MongoDB instance is not public'
+    pretty_name: 'Ensure MongoDB instance is not public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_44:
     categories:
@@ -1947,7 +1947,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_44
-    pretty_name: 'CKV_ALI_44: Ensure MongoDB has Transparent Data Encryption Enabled'
+    pretty_name: 'Ensure MongoDB has Transparent Data Encryption Enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_5:
     categories:
@@ -1956,7 +1956,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_5
-    pretty_name: 'CKV_ALI_5: Ensure Action Trail Logging for all events'
+    pretty_name: 'Ensure Action Trail Logging for all events'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_6:
     categories:
@@ -1965,7 +1965,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_6
-    pretty_name: 'CKV_ALI_6: Ensure OSS bucket is encrypted with Customer Master Key'
+    pretty_name: 'Ensure OSS bucket is encrypted with Customer Master Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_7:
     categories:
@@ -1974,7 +1974,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_7
-    pretty_name: 'CKV_ALI_7: Ensure disk is encrypted'
+    pretty_name: 'Ensure disk is encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_8:
     categories:
@@ -1983,7 +1983,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_8
-    pretty_name: 'CKV_ALI_8: Ensure Disk is encrypted with Customer Master Key'
+    pretty_name: 'Ensure Disk is encrypted with Customer Master Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_9:
     categories:
@@ -1992,7 +1992,7 @@ rules:
     description: Check for publicly accessible Alibaba Cloud resources.
     group: cloud-resources-public-access
     name: CKV_ALI_9
-    pretty_name: 'CKV_ALI_9: Ensure database instance is not public'
+    pretty_name: 'Ensure database instance is not public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ANSIBLE_1:
     categories:
@@ -2003,7 +2003,7 @@ rules:
     description: Check for weak Ansible configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_ANSIBLE_1
-    pretty_name: 'CKV_ANSIBLE_1: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with uri'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ANSIBLE_2:
@@ -2015,7 +2015,7 @@ rules:
     description: Check for weak Ansible configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_ANSIBLE_2
-    pretty_name: 'CKV_ANSIBLE_2: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with get_url'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ANSIBLE_3:
@@ -2027,7 +2027,7 @@ rules:
     description: Check for weak Ansible configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_ANSIBLE_3
-    pretty_name: 'CKV_ANSIBLE_3: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with yum'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ANSIBLE_4:
@@ -2039,7 +2039,7 @@ rules:
     description: Check for weak Ansible configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_ANSIBLE_4
-    pretty_name: 'CKV_ANSIBLE_4: Ensure that SSL validation isn''t disabled with yum'
+    pretty_name: 'Ensure that SSL validation isn''t disabled with yum'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ANSIBLE_5:
     categories:
@@ -2050,7 +2050,7 @@ rules:
     description: Check for weak Ansible configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_ANSIBLE_5
-    pretty_name: 'CKV_ANSIBLE_5: Ensure that packages with untrusted or missing signatures
+    pretty_name: 'Ensure that packages with untrusted or missing signatures
       are not used'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ANSIBLE_6:
@@ -2062,7 +2062,7 @@ rules:
     description: Check for misconfigurations in Ansible resources.
     group: cloud-weak-configuration
     name: CKV_ANSIBLE_6
-    pretty_name: 'CKV_ANSIBLE_6: Ensure that the force parameter is not used, as it
+    pretty_name: 'Ensure that the force parameter is not used, as it
       disables signature validation and allows packages to be downgraded which can
       leave the system in a broken or inconsistent state'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
@@ -2075,7 +2075,7 @@ rules:
     description: Check for misconfigurations in Argo resources.
     group: cloud-weak-configuration
     name: CKV_ARGO_1
-    pretty_name: 'CKV_ARGO_1: Ensure Workflow pods are not using the default ServiceAccount'
+    pretty_name: 'Ensure Workflow pods are not using the default ServiceAccount'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ARGO_2:
     categories:
@@ -2086,7 +2086,7 @@ rules:
     description: Check for misconfigurations in Argo resources.
     group: cloud-weak-configuration
     name: CKV_ARGO_2
-    pretty_name: 'CKV_ARGO_2: Ensure Workflow pods are running as non-root user'
+    pretty_name: 'Ensure Workflow pods are running as non-root user'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_1:
     categories:
@@ -2097,7 +2097,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_1
-    pretty_name: 'CKV_AWS_1: Ensure IAM policies that allow full "*-*" administrative
+    pretty_name: 'Ensure IAM policies that allow full "*-*" administrative
       privileges are not created'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_10:
@@ -2109,7 +2109,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_10
-    pretty_name: 'CKV_AWS_10: Ensure IAM password policy requires minimum length of
+    pretty_name: 'Ensure IAM password policy requires minimum length of
       14 or greater'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_100:
@@ -2121,7 +2121,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_100
-    pretty_name: 'CKV_AWS_100: Ensure AWS EKS node group does not have implicit SSH
+    pretty_name: 'Ensure AWS EKS node group does not have implicit SSH
       access from 0.0.0.0/0'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_101:
@@ -2132,7 +2132,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_101
-    pretty_name: 'CKV_AWS_101: Ensure Neptune logging is enabled'
+    pretty_name: 'Ensure Neptune logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_102:
     categories:
@@ -2143,7 +2143,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_102
-    pretty_name: 'CKV_AWS_102: Ensure Neptune Cluster instance is not publicly available'
+    pretty_name: 'Ensure Neptune Cluster instance is not publicly available'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_103:
     categories:
@@ -2154,7 +2154,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_103
-    pretty_name: 'CKV_AWS_103: Ensure that load balancer is using at least TLS 1.2'
+    pretty_name: 'Ensure that load balancer is using at least TLS 1.2'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_104:
     categories:
@@ -2165,7 +2165,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_104
-    pretty_name: 'CKV_AWS_104: Ensure DocDB has audit logs enabled'
+    pretty_name: 'Ensure DocDB has audit logs enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_105:
     categories:
@@ -2176,7 +2176,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_105
-    pretty_name: 'CKV_AWS_105: Ensure Redshift uses SSL'
+    pretty_name: 'Ensure Redshift uses SSL'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_106:
     categories:
@@ -2187,7 +2187,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_106
-    pretty_name: 'CKV_AWS_106: Ensure EBS default encryption is enabled'
+    pretty_name: 'Ensure EBS default encryption is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_107:
     categories:
@@ -2198,7 +2198,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_107
-    pretty_name: 'CKV_AWS_107: Ensure IAM policies does not allow credentials exposure'
+    pretty_name: 'Ensure IAM policies does not allow credentials exposure'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_108:
     categories:
@@ -2208,7 +2208,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_108
-    pretty_name: 'CKV_AWS_108: Ensure IAM policies does not allow data exfiltration'
+    pretty_name: 'Ensure IAM policies does not allow data exfiltration'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_109:
     categories:
@@ -2219,7 +2219,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_109
-    pretty_name: 'CKV_AWS_109: Ensure IAM policies does not allow permissions management
+    pretty_name: 'Ensure IAM policies does not allow permissions management
       / resource exposure without constraints'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_11:
@@ -2230,7 +2230,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_11
-    pretty_name: 'CKV_AWS_11: Ensure IAM password policy requires at least one lowercase
+    pretty_name: 'Ensure IAM password policy requires at least one lowercase
       letter'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_110:
@@ -2242,7 +2242,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_110
-    pretty_name: 'CKV_AWS_110: Ensure IAM policies does not allow privilege escalation'
+    pretty_name: 'Ensure IAM policies does not allow privilege escalation'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_111:
     categories:
@@ -2253,7 +2253,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_111
-    pretty_name: 'CKV_AWS_111: Ensure IAM policies does not allow write access without
+    pretty_name: 'Ensure IAM policies does not allow write access without
       constraints'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_112:
@@ -2265,7 +2265,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_112
-    pretty_name: 'CKV_AWS_112: Ensure Session Manager data is encrypted in transit'
+    pretty_name: 'Ensure Session Manager data is encrypted in transit'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_113:
     categories:
@@ -2276,7 +2276,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_113
-    pretty_name: 'CKV_AWS_113: Ensure Session Manager logs are enabled and encrypted'
+    pretty_name: 'Ensure Session Manager logs are enabled and encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_114:
     categories:
@@ -2287,7 +2287,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_114
-    pretty_name: 'CKV_AWS_114: Ensure that EMR clusters with Kerberos have Kerberos
+    pretty_name: 'Ensure that EMR clusters with Kerberos have Kerberos
       Realm set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_115:
@@ -2299,7 +2299,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_115
-    pretty_name: 'CKV_AWS_115: Ensure that AWS Lambda function is configured for function-level
+    pretty_name: 'Ensure that AWS Lambda function is configured for function-level
       concurrent execution limit'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_116:
@@ -2310,7 +2310,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_116
-    pretty_name: 'CKV_AWS_116: Ensure that AWS Lambda function is configured for a
+    pretty_name: 'Ensure that AWS Lambda function is configured for a
       Dead Letter Queue(DLQ)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_117:
@@ -2321,7 +2321,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_117
-    pretty_name: 'CKV_AWS_117: Ensure that AWS Lambda function is configured inside
+    pretty_name: 'Ensure that AWS Lambda function is configured inside
       a VPC'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_118:
@@ -2332,7 +2332,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_118
-    pretty_name: 'CKV_AWS_118: Ensure that enhanced monitoring is enabled for Amazon
+    pretty_name: 'Ensure that enhanced monitoring is enabled for Amazon
       RDS instances'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_119:
@@ -2342,7 +2342,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_119
-    pretty_name: 'CKV_AWS_119: Ensure DynamoDB Tables are encrypted using a KMS Customer
+    pretty_name: 'Ensure DynamoDB Tables are encrypted using a KMS Customer
       Managed CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_12:
@@ -2352,7 +2352,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_12
-    pretty_name: 'CKV_AWS_12: Ensure IAM password policy requires at least one number'
+    pretty_name: 'Ensure IAM password policy requires at least one number'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_120:
     categories:
@@ -2362,7 +2362,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_120
-    pretty_name: 'CKV_AWS_120: Ensure API Gateway caching is enabled'
+    pretty_name: 'Ensure API Gateway caching is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_121:
     categories:
@@ -2373,7 +2373,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_121
-    pretty_name: 'CKV_AWS_121: Ensure AWS Config is enabled in all regions'
+    pretty_name: 'Ensure AWS Config is enabled in all regions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_122:
     categories:
@@ -2384,7 +2384,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_122
-    pretty_name: 'CKV_AWS_122: Ensure that direct internet access is disabled for
+    pretty_name: 'Ensure that direct internet access is disabled for
       an Amazon SageMaker Notebook Instance'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_123:
@@ -2396,7 +2396,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_123
-    pretty_name: 'CKV_AWS_123: Ensure that VPC Endpoint Service is configured for
+    pretty_name: 'Ensure that VPC Endpoint Service is configured for
       Manual Acceptance'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_124:
@@ -2406,7 +2406,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_124
-    pretty_name: 'CKV_AWS_124: Ensure that CloudFormation stacks are sending event
+    pretty_name: 'Ensure that CloudFormation stacks are sending event
       notifications to an SNS topic'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_126:
@@ -2417,7 +2417,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_126
-    pretty_name: 'CKV_AWS_126: Ensure that detailed monitoring is enabled for EC2
+    pretty_name: 'Ensure that detailed monitoring is enabled for EC2
       instances'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_127:
@@ -2429,7 +2429,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_127
-    pretty_name: 'CKV_AWS_127: Ensure that Elastic Load Balancer(s) uses SSL certificates
+    pretty_name: 'Ensure that Elastic Load Balancer(s) uses SSL certificates
       provided by AWS Certificate Manager'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_128:
@@ -2441,7 +2441,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_128
-    pretty_name: 'CKV_AWS_128: Ensure that an Amazon RDS Clusters have AWS Identity
+    pretty_name: 'Ensure that an Amazon RDS Clusters have AWS Identity
       and Access Management (IAM) authentication enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_129:
@@ -2453,7 +2453,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_129
-    pretty_name: 'CKV_AWS_129: Ensure that respective logs of Amazon Relational Database
+    pretty_name: 'Ensure that respective logs of Amazon Relational Database
       Service (Amazon RDS) are enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_13:
@@ -2465,7 +2465,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_13
-    pretty_name: 'CKV_AWS_13: Ensure IAM password policy prevents password reuse'
+    pretty_name: 'Ensure IAM password policy prevents password reuse'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_130:
     categories:
@@ -2476,7 +2476,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_130
-    pretty_name: 'CKV_AWS_130: Ensure VPC subnets do not assign public IP by default'
+    pretty_name: 'Ensure VPC subnets do not assign public IP by default'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_131:
     categories:
@@ -2487,7 +2487,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_131
-    pretty_name: 'CKV_AWS_131: Ensure that ALB drops HTTP headers'
+    pretty_name: 'Ensure that ALB drops HTTP headers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_133:
     categories:
@@ -2498,7 +2498,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_133
-    pretty_name: 'CKV_AWS_133: Ensure that RDS instances has backup policy'
+    pretty_name: 'Ensure that RDS instances has backup policy'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_134:
     categories:
@@ -2509,7 +2509,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_134
-    pretty_name: 'CKV_AWS_134: Ensure that Amazon ElastiCache Redis clusters have
+    pretty_name: 'Ensure that Amazon ElastiCache Redis clusters have
       automatic backup turned on'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_135:
@@ -2519,7 +2519,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_135
-    pretty_name: 'CKV_AWS_135: Ensure that EC2 is EBS optimized'
+    pretty_name: 'Ensure that EC2 is EBS optimized'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_136:
     categories:
@@ -2529,7 +2529,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_136
-    pretty_name: 'CKV_AWS_136: Ensure that ECR repositories are encrypted using KMS'
+    pretty_name: 'Ensure that ECR repositories are encrypted using KMS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_137:
     categories:
@@ -2540,7 +2540,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_137
-    pretty_name: 'CKV_AWS_137: Ensure that Elasticsearch is configured inside a VPC'
+    pretty_name: 'Ensure that Elasticsearch is configured inside a VPC'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_138:
     categories:
@@ -2550,7 +2550,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_138
-    pretty_name: 'CKV_AWS_138: Ensure that ELB is cross-zone-load-balancing enabled'
+    pretty_name: 'Ensure that ELB is cross-zone-load-balancing enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_139:
     categories:
@@ -2561,7 +2561,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_139
-    pretty_name: 'CKV_AWS_139: Ensure that RDS clusters have deletion protection enabled'
+    pretty_name: 'Ensure that RDS clusters have deletion protection enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_14:
     categories:
@@ -2571,7 +2571,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_14
-    pretty_name: 'CKV_AWS_14: Ensure IAM password policy requires at least one symbol'
+    pretty_name: 'Ensure IAM password policy requires at least one symbol'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_140:
     categories:
@@ -2582,7 +2582,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_140
-    pretty_name: 'CKV_AWS_140: Ensure that RDS global clusters are encrypted'
+    pretty_name: 'Ensure that RDS global clusters are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_141:
     categories:
@@ -2593,7 +2593,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_141
-    pretty_name: 'CKV_AWS_141: Ensured that redshift cluster allowing version upgrade
+    pretty_name: 'Ensured that redshift cluster allowing version upgrade
       by default'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_142:
@@ -2603,7 +2603,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_142
-    pretty_name: 'CKV_AWS_142: Ensure that Redshift cluster is encrypted by KMS'
+    pretty_name: 'Ensure that Redshift cluster is encrypted by KMS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_143:
     categories:
@@ -2613,7 +2613,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_143
-    pretty_name: 'CKV_AWS_143: Ensure that S3 bucket has lock configuration enabled
+    pretty_name: 'Ensure that S3 bucket has lock configuration enabled
       by default'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_144:
@@ -2624,7 +2624,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_144
-    pretty_name: 'CKV_AWS_144: Ensure that S3 bucket has cross-region replication
+    pretty_name: 'Ensure that S3 bucket has cross-region replication
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_145:
@@ -2634,7 +2634,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_145
-    pretty_name: 'CKV_AWS_145: Ensure that S3 buckets are encrypted with KMS by default'
+    pretty_name: 'Ensure that S3 buckets are encrypted with KMS by default'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_146:
     categories:
@@ -2645,7 +2645,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_146
-    pretty_name: 'CKV_AWS_146: Ensure that RDS database cluster snapshot is encrypted'
+    pretty_name: 'Ensure that RDS database cluster snapshot is encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_147:
     categories:
@@ -2656,7 +2656,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_147
-    pretty_name: 'CKV_AWS_147: Ensure that CodeBuild projects are encrypted'
+    pretty_name: 'Ensure that CodeBuild projects are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_148:
     categories:
@@ -2666,7 +2666,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_148
-    pretty_name: 'CKV_AWS_148: Ensure no default VPC is planned to be provisioned'
+    pretty_name: 'Ensure no default VPC is planned to be provisioned'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_149:
     categories:
@@ -2675,7 +2675,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_149
-    pretty_name: 'CKV_AWS_149: Ensure that Secrets Manager secret is encrypted using
+    pretty_name: 'Ensure that Secrets Manager secret is encrypted using
       KMS CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_15:
@@ -2686,7 +2686,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_15
-    pretty_name: 'CKV_AWS_15: Ensure IAM password policy requires at least one uppercase
+    pretty_name: 'Ensure IAM password policy requires at least one uppercase
       letter'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_150:
@@ -2698,7 +2698,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_150
-    pretty_name: 'CKV_AWS_150: Ensure that Load Balancer has deletion protection enabled'
+    pretty_name: 'Ensure that Load Balancer has deletion protection enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_152:
     categories:
@@ -2708,7 +2708,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_152
-    pretty_name: 'CKV_AWS_152: Ensure that Load Balancer (Network/Gateway) has cross-zone
+    pretty_name: 'Ensure that Load Balancer (Network/Gateway) has cross-zone
       load balancing enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_153:
@@ -2719,7 +2719,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_153
-    pretty_name: 'CKV_AWS_153: Autoscaling groups should supply tags to launch configurations'
+    pretty_name: 'Autoscaling groups should supply tags to launch configurations'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_154:
     categories:
@@ -2730,7 +2730,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_154
-    pretty_name: 'CKV_AWS_154: Ensure Redshift is not deployed outside of a VPC'
+    pretty_name: 'Ensure Redshift is not deployed outside of a VPC'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_155:
     categories:
@@ -2741,7 +2741,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_155
-    pretty_name: 'CKV_AWS_155: Ensure that Workspace user volumes are encrypted'
+    pretty_name: 'Ensure that Workspace user volumes are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_156:
     categories:
@@ -2752,7 +2752,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_156
-    pretty_name: 'CKV_AWS_156: Ensure that Workspace root volumes are encrypted'
+    pretty_name: 'Ensure that Workspace root volumes are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_157:
     categories:
@@ -2762,7 +2762,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_157
-    pretty_name: 'CKV_AWS_157: Ensure that RDS instances have Multi-AZ enabled'
+    pretty_name: 'Ensure that RDS instances have Multi-AZ enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_158:
     categories:
@@ -2771,7 +2771,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_158
-    pretty_name: 'CKV_AWS_158: Ensure that CloudWatch Log Group is encrypted by KMS'
+    pretty_name: 'Ensure that CloudWatch Log Group is encrypted by KMS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_159:
     categories:
@@ -2782,7 +2782,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_159
-    pretty_name: 'CKV_AWS_159: Ensure that Athena Workgroup is encrypted'
+    pretty_name: 'Ensure that Athena Workgroup is encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_16:
     categories:
@@ -2793,7 +2793,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_16
-    pretty_name: 'CKV_AWS_16: Ensure all data stored in the RDS is securely encrypted
+    pretty_name: 'Ensure all data stored in the RDS is securely encrypted
       at rest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_160:
@@ -2803,7 +2803,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_160
-    pretty_name: 'CKV_AWS_160: Ensure that Timestream database is encrypted with KMS
+    pretty_name: 'Ensure that Timestream database is encrypted with KMS
       CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_161:
@@ -2815,7 +2815,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_161
-    pretty_name: 'CKV_AWS_161: Ensure RDS database has IAM authentication enabled'
+    pretty_name: 'Ensure RDS database has IAM authentication enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_162:
     categories:
@@ -2826,7 +2826,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_162
-    pretty_name: 'CKV_AWS_162: Ensure RDS cluster has IAM authentication enabled'
+    pretty_name: 'Ensure RDS cluster has IAM authentication enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_163:
     categories:
@@ -2837,7 +2837,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_163
-    pretty_name: 'CKV_AWS_163: Ensure ECR image scanning on push is enabled'
+    pretty_name: 'Ensure ECR image scanning on push is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_164:
     categories:
@@ -2848,7 +2848,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_164
-    pretty_name: 'CKV_AWS_164: Ensure Transfer Server is not exposed publicly.'
+    pretty_name: 'Ensure Transfer Server is not exposed publicly.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_165:
     categories:
@@ -2859,7 +2859,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_165
-    pretty_name: 'CKV_AWS_165: Ensure Dynamodb point in time recovery (backup) is
+    pretty_name: 'Ensure Dynamodb point in time recovery (backup) is
       enabled for global tables'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_166:
@@ -2869,7 +2869,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_166
-    pretty_name: 'CKV_AWS_166: Ensure Backup Vault is encrypted at rest using KMS
+    pretty_name: 'Ensure Backup Vault is encrypted at rest using KMS
       CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_167:
@@ -2881,7 +2881,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_167
-    pretty_name: 'CKV_AWS_167: Ensure Glacier Vault access policy is not public by
+    pretty_name: 'Ensure Glacier Vault access policy is not public by
       only allowing specific services or principals to access it'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_168:
@@ -2893,7 +2893,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_168
-    pretty_name: 'CKV_AWS_168: Ensure SQS queue policy is not public by only allowing
+    pretty_name: 'Ensure SQS queue policy is not public by only allowing
       specific services or principals to access it'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_169:
@@ -2905,7 +2905,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_169
-    pretty_name: 'CKV_AWS_169: Ensure SNS topic policy is not public by only allowing
+    pretty_name: 'Ensure SNS topic policy is not public by only allowing
       specific services or principals to access it'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_17:
@@ -2917,7 +2917,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_17
-    pretty_name: 'CKV_AWS_17: Ensure all data stored in RDS is not publicly accessible'
+    pretty_name: 'Ensure all data stored in RDS is not publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_170:
     categories:
@@ -2928,7 +2928,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_170
-    pretty_name: 'CKV_AWS_170: Ensure QLDB ledger permissions mode is set to STANDARD'
+    pretty_name: 'Ensure QLDB ledger permissions mode is set to STANDARD'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_171:
     categories:
@@ -2939,7 +2939,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_171
-    pretty_name: 'CKV_AWS_171: Ensure Cluster security configuration encryption is
+    pretty_name: 'Ensure Cluster security configuration encryption is
       using SSE-KMS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_172:
@@ -2951,7 +2951,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_172
-    pretty_name: 'CKV_AWS_172: Ensure QLDB ledger has deletion protection enabled'
+    pretty_name: 'Ensure QLDB ledger has deletion protection enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_173:
     categories:
@@ -2961,7 +2961,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_173
-    pretty_name: 'CKV_AWS_173: Check encryption settings for Lambda environmental
+    pretty_name: 'Check encryption settings for Lambda environmental
       variable'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_174:
@@ -2973,7 +2973,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_174
-    pretty_name: 'CKV_AWS_174: Verify CloudFront Distribution Viewer Certificate is
+    pretty_name: 'Verify CloudFront Distribution Viewer Certificate is
       using TLS v1.2'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_175:
@@ -2983,7 +2983,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_175
-    pretty_name: 'CKV_AWS_175: Ensure WAF has associated rules'
+    pretty_name: 'Ensure WAF has associated rules'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_176:
     categories:
@@ -2992,7 +2992,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_176
-    pretty_name: 'CKV_AWS_176: Ensure Logging is enabled for WAF  Web Access Control
+    pretty_name: 'Ensure Logging is enabled for WAF  Web Access Control
       Lists'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_177:
@@ -3002,7 +3002,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_177
-    pretty_name: 'CKV_AWS_177: Ensure Kinesis Video Stream is encrypted by KMS using
+    pretty_name: 'Ensure Kinesis Video Stream is encrypted by KMS using
       a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_178:
@@ -3012,7 +3012,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_178
-    pretty_name: 'CKV_AWS_178: Ensure fx ontap file system is encrypted by KMS using
+    pretty_name: 'Ensure fx ontap file system is encrypted by KMS using
       a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_179:
@@ -3022,7 +3022,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_179
-    pretty_name: 'CKV_AWS_179: Ensure FSX Windows filesystem is encrypted by KMS using
+    pretty_name: 'Ensure FSX Windows filesystem is encrypted by KMS using
       a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_18:
@@ -3034,7 +3034,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_18
-    pretty_name: 'CKV_AWS_18: Ensure the S3 bucket has access logging enabled'
+    pretty_name: 'Ensure the S3 bucket has access logging enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_180:
     categories:
@@ -3043,7 +3043,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_180
-    pretty_name: 'CKV_AWS_180: Ensure Image Builder component is encrypted by KMS
+    pretty_name: 'Ensure Image Builder component is encrypted by KMS
       using a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_181:
@@ -3053,7 +3053,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_181
-    pretty_name: 'CKV_AWS_181: Ensure S3 Object Copy is encrypted by KMS using a customer
+    pretty_name: 'Ensure S3 Object Copy is encrypted by KMS using a customer
       managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_182:
@@ -3063,7 +3063,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_182
-    pretty_name: 'CKV_AWS_182: Ensure Doc DB is encrypted by KMS using a customer
+    pretty_name: 'Ensure Doc DB is encrypted by KMS using a customer
       managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_183:
@@ -3073,7 +3073,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_183
-    pretty_name: 'CKV_AWS_183: Ensure EBS Snapshot Copy is encrypted by KMS using
+    pretty_name: 'Ensure EBS Snapshot Copy is encrypted by KMS using
       a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_184:
@@ -3083,7 +3083,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_184
-    pretty_name: 'CKV_AWS_184: Ensure resource is encrypted by KMS using a customer
+    pretty_name: 'Ensure resource is encrypted by KMS using a customer
       managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_185:
@@ -3093,7 +3093,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_185
-    pretty_name: 'CKV_AWS_185: Ensure Kinesis Stream is encrypted by KMS using a customer
+    pretty_name: 'Ensure Kinesis Stream is encrypted by KMS using a customer
       managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_186:
@@ -3103,7 +3103,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_186
-    pretty_name: 'CKV_AWS_186: Ensure S3 bucket Object is encrypted by KMS using a
+    pretty_name: 'Ensure S3 bucket Object is encrypted by KMS using a
       customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_187:
@@ -3113,7 +3113,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_187
-    pretty_name: 'CKV_AWS_187: Ensure Sagemaker domain is encrypted by KMS using a
+    pretty_name: 'Ensure Sagemaker domain is encrypted by KMS using a
       customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_188:
@@ -3123,7 +3123,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_188
-    pretty_name: 'CKV_AWS_188: Ensure RedShift Cluster is encrypted by KMS using a
+    pretty_name: 'Ensure RedShift Cluster is encrypted by KMS using a
       customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_189:
@@ -3133,7 +3133,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_189
-    pretty_name: 'CKV_AWS_189: Ensure EBS Volume is encrypted by KMS using a customer
+    pretty_name: 'Ensure EBS Volume is encrypted by KMS using a customer
       managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_19:
@@ -3145,7 +3145,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_19
-    pretty_name: 'CKV_AWS_19: Ensure all data stored in the S3 bucket is securely
+    pretty_name: 'Ensure all data stored in the S3 bucket is securely
       encrypted at rest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_190:
@@ -3155,7 +3155,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_190
-    pretty_name: 'CKV_AWS_190: Ensure lustre file systems is encrypted by KMS using
+    pretty_name: 'Ensure lustre file systems is encrypted by KMS using
       a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_191:
@@ -3165,7 +3165,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_191
-    pretty_name: 'CKV_AWS_191: Ensure Elasticache replication group is encrypted by
+    pretty_name: 'Ensure Elasticache replication group is encrypted by
       KMS using a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_192:
@@ -3175,7 +3175,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_192
-    pretty_name: 'CKV_AWS_192: Ensure WAF prevents message lookup in Log4j2. See CVE-2021-44228
+    pretty_name: 'Ensure WAF prevents message lookup in Log4j2. See CVE-2021-44228
       aka log4jshell'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_193:
@@ -3187,7 +3187,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_193
-    pretty_name: 'CKV_AWS_193: Ensure AppSync has Logging enabled'
+    pretty_name: 'Ensure AppSync has Logging enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_194:
     categories:
@@ -3198,7 +3198,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_194
-    pretty_name: 'CKV_AWS_194: Ensure AppSync has Field-Level logs enabled'
+    pretty_name: 'Ensure AppSync has Field-Level logs enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_195:
     categories:
@@ -3209,7 +3209,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_195
-    pretty_name: 'CKV_AWS_195: Ensure Glue component has a security configuration
+    pretty_name: 'Ensure Glue component has a security configuration
       associated'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_196:
@@ -3221,7 +3221,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_196
-    pretty_name: 'CKV_AWS_196: Ensure no aws_elasticache_security_group resources
+    pretty_name: 'Ensure no aws_elasticache_security_group resources
       exist'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_197:
@@ -3233,7 +3233,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_197
-    pretty_name: 'CKV_AWS_197: Ensure MQ Broker Audit logging is enabled'
+    pretty_name: 'Ensure MQ Broker Audit logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_198:
     categories:
@@ -3244,7 +3244,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_198
-    pretty_name: 'CKV_AWS_198: Ensure no aws_db_security_group resources exist'
+    pretty_name: 'Ensure no aws_db_security_group resources exist'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_199:
     categories:
@@ -3253,7 +3253,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_199
-    pretty_name: 'CKV_AWS_199: Ensure Image Builder Distribution Configuration encrypts
+    pretty_name: 'Ensure Image Builder Distribution Configuration encrypts
       AMI''s using KMS - a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_2:
@@ -3265,7 +3265,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_2
-    pretty_name: 'CKV_AWS_2: Ensure ALB protocol is HTTPS'
+    pretty_name: 'Ensure ALB protocol is HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_20:
     categories:
@@ -3276,7 +3276,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_20
-    pretty_name: 'CKV_AWS_20: S3 Bucket has an ACL defined which allows public READ
+    pretty_name: 'S3 Bucket has an ACL defined which allows public READ
       access.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_200:
@@ -3286,7 +3286,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_200
-    pretty_name: 'CKV_AWS_200: Ensure that Image Recipe EBS Disk are encrypted with
+    pretty_name: 'Ensure that Image Recipe EBS Disk are encrypted with
       CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_201:
@@ -3296,7 +3296,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_201
-    pretty_name: 'CKV_AWS_201: Ensure MemoryDB is encrypted at rest using KMS CMKs'
+    pretty_name: 'Ensure MemoryDB is encrypted at rest using KMS CMKs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_202:
     categories:
@@ -3307,7 +3307,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_202
-    pretty_name: 'CKV_AWS_202: Ensure MemoryDB data is encrypted in transit'
+    pretty_name: 'Ensure MemoryDB data is encrypted in transit'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_203:
     categories:
@@ -3316,7 +3316,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_203
-    pretty_name: 'CKV_AWS_203: Ensure resource is encrypted by KMS using a customer
+    pretty_name: 'Ensure resource is encrypted by KMS using a customer
       managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_204:
@@ -3326,7 +3326,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_204
-    pretty_name: 'CKV_AWS_204: Ensure AMIs are encrypted using KMS CMKs'
+    pretty_name: 'Ensure AMIs are encrypted using KMS CMKs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_205:
     categories:
@@ -3337,7 +3337,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_205
-    pretty_name: 'CKV_AWS_205: Ensure to Limit AMI launch Permissions'
+    pretty_name: 'Ensure to Limit AMI launch Permissions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_206:
     categories:
@@ -3348,7 +3348,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_206
-    pretty_name: 'CKV_AWS_206: Ensure API Gateway Domain uses a modern security Policy'
+    pretty_name: 'Ensure API Gateway Domain uses a modern security Policy'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_207:
     categories:
@@ -3359,7 +3359,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_207
-    pretty_name: 'CKV_AWS_207: Ensure MQ Broker minor version updates are enabled'
+    pretty_name: 'Ensure MQ Broker minor version updates are enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_208:
     categories:
@@ -3370,7 +3370,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_208
-    pretty_name: 'CKV_AWS_208: Ensure MQBroker version is current'
+    pretty_name: 'Ensure MQBroker version is current'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_209:
     categories:
@@ -3379,7 +3379,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_209
-    pretty_name: 'CKV_AWS_209: Ensure MQ broker encrypted by KMS using a customer
+    pretty_name: 'Ensure MQ broker encrypted by KMS using a customer
       managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_21:
@@ -3390,7 +3390,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_21
-    pretty_name: 'CKV_AWS_21: Ensure all data stored in the S3 bucket have versioning
+    pretty_name: 'Ensure all data stored in the S3 bucket have versioning
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_210:
@@ -3402,7 +3402,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_210
-    pretty_name: 'CKV_AWS_210: Batch job does not define a privileged container'
+    pretty_name: 'Batch job does not define a privileged container'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_211:
     categories:
@@ -3413,7 +3413,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_211
-    pretty_name: 'CKV_AWS_211: Ensure RDS uses a modern CaCert'
+    pretty_name: 'Ensure RDS uses a modern CaCert'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_212:
     categories:
@@ -3422,7 +3422,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_212
-    pretty_name: 'CKV_AWS_212: Ensure EBS Volume is encrypted by KMS using a customer
+    pretty_name: 'Ensure EBS Volume is encrypted by KMS using a customer
       managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_213:
@@ -3434,7 +3434,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_213
-    pretty_name: 'CKV_AWS_213: Ensure ELB Policy uses only secure protocols'
+    pretty_name: 'Ensure ELB Policy uses only secure protocols'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_214:
     categories:
@@ -3445,7 +3445,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_214
-    pretty_name: 'CKV_AWS_214: Ensure Appsync API Cache is encrypted at rest'
+    pretty_name: 'Ensure Appsync API Cache is encrypted at rest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_215:
     categories:
@@ -3456,7 +3456,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_215
-    pretty_name: 'CKV_AWS_215: Ensure Appsync API Cache is encrypted in transit'
+    pretty_name: 'Ensure Appsync API Cache is encrypted in transit'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_216:
     categories:
@@ -3465,7 +3465,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_216
-    pretty_name: 'CKV_AWS_216: Ensure Cloudfront distribution is enabled'
+    pretty_name: 'Ensure Cloudfront distribution is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_217:
     categories:
@@ -3476,7 +3476,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_217
-    pretty_name: 'CKV_AWS_217: Ensure Create before destroy for API deployments'
+    pretty_name: 'Ensure Create before destroy for API deployments'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_218:
     categories:
@@ -3487,7 +3487,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_218
-    pretty_name: 'CKV_AWS_218: Ensure that Cloudsearch is using latest TLS'
+    pretty_name: 'Ensure that Cloudsearch is using latest TLS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_219:
     categories:
@@ -3496,7 +3496,7 @@ rules:
     description: Check for weak AWS configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_AWS_219
-    pretty_name: 'CKV_AWS_219: Ensure Code Pipeline Artifact store is using a KMS
+    pretty_name: 'Ensure Code Pipeline Artifact store is using a KMS
       CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_22:
@@ -3506,7 +3506,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_22
-    pretty_name: 'CKV_AWS_22: Ensure SageMaker Notebook is encrypted at rest using
+    pretty_name: 'Ensure SageMaker Notebook is encrypted at rest using
       KMS CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_220:
@@ -3518,7 +3518,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_220
-    pretty_name: 'CKV_AWS_220: Ensure that Cloudsearch is using https'
+    pretty_name: 'Ensure that Cloudsearch is using https'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_221:
     categories:
@@ -3527,7 +3527,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_221
-    pretty_name: 'CKV_AWS_221: Ensure Code artifact Domain is encrypted by KMS using
+    pretty_name: 'Ensure Code artifact Domain is encrypted by KMS using
       a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_222:
@@ -3539,7 +3539,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_222
-    pretty_name: 'CKV_AWS_222: Ensure DMS instance gets all minor upgrade automatically'
+    pretty_name: 'Ensure DMS instance gets all minor upgrade automatically'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_223:
     categories:
@@ -3550,7 +3550,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_223
-    pretty_name: 'CKV_AWS_223: Ensure ECS Cluster enables logging of ECS Exec'
+    pretty_name: 'Ensure ECS Cluster enables logging of ECS Exec'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_224:
     categories:
@@ -3559,7 +3559,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_224
-    pretty_name: 'CKV_AWS_224: Ensure Cluster logging with CMK'
+    pretty_name: 'Ensure Cluster logging with CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_225:
     categories:
@@ -3570,7 +3570,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_225
-    pretty_name: 'CKV_AWS_225: Ensure API Gateway method setting caching is enabled'
+    pretty_name: 'Ensure API Gateway method setting caching is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_226:
     categories:
@@ -3581,7 +3581,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_226
-    pretty_name: 'CKV_AWS_226: Ensure DB instance gets all minor upgrades automatically'
+    pretty_name: 'Ensure DB instance gets all minor upgrades automatically'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_227:
     categories:
@@ -3592,7 +3592,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_227
-    pretty_name: 'CKV_AWS_227: Ensure KMS key is enabled'
+    pretty_name: 'Ensure KMS key is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_228:
     categories:
@@ -3603,7 +3603,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_228
-    pretty_name: 'CKV_AWS_228: Verify Elasticsearch domain is using an up to date
+    pretty_name: 'Verify Elasticsearch domain is using an up to date
       TLS policy'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_229:
@@ -3615,7 +3615,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_229
-    pretty_name: 'CKV_AWS_229: Ensure no NACL allow ingress from 0.0.0.0:0 to port
+    pretty_name: 'Ensure no NACL allow ingress from 0.0.0.0:0 to port
       21'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_23:
@@ -3627,7 +3627,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_23
-    pretty_name: 'CKV_AWS_23: Ensure every security groups rule has a description'
+    pretty_name: 'Ensure every security groups rule has a description'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_230:
     categories:
@@ -3638,7 +3638,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_230
-    pretty_name: 'CKV_AWS_230: Ensure no NACL allow ingress from 0.0.0.0:0 to port
+    pretty_name: 'Ensure no NACL allow ingress from 0.0.0.0:0 to port
       20'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_231:
@@ -3650,7 +3650,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_231
-    pretty_name: 'CKV_AWS_231: Ensure no NACL allow ingress from 0.0.0.0:0 to port
+    pretty_name: 'Ensure no NACL allow ingress from 0.0.0.0:0 to port
       3389'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_232:
@@ -3662,7 +3662,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_232
-    pretty_name: 'CKV_AWS_232: Ensure no NACL allow ingress from 0.0.0.0:0 to port
+    pretty_name: 'Ensure no NACL allow ingress from 0.0.0.0:0 to port
       22'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_233:
@@ -3674,7 +3674,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_233
-    pretty_name: 'CKV_AWS_233: Ensure Create before destroy for ACM certificates'
+    pretty_name: 'Ensure Create before destroy for ACM certificates'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_234:
     categories:
@@ -3684,7 +3684,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_234
-    pretty_name: 'CKV_AWS_234: Verify logging preference for ACM certificates'
+    pretty_name: 'Verify logging preference for ACM certificates'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_235:
     categories:
@@ -3695,7 +3695,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_235
-    pretty_name: 'CKV_AWS_235: Ensure that copied AMIs are encrypted'
+    pretty_name: 'Ensure that copied AMIs are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_236:
     categories:
@@ -3704,7 +3704,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_236
-    pretty_name: 'CKV_AWS_236: Ensure AMI copying uses a CMK'
+    pretty_name: 'Ensure AMI copying uses a CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_237:
     categories:
@@ -3715,7 +3715,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_237
-    pretty_name: 'CKV_AWS_237: Ensure Create before destroy for API GATEWAY'
+    pretty_name: 'Ensure Create before destroy for API GATEWAY'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_238:
     categories:
@@ -3724,7 +3724,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_238
-    pretty_name: 'CKV_AWS_238: Ensure that Guard Duty detector is enabled'
+    pretty_name: 'Ensure that Guard Duty detector is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_239:
     categories:
@@ -3735,7 +3735,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_239
-    pretty_name: 'CKV_AWS_239: Ensure DAX cluster endpoint is using TLS'
+    pretty_name: 'Ensure DAX cluster endpoint is using TLS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_24:
     categories:
@@ -3746,7 +3746,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_24
-    pretty_name: 'CKV_AWS_24: Ensure no security groups allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security groups allow ingress from 0.0.0.0:0
       to port 22'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_240:
@@ -3758,7 +3758,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_240
-    pretty_name: 'CKV_AWS_240: Ensure Kinesis Firehose delivery stream is encrypted'
+    pretty_name: 'Ensure Kinesis Firehose delivery stream is encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_241:
     categories:
@@ -3767,7 +3767,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_241
-    pretty_name: 'CKV_AWS_241: Ensure that Kinesis Firehose Delivery Streams are encrypted
+    pretty_name: 'Ensure that Kinesis Firehose Delivery Streams are encrypted
       with CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_242:
@@ -3779,7 +3779,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_242
-    pretty_name: 'CKV_AWS_242: Ensure MWAA environment has scheduler logs enabled'
+    pretty_name: 'Ensure MWAA environment has scheduler logs enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_243:
     categories:
@@ -3790,7 +3790,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_243
-    pretty_name: 'CKV_AWS_243: Ensure MWAA environment has worker logs enabled'
+    pretty_name: 'Ensure MWAA environment has worker logs enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_244:
     categories:
@@ -3801,7 +3801,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_244
-    pretty_name: 'CKV_AWS_244: Ensure MWAA environment has webserver logs enabled'
+    pretty_name: 'Ensure MWAA environment has webserver logs enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_245:
     categories:
@@ -3810,7 +3810,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_245
-    pretty_name: 'CKV_AWS_245: Ensure replicated backups are encrypted at rest using
+    pretty_name: 'Ensure replicated backups are encrypted at rest using
       KMS CMKs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_246:
@@ -3820,7 +3820,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_246
-    pretty_name: 'CKV_AWS_246: Ensure RDS Cluster activity streams are encrypted using
+    pretty_name: 'Ensure RDS Cluster activity streams are encrypted using
       KMS CMKs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_247:
@@ -3830,7 +3830,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_247
-    pretty_name: 'CKV_AWS_247: Ensure all data stored in the Elasticsearch is encrypted
+    pretty_name: 'Ensure all data stored in the Elasticsearch is encrypted
       with a CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_248:
@@ -3842,7 +3842,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_248
-    pretty_name: 'CKV_AWS_248: Ensure that Elasticsearch is not using the default
+    pretty_name: 'Ensure that Elasticsearch is not using the default
       Security Group'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_249:
@@ -3853,7 +3853,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_249
-    pretty_name: 'CKV_AWS_249: Ensure that the Execution Role ARN and the Task Role
+    pretty_name: 'Ensure that the Execution Role ARN and the Task Role
       ARN are different in ECS Task definitions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_25:
@@ -3865,7 +3865,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_25
-    pretty_name: 'CKV_AWS_25: Ensure no security groups allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security groups allow ingress from 0.0.0.0:0
       to port 3389'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_250:
@@ -3877,7 +3877,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_250
-    pretty_name: 'CKV_AWS_250: Ensure that RDS PostgreSQL instances use a non vulnerable
+    pretty_name: 'Ensure that RDS PostgreSQL instances use a non vulnerable
       version with the log_fdw extension'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_251:
@@ -3889,7 +3889,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_251
-    pretty_name: 'CKV_AWS_251: Ensure CloudTrail logging is enabled'
+    pretty_name: 'Ensure CloudTrail logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_252:
     categories:
@@ -3898,7 +3898,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_252
-    pretty_name: 'CKV_AWS_252: Ensure CloudTrail defines an SNS Topic'
+    pretty_name: 'Ensure CloudTrail defines an SNS Topic'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_253:
     categories:
@@ -3909,7 +3909,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_253
-    pretty_name: 'CKV_AWS_253: Ensure DLM cross region events are encrypted'
+    pretty_name: 'Ensure DLM cross region events are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_254:
     categories:
@@ -3918,7 +3918,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_254
-    pretty_name: 'CKV_AWS_254: Ensure DLM cross region events are encrypted with Customer
+    pretty_name: 'Ensure DLM cross region events are encrypted with Customer
       Managed Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_255:
@@ -3930,7 +3930,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_255
-    pretty_name: 'CKV_AWS_255: Ensure DLM cross region schedules are encrypted'
+    pretty_name: 'Ensure DLM cross region schedules are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_256:
     categories:
@@ -3939,7 +3939,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_256
-    pretty_name: 'CKV_AWS_256: Ensure DLM cross region schedules are encrypted using
+    pretty_name: 'Ensure DLM cross region schedules are encrypted using
       a Customer Managed Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_257:
@@ -3950,7 +3950,7 @@ rules:
     description: Check for weak AWS configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_AWS_257
-    pretty_name: 'CKV_AWS_257: Ensure codecommit branch changes have at least 2 approvals'
+    pretty_name: 'Ensure codecommit branch changes have at least 2 approvals'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_258:
     categories:
@@ -3961,7 +3961,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_258
-    pretty_name: 'CKV_AWS_258: Ensure that Lambda function URLs AuthType is not None'
+    pretty_name: 'Ensure that Lambda function URLs AuthType is not None'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_259:
     categories:
@@ -3972,7 +3972,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_259
-    pretty_name: 'CKV_AWS_259: Ensure CloudFront response header policy enforces Strict
+    pretty_name: 'Ensure CloudFront response header policy enforces Strict
       Transport Security'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_26:
@@ -3984,7 +3984,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_26
-    pretty_name: 'CKV_AWS_26: Ensure all data stored in the SNS topic is encrypted'
+    pretty_name: 'Ensure all data stored in the SNS topic is encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_260:
     categories:
@@ -3995,7 +3995,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_260
-    pretty_name: 'CKV_AWS_260: Ensure no security groups allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security groups allow ingress from 0.0.0.0:0
       to port 80'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_261:
@@ -4006,7 +4006,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_261
-    pretty_name: 'CKV_AWS_261: Ensure HTTP HTTPS Target group defines Healthcheck'
+    pretty_name: 'Ensure HTTP HTTPS Target group defines Healthcheck'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_262:
     categories:
@@ -4015,7 +4015,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_262
-    pretty_name: 'CKV_AWS_262: Ensure Kendra index Server side encryption uses CMK'
+    pretty_name: 'Ensure Kendra index Server side encryption uses CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_263:
     categories:
@@ -4024,7 +4024,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_263
-    pretty_name: 'CKV_AWS_263: Ensure App Flow flow uses CMK'
+    pretty_name: 'Ensure App Flow flow uses CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_264:
     categories:
@@ -4033,7 +4033,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_264
-    pretty_name: 'CKV_AWS_264: Ensure App Flow connector profile uses CMK'
+    pretty_name: 'Ensure App Flow connector profile uses CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_265:
     categories:
@@ -4042,7 +4042,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_265
-    pretty_name: 'CKV_AWS_265: Ensure Keyspaces Table uses CMK'
+    pretty_name: 'Ensure Keyspaces Table uses CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_266:
     categories:
@@ -4051,7 +4051,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_266
-    pretty_name: 'CKV_AWS_266: Ensure App Flow connector profile uses CMK'
+    pretty_name: 'Ensure App Flow connector profile uses CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_267:
     categories:
@@ -4060,7 +4060,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_267
-    pretty_name: 'CKV_AWS_267: Ensure that Comprehend Entity Recognizer''s model is
+    pretty_name: 'Ensure that Comprehend Entity Recognizer''s model is
       encrypted by KMS using a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_268:
@@ -4070,7 +4070,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_268
-    pretty_name: 'CKV_AWS_268: Ensure that Comprehend Entity Recognizer''s volume
+    pretty_name: 'Ensure that Comprehend Entity Recognizer''s volume
       is encrypted by KMS using a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_269:
@@ -4080,7 +4080,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_269
-    pretty_name: 'CKV_AWS_269: Ensure Connect Instance Kinesis Video Stream Storage
+    pretty_name: 'Ensure Connect Instance Kinesis Video Stream Storage
       Config uses CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_27:
@@ -4092,7 +4092,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_27
-    pretty_name: 'CKV_AWS_27: Ensure all data stored in the SQS queue is encrypted'
+    pretty_name: 'Ensure all data stored in the SQS queue is encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_270:
     categories:
@@ -4101,7 +4101,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_270
-    pretty_name: 'CKV_AWS_270: Ensure Connect Instance S3 Storage Config uses CMK'
+    pretty_name: 'Ensure Connect Instance S3 Storage Config uses CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_271:
     categories:
@@ -4110,7 +4110,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_271
-    pretty_name: 'CKV_AWS_271: Ensure DynamoDB table replica KMS encryption uses CMK'
+    pretty_name: 'Ensure DynamoDB table replica KMS encryption uses CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_272:
     categories:
@@ -4121,7 +4121,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_272
-    pretty_name: 'CKV_AWS_272: Ensure AWS Lambda function is configured to validate
+    pretty_name: 'Ensure AWS Lambda function is configured to validate
       code-signing'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_273:
@@ -4132,7 +4132,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_273
-    pretty_name: 'CKV_AWS_273: Ensure access is controlled through SSO and not AWS
+    pretty_name: 'Ensure access is controlled through SSO and not AWS
       IAM defined users'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_274:
@@ -4143,7 +4143,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_274
-    pretty_name: 'CKV_AWS_274: Disallow IAM roles, users, and groups from using the
+    pretty_name: 'Disallow IAM roles, users, and groups from using the
       AWS AdministratorAccess policy'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_275:
@@ -4154,7 +4154,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_275
-    pretty_name: 'CKV_AWS_275: Disallow policies from using the AWS AdministratorAccess
+    pretty_name: 'Disallow policies from using the AWS AdministratorAccess
       policy'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_276:
@@ -4164,7 +4164,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_276
-    pretty_name: 'CKV_AWS_276: Ensure Data Trace is not enabled in API Gateway Method
+    pretty_name: 'Ensure Data Trace is not enabled in API Gateway Method
       Settings'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_277:
@@ -4176,7 +4176,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_277
-    pretty_name: 'CKV_AWS_277: Ensure no security groups allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security groups allow ingress from 0.0.0.0:0
       to port -1'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_278:
@@ -4188,7 +4188,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_278
-    pretty_name: 'CKV_AWS_278: Ensure MemoryDB snapshot is encrypted by KMS using
+    pretty_name: 'Ensure MemoryDB snapshot is encrypted by KMS using
       a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_279:
@@ -4200,7 +4200,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_279
-    pretty_name: 'CKV_AWS_279: Ensure Neptune snapshot is securely encrypted'
+    pretty_name: 'Ensure Neptune snapshot is securely encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_28:
     categories:
@@ -4211,7 +4211,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_28
-    pretty_name: 'CKV_AWS_28: Ensure Dynamodb point in time recovery (backup) is enabled'
+    pretty_name: 'Ensure Dynamodb point in time recovery (backup) is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_280:
     categories:
@@ -4222,7 +4222,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_280
-    pretty_name: 'CKV_AWS_280: Ensure Neptune snapshot is encrypted by KMS using a
+    pretty_name: 'Ensure Neptune snapshot is encrypted by KMS using a
       customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_281:
@@ -4234,7 +4234,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_281
-    pretty_name: 'CKV_AWS_281: Ensure RedShift snapshot copy is encrypted by KMS using
+    pretty_name: 'Ensure RedShift snapshot copy is encrypted by KMS using
       a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_282:
@@ -4246,7 +4246,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_282
-    pretty_name: 'CKV_AWS_282: Ensure that Redshift Serverless namespace is encrypted
+    pretty_name: 'Ensure that Redshift Serverless namespace is encrypted
       by KMS using a customer managed key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_283:
@@ -4258,7 +4258,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_283
-    pretty_name: 'CKV_AWS_283: Ensure no IAM policies documents allow ALL or any AWS
+    pretty_name: 'Ensure no IAM policies documents allow ALL or any AWS
       principal permissions to the resource'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_284:
@@ -4270,7 +4270,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_284
-    pretty_name: 'CKV_AWS_284: Ensure State Machine has X-Ray tracing enabled'
+    pretty_name: 'Ensure State Machine has X-Ray tracing enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_285:
     categories:
@@ -4281,7 +4281,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_285
-    pretty_name: 'CKV_AWS_285: Ensure State Machine has execution history logging
+    pretty_name: 'Ensure State Machine has execution history logging
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_286:
@@ -4293,7 +4293,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_286
-    pretty_name: 'CKV_AWS_286: Ensure IAM policies does not allow privilege escalation'
+    pretty_name: 'Ensure IAM policies does not allow privilege escalation'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_287:
     categories:
@@ -4304,7 +4304,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_287
-    pretty_name: 'CKV_AWS_287: Ensure IAM policies does not allow credentials exposure'
+    pretty_name: 'Ensure IAM policies does not allow credentials exposure'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_288:
     categories:
@@ -4315,7 +4315,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_288
-    pretty_name: 'CKV_AWS_288: Ensure IAM policies does not allow data exfiltration'
+    pretty_name: 'Ensure IAM policies does not allow data exfiltration'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_289:
     categories:
@@ -4326,7 +4326,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_289
-    pretty_name: 'CKV_AWS_289: Ensure IAM policies does not allow permissions management
+    pretty_name: 'Ensure IAM policies does not allow permissions management
       / resource exposure without constraints'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_29:
@@ -4338,7 +4338,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_29
-    pretty_name: 'CKV_AWS_29: Ensure all data stored in the Elasticache Replication
+    pretty_name: 'Ensure all data stored in the Elasticache Replication
       Group is securely encrypted at rest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_290:
@@ -4350,7 +4350,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_290
-    pretty_name: 'CKV_AWS_290: Ensure IAM policies does not allow write access without
+    pretty_name: 'Ensure IAM policies does not allow write access without
       constraints'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_291:
@@ -4362,7 +4362,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_291
-    pretty_name: 'CKV_AWS_291: Ensure MSK nodes are private'
+    pretty_name: 'Ensure MSK nodes are private'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_292:
     categories:
@@ -4373,7 +4373,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_292
-    pretty_name: 'CKV_AWS_292: Ensure DocDB Global Cluster is encrypted at rest (default
+    pretty_name: 'Ensure DocDB Global Cluster is encrypted at rest (default
       is unencrypted)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_293:
@@ -4385,7 +4385,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_293
-    pretty_name: 'CKV_AWS_293: Ensure that AWS database instances have deletion protection
+    pretty_name: 'Ensure that AWS database instances have deletion protection
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_294:
@@ -4397,7 +4397,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_294
-    pretty_name: 'CKV_AWS_294: Ensure Cloud Trail Event Data Store uses CMK'
+    pretty_name: 'Ensure Cloud Trail Event Data Store uses CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_295:
     categories:
@@ -4408,7 +4408,7 @@ rules:
     description: stored-secrets
     group: stored-secrets
     name: CKV_AWS_295
-    pretty_name: 'CKV_AWS_295: Ensure DataSync Location Object Storage doesn''t expose
+    pretty_name: 'Ensure DataSync Location Object Storage doesn''t expose
       secrets'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_296:
@@ -4420,7 +4420,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_296
-    pretty_name: 'CKV_AWS_296: Ensure DMS endpoint uses Customer Managed Key (CMK)'
+    pretty_name: 'Ensure DMS endpoint uses Customer Managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_297:
     categories:
@@ -4431,7 +4431,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_297
-    pretty_name: 'CKV_AWS_297: Ensure EventBridge Scheduler Schedule uses Customer
+    pretty_name: 'Ensure EventBridge Scheduler Schedule uses Customer
       Managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_298:
@@ -4443,7 +4443,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_298
-    pretty_name: 'CKV_AWS_298: Ensure DMS S3 uses Customer Managed Key (CMK)'
+    pretty_name: 'Ensure DMS S3 uses Customer Managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_299:
     categories:
@@ -4454,7 +4454,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_299
-    pretty_name: 'CKV_AWS_299: Ensure DMS S3 defines in-transit encryption'
+    pretty_name: 'Ensure DMS S3 defines in-transit encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_3:
     categories:
@@ -4465,7 +4465,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_3
-    pretty_name: 'CKV_AWS_3: Ensure all data stored in the EBS is securely encrypted'
+    pretty_name: 'Ensure all data stored in the EBS is securely encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_30:
     categories:
@@ -4476,7 +4476,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_30
-    pretty_name: 'CKV_AWS_30: Ensure all data stored in the Elasticache Replication
+    pretty_name: 'Ensure all data stored in the Elasticache Replication
       Group is securely encrypted at transit'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_300:
@@ -4488,7 +4488,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_300
-    pretty_name: 'CKV_AWS_300: Ensure S3 lifecycle configuration sets period for aborting
+    pretty_name: 'Ensure S3 lifecycle configuration sets period for aborting
       failed uploads'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_301:
@@ -4500,7 +4500,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_301
-    pretty_name: 'CKV_AWS_301: Ensure that AWS Lambda function is not publicly accessible'
+    pretty_name: 'Ensure that AWS Lambda function is not publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_302:
     categories:
@@ -4511,7 +4511,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_302
-    pretty_name: 'CKV_AWS_302: Ensure DB Snapshots are not Public'
+    pretty_name: 'Ensure DB Snapshots are not Public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_303:
     categories:
@@ -4522,7 +4522,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_303
-    pretty_name: 'CKV_AWS_303: Ensure SSM documents are not Public'
+    pretty_name: 'Ensure SSM documents are not Public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_304:
     categories:
@@ -4533,7 +4533,7 @@ rules:
     description: Check that ensures best practices in AWS secrets management.
     group: cloud-weak-secrets-management
     name: CKV_AWS_304
-    pretty_name: 'CKV_AWS_304: Ensure Secrets Manager secrets should be rotated within
+    pretty_name: 'Ensure Secrets Manager secrets should be rotated within
       90 days'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_305:
@@ -4545,7 +4545,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_305
-    pretty_name: 'CKV_AWS_305: Ensure Cloudfront distribution has a default root object
+    pretty_name: 'Ensure Cloudfront distribution has a default root object
       configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_306:
@@ -4557,7 +4557,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_306
-    pretty_name: 'CKV_AWS_306: Ensure SageMaker notebook instances should be launched
+    pretty_name: 'Ensure SageMaker notebook instances should be launched
       into a custom VPC'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_307:
@@ -4569,7 +4569,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_307
-    pretty_name: 'CKV_AWS_307: Ensure SageMaker Users should not have root access
+    pretty_name: 'Ensure SageMaker Users should not have root access
       to SageMaker notebook instances'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_308:
@@ -4581,7 +4581,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_308
-    pretty_name: 'CKV_AWS_308: Ensure API Gateway method setting caching is set to
+    pretty_name: 'Ensure API Gateway method setting caching is set to
       encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_309:
@@ -4593,7 +4593,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_309
-    pretty_name: 'CKV_AWS_309: Ensure API GatewayV2 routes specify an authorization
+    pretty_name: 'Ensure API GatewayV2 routes specify an authorization
       type'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_31:
@@ -4605,7 +4605,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_31
-    pretty_name: 'CKV_AWS_31: Ensure all data stored in the Elasticache Replication
+    pretty_name: 'Ensure all data stored in the Elasticache Replication
       Group is securely encrypted at transit and has auth token'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_310:
@@ -4617,7 +4617,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_310
-    pretty_name: 'CKV_AWS_310: Ensure CloudFront distributions should have origin
+    pretty_name: 'Ensure CloudFront distributions should have origin
       failover configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_311:
@@ -4629,7 +4629,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_311
-    pretty_name: 'CKV_AWS_311: Ensure that CodeBuild S3 logs are encrypted'
+    pretty_name: 'Ensure that CodeBuild S3 logs are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_312:
     categories:
@@ -4640,7 +4640,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_312
-    pretty_name: 'CKV_AWS_312: Ensure Elastic Beanstalk environments have enhanced
+    pretty_name: 'Ensure Elastic Beanstalk environments have enhanced
       health reporting enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_313:
@@ -4652,7 +4652,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_313
-    pretty_name: 'CKV_AWS_313: Ensure RDS cluster configured to copy tags to snapshots'
+    pretty_name: 'Ensure RDS cluster configured to copy tags to snapshots'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_314:
     categories:
@@ -4663,7 +4663,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_314
-    pretty_name: 'CKV_AWS_314: Ensure CodeBuild project environments have a logging
+    pretty_name: 'Ensure CodeBuild project environments have a logging
       configuration'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_315:
@@ -4675,7 +4675,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_315
-    pretty_name: 'CKV_AWS_315: Ensure EC2 Auto Scaling groups use EC2 launch templates'
+    pretty_name: 'Ensure EC2 Auto Scaling groups use EC2 launch templates'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_316:
     categories:
@@ -4686,7 +4686,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_316
-    pretty_name: 'CKV_AWS_316: Ensure CodeBuild project environments do not have privileged
+    pretty_name: 'Ensure CodeBuild project environments do not have privileged
       mode enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_317:
@@ -4698,7 +4698,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_317
-    pretty_name: 'CKV_AWS_317: Ensure Elasticsearch Domain Audit Logging is enabled'
+    pretty_name: 'Ensure Elasticsearch Domain Audit Logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_318:
     categories:
@@ -4709,7 +4709,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_318
-    pretty_name: 'CKV_AWS_318: Ensure Elasticsearch domains are configured with at
+    pretty_name: 'Ensure Elasticsearch domains are configured with at
       least three dedicated master nodes for HA'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_319:
@@ -4721,7 +4721,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_319
-    pretty_name: 'CKV_AWS_319: Ensure that CloudWatch alarm actions are enabled'
+    pretty_name: 'Ensure that CloudWatch alarm actions are enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_32:
     categories:
@@ -4732,7 +4732,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_32
-    pretty_name: 'CKV_AWS_32: Ensure ECR policy is not set to public'
+    pretty_name: 'Ensure ECR policy is not set to public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_320:
     categories:
@@ -4743,7 +4743,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_320
-    pretty_name: 'CKV_AWS_320: Ensure Redshift clusters do not use the default database
+    pretty_name: 'Ensure Redshift clusters do not use the default database
       name'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_321:
@@ -4755,7 +4755,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_321
-    pretty_name: 'CKV_AWS_321: Ensure Redshift clusters use enhanced VPC routing'
+    pretty_name: 'Ensure Redshift clusters use enhanced VPC routing'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_322:
     categories:
@@ -4766,7 +4766,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_322
-    pretty_name: 'CKV_AWS_322: Ensure ElastiCache for Redis cache clusters have auto
+    pretty_name: 'Ensure ElastiCache for Redis cache clusters have auto
       minor version upgrades enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_323:
@@ -4778,7 +4778,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_323
-    pretty_name: 'CKV_AWS_323: Ensure ElastiCache clusters do not use the default
+    pretty_name: 'Ensure ElastiCache clusters do not use the default
       subnet group'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_324:
@@ -4790,7 +4790,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_324
-    pretty_name: 'CKV_AWS_324: Ensure that RDS Cluster log capture is enabled'
+    pretty_name: 'Ensure that RDS Cluster log capture is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_325:
     categories:
@@ -4801,7 +4801,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_325
-    pretty_name: 'CKV_AWS_325: Ensure that RDS Cluster audit logging is enabled for
+    pretty_name: 'Ensure that RDS Cluster audit logging is enabled for
       MySQL engine'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_326:
@@ -4813,7 +4813,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_326
-    pretty_name: 'CKV_AWS_326: Ensure that RDS Aurora Clusters have backtracking enabled'
+    pretty_name: 'Ensure that RDS Aurora Clusters have backtracking enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_327:
     categories:
@@ -4824,7 +4824,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_327
-    pretty_name: 'CKV_AWS_327: Ensure RDS Clusters are encrypted using KMS CMKs'
+    pretty_name: 'Ensure RDS Clusters are encrypted using KMS CMKs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_328:
     categories:
@@ -4835,7 +4835,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_328
-    pretty_name: 'CKV_AWS_328: Ensure that ALB is configured with defensive or strictest
+    pretty_name: 'Ensure that ALB is configured with defensive or strictest
       desync mitigation mode'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_329:
@@ -4847,7 +4847,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_329
-    pretty_name: 'CKV_AWS_329: EFS access points should enforce a root directory'
+    pretty_name: 'EFS access points should enforce a root directory'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_33:
     categories:
@@ -4858,7 +4858,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_33
-    pretty_name: 'CKV_AWS_33: Ensure KMS key policy does not contain wildcard (*)
+    pretty_name: 'Ensure KMS key policy does not contain wildcard (*)
       principal'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_330:
@@ -4870,7 +4870,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_330
-    pretty_name: 'CKV_AWS_330: EFS access points should enforce a user identity'
+    pretty_name: 'EFS access points should enforce a user identity'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_331:
     categories:
@@ -4881,7 +4881,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_331
-    pretty_name: 'CKV_AWS_331: Ensure Transit Gateways do not automatically accept
+    pretty_name: 'Ensure Transit Gateways do not automatically accept
       VPC attachment requests'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_332:
@@ -4893,7 +4893,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_332
-    pretty_name: 'CKV_AWS_332: Ensure ECS Fargate services run on the latest Fargate
+    pretty_name: 'Ensure ECS Fargate services run on the latest Fargate
       platform version'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_333:
@@ -4905,7 +4905,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_333
-    pretty_name: 'CKV_AWS_333: Ensure ECS services do not have public IP addresses
+    pretty_name: 'Ensure ECS services do not have public IP addresses
       assigned to them automatically'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_334:
@@ -4917,7 +4917,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_334
-    pretty_name: 'CKV_AWS_334: Ensure ECS containers should run as non-privileged'
+    pretty_name: 'Ensure ECS containers should run as non-privileged'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_34:
     categories:
@@ -4928,7 +4928,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_34
-    pretty_name: 'CKV_AWS_34: Ensure cloudfront distribution ViewerProtocolPolicy
+    pretty_name: 'Ensure cloudfront distribution ViewerProtocolPolicy
       is set to HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_35:
@@ -4938,7 +4938,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_35
-    pretty_name: 'CKV_AWS_35: Ensure CloudTrail logs are encrypted at rest using KMS
+    pretty_name: 'Ensure CloudTrail logs are encrypted at rest using KMS
       CMKs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_36:
@@ -4950,7 +4950,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_36
-    pretty_name: 'CKV_AWS_36: Ensure CloudTrail log file validation is enabled'
+    pretty_name: 'Ensure CloudTrail log file validation is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_37:
     categories:
@@ -4961,7 +4961,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_37
-    pretty_name: 'CKV_AWS_37: Ensure Amazon EKS control plane logging enabled for
+    pretty_name: 'Ensure Amazon EKS control plane logging enabled for
       all log types'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_38:
@@ -4972,7 +4972,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_38
-    pretty_name: 'CKV_AWS_38: Ensure Amazon EKS public endpoint not accessible to
+    pretty_name: 'Ensure Amazon EKS public endpoint not accessible to
       0.0.0.0/0'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_39:
@@ -4983,7 +4983,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_39
-    pretty_name: 'CKV_AWS_39: Ensure Amazon EKS public endpoint disabled'
+    pretty_name: 'Ensure Amazon EKS public endpoint disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_40:
     categories:
@@ -4994,7 +4994,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_40
-    pretty_name: 'CKV_AWS_40: Ensure IAM policies are attached only to groups or roles'
+    pretty_name: 'Ensure IAM policies are attached only to groups or roles'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_41:
     categories:
@@ -5005,7 +5005,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_AWS_41
-    pretty_name: 'CKV_AWS_41: Ensure no hard coded AWS access key and secret key exists
+    pretty_name: 'Ensure no hard coded AWS access key and secret key exists
       in provider'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_42:
@@ -5017,7 +5017,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_42
-    pretty_name: 'CKV_AWS_42: Ensure EFS is securely encrypted'
+    pretty_name: 'Ensure EFS is securely encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_43:
     categories:
@@ -5028,7 +5028,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_43
-    pretty_name: 'CKV_AWS_43: Ensure Kinesis Stream is securely encrypted'
+    pretty_name: 'Ensure Kinesis Stream is securely encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_44:
     categories:
@@ -5039,7 +5039,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_44
-    pretty_name: 'CKV_AWS_44: Ensure Neptune storage is securely encrypted'
+    pretty_name: 'Ensure Neptune storage is securely encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_45:
     categories:
@@ -5050,7 +5050,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_AWS_45
-    pretty_name: 'CKV_AWS_45: Ensure no hard-coded secrets exist in lambda environment'
+    pretty_name: 'Ensure no hard-coded secrets exist in lambda environment'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_46:
     categories:
@@ -5061,7 +5061,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_AWS_46
-    pretty_name: 'CKV_AWS_46: Ensure no hard-coded secrets exist in EC2 user data'
+    pretty_name: 'Ensure no hard-coded secrets exist in EC2 user data'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_47:
     categories:
@@ -5072,7 +5072,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_47
-    pretty_name: 'CKV_AWS_47: Ensure DAX is encrypted at rest (default is unencrypted)'
+    pretty_name: 'Ensure DAX is encrypted at rest (default is unencrypted)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_48:
     categories:
@@ -5083,7 +5083,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_48
-    pretty_name: 'CKV_AWS_48: Ensure MQ Broker logging is enabled'
+    pretty_name: 'Ensure MQ Broker logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_49:
     categories:
@@ -5094,7 +5094,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_49
-    pretty_name: 'CKV_AWS_49: Ensure no IAM policies documents allow "*" as a statement''s
+    pretty_name: 'Ensure no IAM policies documents allow "*" as a statement''s
       actions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_5:
@@ -5106,7 +5106,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_5
-    pretty_name: 'CKV_AWS_5: Ensure all data stored in the Elasticsearch is securely
+    pretty_name: 'Ensure all data stored in the Elasticsearch is securely
       encrypted at rest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_50:
@@ -5117,7 +5117,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_50
-    pretty_name: 'CKV_AWS_50: X-ray tracing is enabled for Lambda'
+    pretty_name: 'X-ray tracing is enabled for Lambda'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_51:
     categories:
@@ -5128,7 +5128,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_51
-    pretty_name: 'CKV_AWS_51: Ensure ECR Image Tags are immutable'
+    pretty_name: 'Ensure ECR Image Tags are immutable'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_53:
     categories:
@@ -5139,7 +5139,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_53
-    pretty_name: 'CKV_AWS_53: Ensure S3 bucket has block public ACLS enabled'
+    pretty_name: 'Ensure S3 bucket has block public ACLS enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_54:
     categories:
@@ -5150,7 +5150,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_54
-    pretty_name: 'CKV_AWS_54: Ensure S3 bucket has block public policy enabled'
+    pretty_name: 'Ensure S3 bucket has block public policy enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_55:
     categories:
@@ -5161,7 +5161,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_55
-    pretty_name: 'CKV_AWS_55: Ensure S3 bucket has ignore public ACLs enabled'
+    pretty_name: 'Ensure S3 bucket has ignore public ACLs enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_56:
     categories:
@@ -5172,7 +5172,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_56
-    pretty_name: 'CKV_AWS_56: Ensure S3 bucket has ''restrict_public_bucket'' enabled'
+    pretty_name: 'Ensure S3 bucket has ''restrict_public_bucket'' enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_57:
     categories:
@@ -5183,7 +5183,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_57
-    pretty_name: 'CKV_AWS_57: S3 Bucket has an ACL defined which allows public WRITE
+    pretty_name: 'S3 Bucket has an ACL defined which allows public WRITE
       access.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_58:
@@ -5195,7 +5195,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_58
-    pretty_name: 'CKV_AWS_58: Ensure EKS Cluster has Secrets Encryption Enabled'
+    pretty_name: 'Ensure EKS Cluster has Secrets Encryption Enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_59:
     categories:
@@ -5206,7 +5206,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_59
-    pretty_name: 'CKV_AWS_59: Ensure there is no open access to back-end resources
+    pretty_name: 'Ensure there is no open access to back-end resources
       through API'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_6:
@@ -5218,7 +5218,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_6
-    pretty_name: 'CKV_AWS_6: Ensure all Elasticsearch has node-to-node encryption
+    pretty_name: 'Ensure all Elasticsearch has node-to-node encryption
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_60:
@@ -5230,7 +5230,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_60
-    pretty_name: 'CKV_AWS_60: Ensure IAM role allows only specific services or principals
+    pretty_name: 'Ensure IAM role allows only specific services or principals
       to assume it'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_61:
@@ -5242,7 +5242,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_61
-    pretty_name: 'CKV_AWS_61: Ensure AWS IAM policy does not allow assume role permission
+    pretty_name: 'Ensure AWS IAM policy does not allow assume role permission
       across all services'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_62:
@@ -5254,7 +5254,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_62
-    pretty_name: 'CKV_AWS_62: Ensure IAM policies that allow full "*-*" administrative
+    pretty_name: 'Ensure IAM policies that allow full "*-*" administrative
       privileges are not created'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_63:
@@ -5266,7 +5266,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_63
-    pretty_name: 'CKV_AWS_63: Ensure no IAM policies documents allow "*" as a statement''s
+    pretty_name: 'Ensure no IAM policies documents allow "*" as a statement''s
       actions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_64:
@@ -5278,7 +5278,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_64
-    pretty_name: 'CKV_AWS_64: Ensure all data stored in the Redshift cluster is securely
+    pretty_name: 'Ensure all data stored in the Redshift cluster is securely
       encrypted at rest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_65:
@@ -5289,7 +5289,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_65
-    pretty_name: 'CKV_AWS_65: Ensure container insights are enabled on ECS cluster'
+    pretty_name: 'Ensure container insights are enabled on ECS cluster'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_66:
     categories:
@@ -5300,7 +5300,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_66
-    pretty_name: 'CKV_AWS_66: Ensure that CloudWatch Log Group specifies retention
+    pretty_name: 'Ensure that CloudWatch Log Group specifies retention
       days'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_67:
@@ -5312,7 +5312,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_67
-    pretty_name: 'CKV_AWS_67: Ensure CloudTrail is enabled in all Regions'
+    pretty_name: 'Ensure CloudTrail is enabled in all Regions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_68:
     categories:
@@ -5321,7 +5321,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_68
-    pretty_name: 'CKV_AWS_68: CloudFront Distribution should have WAF enabled'
+    pretty_name: 'CloudFront Distribution should have WAF enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_69:
     categories:
@@ -5332,7 +5332,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_69
-    pretty_name: 'CKV_AWS_69: Ensure MQ Broker is not publicly exposed'
+    pretty_name: 'Ensure MQ Broker is not publicly exposed'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_7:
     categories:
@@ -5343,7 +5343,7 @@ rules:
     description: Check that ensures best practices in AWS secrets management.
     group: cloud-weak-secrets-management
     name: CKV_AWS_7
-    pretty_name: 'CKV_AWS_7: Ensure rotation for customer created CMKs is enabled'
+    pretty_name: 'Ensure rotation for customer created CMKs is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_70:
     categories:
@@ -5354,7 +5354,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_70
-    pretty_name: 'CKV_AWS_70: Ensure S3 bucket does not allow an action with any Principal'
+    pretty_name: 'Ensure S3 bucket does not allow an action with any Principal'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_71:
     categories:
@@ -5364,7 +5364,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_71
-    pretty_name: 'CKV_AWS_71: Ensure Redshift Cluster logging is enabled'
+    pretty_name: 'Ensure Redshift Cluster logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_72:
     categories:
@@ -5375,7 +5375,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_72
-    pretty_name: 'CKV_AWS_72: Ensure SQS policy does not allow ALL (*) actions.'
+    pretty_name: 'Ensure SQS policy does not allow ALL (*) actions.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_73:
     categories:
@@ -5385,7 +5385,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_73
-    pretty_name: 'CKV_AWS_73: Ensure API Gateway has X-Ray Tracing enabled'
+    pretty_name: 'Ensure API Gateway has X-Ray Tracing enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_74:
     categories:
@@ -5396,7 +5396,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_74
-    pretty_name: 'CKV_AWS_74: Ensure DocDB is encrypted at rest (default is unencrypted)'
+    pretty_name: 'Ensure DocDB is encrypted at rest (default is unencrypted)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_75:
     categories:
@@ -5405,7 +5405,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_75
-    pretty_name: 'CKV_AWS_75: Ensure Global Accelerator accelerator has flow logs
+    pretty_name: 'Ensure Global Accelerator accelerator has flow logs
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_76:
@@ -5417,7 +5417,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_76
-    pretty_name: 'CKV_AWS_76: Ensure API Gateway has Access Logging enabled'
+    pretty_name: 'Ensure API Gateway has Access Logging enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_77:
     categories:
@@ -5428,7 +5428,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_77
-    pretty_name: 'CKV_AWS_77: Ensure Athena Database is encrypted at rest (default
+    pretty_name: 'Ensure Athena Database is encrypted at rest (default
       is unencrypted)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_78:
@@ -5440,7 +5440,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_78
-    pretty_name: 'CKV_AWS_78: Ensure that CodeBuild Project encryption is not disabled'
+    pretty_name: 'Ensure that CodeBuild Project encryption is not disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_79:
     categories:
@@ -5451,7 +5451,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_79
-    pretty_name: 'CKV_AWS_79: Ensure Instance Metadata Service Version 1 is not enabled'
+    pretty_name: 'Ensure Instance Metadata Service Version 1 is not enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_8:
     categories:
@@ -5462,7 +5462,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_8
-    pretty_name: 'CKV_AWS_8: Ensure all data stored in the Launch configuration or
+    pretty_name: 'Ensure all data stored in the Launch configuration or
       instance Elastic Blocks Store is securely encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_80:
@@ -5474,7 +5474,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_80
-    pretty_name: 'CKV_AWS_80: Ensure MSK Cluster logging is enabled'
+    pretty_name: 'Ensure MSK Cluster logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_81:
     categories:
@@ -5485,7 +5485,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_81
-    pretty_name: 'CKV_AWS_81: Ensure MSK Cluster encryption in rest and transit is
+    pretty_name: 'Ensure MSK Cluster encryption in rest and transit is
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_82:
@@ -5497,7 +5497,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_82
-    pretty_name: 'CKV_AWS_82: Ensure Athena Workgroup should enforce configuration
+    pretty_name: 'Ensure Athena Workgroup should enforce configuration
       to prevent client disabling encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_83:
@@ -5509,7 +5509,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_83
-    pretty_name: 'CKV_AWS_83: Ensure Elasticsearch Domain enforces HTTPS'
+    pretty_name: 'Ensure Elasticsearch Domain enforces HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_84:
     categories:
@@ -5519,7 +5519,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_84
-    pretty_name: 'CKV_AWS_84: Ensure Elasticsearch Domain Logging is enabled'
+    pretty_name: 'Ensure Elasticsearch Domain Logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_85:
     categories:
@@ -5529,7 +5529,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_85
-    pretty_name: 'CKV_AWS_85: Ensure DocDB Logging is enabled'
+    pretty_name: 'Ensure DocDB Logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_86:
     categories:
@@ -5540,7 +5540,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_86
-    pretty_name: 'CKV_AWS_86: Ensure Cloudfront distribution has Access Logging enabled'
+    pretty_name: 'Ensure Cloudfront distribution has Access Logging enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_87:
     categories:
@@ -5551,7 +5551,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_87
-    pretty_name: 'CKV_AWS_87: Redshift cluster should not be publicly accessible'
+    pretty_name: 'Redshift cluster should not be publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_88:
     categories:
@@ -5562,7 +5562,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_88
-    pretty_name: 'CKV_AWS_88: EC2 instance should not have public IP.'
+    pretty_name: 'EC2 instance should not have public IP.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_89:
     categories:
@@ -5573,7 +5573,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_89
-    pretty_name: 'CKV_AWS_89: DMS replication instance should not be publicly accessible'
+    pretty_name: 'DMS replication instance should not be publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_9:
     categories:
@@ -5582,7 +5582,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_9
-    pretty_name: 'CKV_AWS_9: Ensure IAM password policy expires passwords within 90
+    pretty_name: 'Ensure IAM password policy expires passwords within 90
       days or less'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_90:
@@ -5594,7 +5594,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_90
-    pretty_name: 'CKV_AWS_90: Ensure DocDB TLS is not disabled'
+    pretty_name: 'Ensure DocDB TLS is not disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_91:
     categories:
@@ -5605,7 +5605,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_91
-    pretty_name: 'CKV_AWS_91: Ensure the ELBv2 (Application/Network) has access logging
+    pretty_name: 'Ensure the ELBv2 (Application/Network) has access logging
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_92:
@@ -5617,7 +5617,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_92
-    pretty_name: 'CKV_AWS_92: Ensure the ELB has access logging enabled'
+    pretty_name: 'Ensure the ELB has access logging enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_93:
     categories:
@@ -5628,7 +5628,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_93
-    pretty_name: 'CKV_AWS_93: Ensure S3 bucket policy does not lockout all but root
+    pretty_name: 'Ensure S3 bucket policy does not lockout all but root
       user. (Prevent lockouts needing root account fixes)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_94:
@@ -5640,7 +5640,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_94
-    pretty_name: 'CKV_AWS_94: Ensure Glue Data Catalog Encryption is enabled'
+    pretty_name: 'Ensure Glue Data Catalog Encryption is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_95:
     categories:
@@ -5651,7 +5651,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_95
-    pretty_name: 'CKV_AWS_95: Ensure API Gateway V2 has Access Logging enabled'
+    pretty_name: 'Ensure API Gateway V2 has Access Logging enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_96:
     categories:
@@ -5662,7 +5662,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_96
-    pretty_name: 'CKV_AWS_96: Ensure all data stored in Aurora is securely encrypted
+    pretty_name: 'Ensure all data stored in Aurora is securely encrypted
       at rest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_97:
@@ -5674,7 +5674,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_97
-    pretty_name: 'CKV_AWS_97: Ensure Encryption in transit is enabled for EFS volumes
+    pretty_name: 'Ensure Encryption in transit is enabled for EFS volumes
       in ECS Task definitions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_98:
@@ -5686,7 +5686,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_98
-    pretty_name: 'CKV_AWS_98: Ensure all data stored in the Sagemaker Endpoint is
+    pretty_name: 'Ensure all data stored in the Sagemaker Endpoint is
       securely encrypted at rest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_99:
@@ -5698,7 +5698,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_99
-    pretty_name: 'CKV_AWS_99: Ensure Glue Security Configuration Encryption is enabled'
+    pretty_name: 'Ensure Glue Security Configuration Encryption is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZUREPIPELINES_1:
     categories:
@@ -5709,7 +5709,7 @@ rules:
     description: Check for weak Azure Pipelines configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_AZUREPIPELINES_1
-    pretty_name: 'CKV_AZUREPIPELINES_1: Ensure container job uses a non latest version
+    pretty_name: 'Ensure container job uses a non latest version
       tag'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZUREPIPELINES_2:
@@ -5720,7 +5720,7 @@ rules:
     description: Check for weak Azure Pipelines configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_AZUREPIPELINES_2
-    pretty_name: 'CKV_AZUREPIPELINES_2: Ensure container job uses a version digest'
+    pretty_name: 'Ensure container job uses a version digest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZUREPIPELINES_3:
     categories:
@@ -5731,7 +5731,7 @@ rules:
     description: Check for weak Azure Pipelines configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_AZUREPIPELINES_3
-    pretty_name: 'CKV_AZUREPIPELINES_3: Ensure set variable is not marked as a secret'
+    pretty_name: 'Ensure set variable is not marked as a secret'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_1:
     categories:
@@ -5742,7 +5742,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_1
-    pretty_name: 'CKV_AZURE_1: Ensure Azure Instance does not use basic authentication(Use
+    pretty_name: 'Ensure Azure Instance does not use basic authentication(Use
       SSH Key Instead)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_10:
@@ -5754,7 +5754,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_10
-    pretty_name: 'CKV_AZURE_10: Ensure that SSH access is restricted from the internet'
+    pretty_name: 'Ensure that SSH access is restricted from the internet'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_100:
     categories:
@@ -5763,7 +5763,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_100
-    pretty_name: 'CKV_AZURE_100: Ensure that Cosmos DB accounts have customer-managed
+    pretty_name: 'Ensure that Cosmos DB accounts have customer-managed
       keys to encrypt data at rest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_101:
@@ -5775,7 +5775,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_101
-    pretty_name: 'CKV_AZURE_101: Ensure that Azure Cosmos DB disables public network
+    pretty_name: 'Ensure that Azure Cosmos DB disables public network
       access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_102:
@@ -5786,7 +5786,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_102
-    pretty_name: 'CKV_AZURE_102: Ensure that PostgreSQL server enables geo-redundant
+    pretty_name: 'Ensure that PostgreSQL server enables geo-redundant
       backups'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_103:
@@ -5797,7 +5797,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_103
-    pretty_name: 'CKV_AZURE_103: Ensure that Azure Data Factory uses Git repository
+    pretty_name: 'Ensure that Azure Data Factory uses Git repository
       for source control'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_104:
@@ -5809,7 +5809,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_104
-    pretty_name: 'CKV_AZURE_104: Ensure that Azure Data factory public network access
+    pretty_name: 'Ensure that Azure Data factory public network access
       is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_105:
@@ -5821,7 +5821,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_105
-    pretty_name: 'CKV_AZURE_105: Ensure that Data Lake Store accounts enables encryption'
+    pretty_name: 'Ensure that Data Lake Store accounts enables encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_106:
     categories:
@@ -5832,7 +5832,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_106
-    pretty_name: 'CKV_AZURE_106: Ensure that Azure Event Grid Domain public network
+    pretty_name: 'Ensure that Azure Event Grid Domain public network
       access is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_107:
@@ -5843,7 +5843,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_107
-    pretty_name: 'CKV_AZURE_107: Ensure that API management services use virtual networks'
+    pretty_name: 'Ensure that API management services use virtual networks'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_108:
     categories:
@@ -5852,7 +5852,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_108
-    pretty_name: 'CKV_AZURE_108: Ensure that Azure IoT Hub disables public network
+    pretty_name: 'Ensure that Azure IoT Hub disables public network
       access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_109:
@@ -5864,7 +5864,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_109
-    pretty_name: 'CKV_AZURE_109: Ensure that key vault allows firewall rules settings'
+    pretty_name: 'Ensure that key vault allows firewall rules settings'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_11:
     categories:
@@ -5875,7 +5875,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_11
-    pretty_name: 'CKV_AZURE_11: Ensure no SQL Databases allow ingress from 0.0.0.0/0
+    pretty_name: 'Ensure no SQL Databases allow ingress from 0.0.0.0/0
       (ANY IP)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_110:
@@ -5887,7 +5887,7 @@ rules:
     description: Check that ensures best practices in Azure secrets management.
     group: cloud-weak-secrets-management
     name: CKV_AZURE_110
-    pretty_name: 'CKV_AZURE_110: Ensure that key vault enables purge protection'
+    pretty_name: 'Ensure that key vault enables purge protection'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_111:
     categories:
@@ -5898,7 +5898,7 @@ rules:
     description: Check that ensures best practices in Azure secrets management.
     group: cloud-weak-secrets-management
     name: CKV_AZURE_111
-    pretty_name: 'CKV_AZURE_111: Ensure that key vault enables soft delete'
+    pretty_name: 'Ensure that key vault enables soft delete'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_112:
     categories:
@@ -5908,7 +5908,7 @@ rules:
     description: Check that ensures best practices in Azure secrets management.
     group: cloud-weak-secrets-management
     name: CKV_AZURE_112
-    pretty_name: 'CKV_AZURE_112: Ensure that key vault key is backed by HSM'
+    pretty_name: 'Ensure that key vault key is backed by HSM'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_113:
     categories:
@@ -5919,7 +5919,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_113
-    pretty_name: 'CKV_AZURE_113: Ensure that SQL server disables public network access'
+    pretty_name: 'Ensure that SQL server disables public network access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_114:
     categories:
@@ -5929,7 +5929,7 @@ rules:
     description: Check that ensures best practices in Azure secrets management.
     group: cloud-weak-secrets-management
     name: CKV_AZURE_114
-    pretty_name: 'CKV_AZURE_114: Ensure that key vault secrets have "content_type"
+    pretty_name: 'Ensure that key vault secrets have "content_type"
       set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_115:
@@ -5941,7 +5941,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_115
-    pretty_name: 'CKV_AZURE_115: Ensure that AKS enables private clusters'
+    pretty_name: 'Ensure that AKS enables private clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_116:
     categories:
@@ -5952,7 +5952,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_116
-    pretty_name: 'CKV_AZURE_116: Ensure that AKS uses Azure Policies Add-on'
+    pretty_name: 'Ensure that AKS uses Azure Policies Add-on'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_117:
     categories:
@@ -5963,7 +5963,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_117
-    pretty_name: 'CKV_AZURE_117: Ensure that AKS uses disk encryption set'
+    pretty_name: 'Ensure that AKS uses disk encryption set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_118:
     categories:
@@ -5974,7 +5974,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_118
-    pretty_name: 'CKV_AZURE_118: Ensure that Network Interfaces disable IP forwarding'
+    pretty_name: 'Ensure that Network Interfaces disable IP forwarding'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_119:
     categories:
@@ -5985,7 +5985,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_119
-    pretty_name: 'CKV_AZURE_119: Ensure that Network Interfaces don''t use public
+    pretty_name: 'Ensure that Network Interfaces don''t use public
       IPs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_12:
@@ -5995,7 +5995,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_12
-    pretty_name: 'CKV_AZURE_12: Ensure that Network Security Group Flow Log retention
+    pretty_name: 'Ensure that Network Security Group Flow Log retention
       period is ''greater than 90 days'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_120:
@@ -6005,7 +6005,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_120
-    pretty_name: 'CKV_AZURE_120: Ensure that Application Gateway enables WAF'
+    pretty_name: 'Ensure that Application Gateway enables WAF'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_121:
     categories:
@@ -6014,7 +6014,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_121
-    pretty_name: 'CKV_AZURE_121: Ensure that Azure Front Door enables WAF'
+    pretty_name: 'Ensure that Azure Front Door enables WAF'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_122:
     categories:
@@ -6023,7 +6023,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_122
-    pretty_name: 'CKV_AZURE_122: Ensure that Application Gateway uses WAF in "Detection"
+    pretty_name: 'Ensure that Application Gateway uses WAF in "Detection"
       or "Prevention" modes'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_123:
@@ -6033,7 +6033,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_123
-    pretty_name: 'CKV_AZURE_123: Ensure that Azure Front Door uses WAF in "Detection"
+    pretty_name: 'Ensure that Azure Front Door uses WAF in "Detection"
       or "Prevention" modes'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_124:
@@ -6045,7 +6045,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_124
-    pretty_name: 'CKV_AZURE_124: Ensure that Azure Cognitive Search disables public
+    pretty_name: 'Ensure that Azure Cognitive Search disables public
       network access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_125:
@@ -6057,7 +6057,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_125
-    pretty_name: 'CKV_AZURE_125: Ensures that Service Fabric use three levels of protection
+    pretty_name: 'Ensures that Service Fabric use three levels of protection
       available'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_126:
@@ -6069,7 +6069,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_126
-    pretty_name: 'CKV_AZURE_126: Ensures that Active Directory is used for authentication
+    pretty_name: 'Ensures that Active Directory is used for authentication
       for Service Fabric'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_127:
@@ -6079,7 +6079,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_127
-    pretty_name: 'CKV_AZURE_127: Ensure that My SQL server enables Threat detection
+    pretty_name: 'Ensure that My SQL server enables Threat detection
       policy'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_128:
@@ -6089,7 +6089,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_128
-    pretty_name: 'CKV_AZURE_128: Ensure that PostgreSQL server enables Threat detection
+    pretty_name: 'Ensure that PostgreSQL server enables Threat detection
       policy'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_129:
@@ -6100,7 +6100,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_129
-    pretty_name: 'CKV_AZURE_129: Ensure that MariaDB server enables geo-redundant
+    pretty_name: 'Ensure that MariaDB server enables geo-redundant
       backups'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_13:
@@ -6112,7 +6112,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_13
-    pretty_name: 'CKV_AZURE_13: Ensure App Service Authentication is set on Azure
+    pretty_name: 'Ensure App Service Authentication is set on Azure
       App Service'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_130:
@@ -6124,7 +6124,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_130
-    pretty_name: 'CKV_AZURE_130: Ensure that PostgreSQL server enables infrastructure
+    pretty_name: 'Ensure that PostgreSQL server enables infrastructure
       encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_131:
@@ -6136,7 +6136,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_AZURE_131
-    pretty_name: 'CKV_AZURE_131: SecureString parameter should not have hardcoded
+    pretty_name: 'SecureString parameter should not have hardcoded
       default values'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_132:
@@ -6148,7 +6148,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_132
-    pretty_name: 'CKV_AZURE_132: Ensure cosmosdb does not allow privileged escalation
+    pretty_name: 'Ensure cosmosdb does not allow privileged escalation
       by restricting management plane changes'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_133:
@@ -6158,7 +6158,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_133
-    pretty_name: 'CKV_AZURE_133: Ensure Front Door WAF prevents message lookup in
+    pretty_name: 'Ensure Front Door WAF prevents message lookup in
       Log4j2. See CVE-2021-44228 aka log4jshell'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_134:
@@ -6170,7 +6170,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_134
-    pretty_name: 'CKV_AZURE_134: Ensure that Cognitive Services accounts disable public
+    pretty_name: 'Ensure that Cognitive Services accounts disable public
       network access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_135:
@@ -6180,7 +6180,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_135
-    pretty_name: 'CKV_AZURE_135: Ensure Application Gateway WAF prevents message lookup
+    pretty_name: 'Ensure Application Gateway WAF prevents message lookup
       in Log4j2. See CVE-2021-44228 aka log4jshell'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_136:
@@ -6191,7 +6191,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_136
-    pretty_name: 'CKV_AZURE_136: Ensure that PostgreSQL Flexible server enables geo-redundant
+    pretty_name: 'Ensure that PostgreSQL Flexible server enables geo-redundant
       backups'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_137:
@@ -6203,7 +6203,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_137
-    pretty_name: 'CKV_AZURE_137: Ensure ACR admin account is disabled'
+    pretty_name: 'Ensure ACR admin account is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_138:
     categories:
@@ -6213,7 +6213,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_138
-    pretty_name: 'CKV_AZURE_138: Ensures that ACR disables anonymous pulling of images'
+    pretty_name: 'Ensures that ACR disables anonymous pulling of images'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_139:
     categories:
@@ -6224,7 +6224,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_139
-    pretty_name: 'CKV_AZURE_139: Ensure ACR set to disable public networking'
+    pretty_name: 'Ensure ACR set to disable public networking'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_14:
     categories:
@@ -6235,7 +6235,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_14
-    pretty_name: 'CKV_AZURE_14: Ensure web app redirects all HTTP traffic to HTTPS
+    pretty_name: 'Ensure web app redirects all HTTP traffic to HTTPS
       in Azure App Service'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_140:
@@ -6247,7 +6247,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_140
-    pretty_name: 'CKV_AZURE_140: Ensure that Local Authentication is disabled on CosmosDB'
+    pretty_name: 'Ensure that Local Authentication is disabled on CosmosDB'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_141:
     categories:
@@ -6258,7 +6258,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_141
-    pretty_name: 'CKV_AZURE_141: Ensure AKS local admin account is disabled'
+    pretty_name: 'Ensure AKS local admin account is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_142:
     categories:
@@ -6269,7 +6269,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_142
-    pretty_name: 'CKV_AZURE_142: Ensure Machine Learning Compute Cluster Local Authentication
+    pretty_name: 'Ensure Machine Learning Compute Cluster Local Authentication
       is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_143:
@@ -6281,7 +6281,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_143
-    pretty_name: 'CKV_AZURE_143: Ensure AKS cluster nodes do not have public IP addresses'
+    pretty_name: 'Ensure AKS cluster nodes do not have public IP addresses'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_144:
     categories:
@@ -6292,7 +6292,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_144
-    pretty_name: 'CKV_AZURE_144: Ensure that Public Access is disabled for Machine
+    pretty_name: 'Ensure that Public Access is disabled for Machine
       Learning Workspace'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_145:
@@ -6304,7 +6304,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_145
-    pretty_name: 'CKV_AZURE_145: Ensure Function app is using the latest version of
+    pretty_name: 'Ensure Function app is using the latest version of
       TLS encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_146:
@@ -6315,7 +6315,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_146
-    pretty_name: 'CKV_AZURE_146: Ensure server parameter ''log_retention'' is set
+    pretty_name: 'Ensure server parameter ''log_retention'' is set
       to ''ON'' for PostgreSQL Database Server'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_147:
@@ -6327,7 +6327,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_147
-    pretty_name: 'CKV_AZURE_147: Ensure PostgreSQL is using the latest version of
+    pretty_name: 'Ensure PostgreSQL is using the latest version of
       TLS encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_148:
@@ -6339,7 +6339,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_148
-    pretty_name: 'CKV_AZURE_148: Ensure Redis Cache is using the latest version of
+    pretty_name: 'Ensure Redis Cache is using the latest version of
       TLS encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_149:
@@ -6351,7 +6351,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_149
-    pretty_name: 'CKV_AZURE_149: Ensure that Virtual machine does not enable password
+    pretty_name: 'Ensure that Virtual machine does not enable password
       authentication'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_15:
@@ -6363,7 +6363,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_15
-    pretty_name: 'CKV_AZURE_15: Ensure web app is using the latest version of TLS
+    pretty_name: 'Ensure web app is using the latest version of TLS
       encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_150:
@@ -6375,7 +6375,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_150
-    pretty_name: 'CKV_AZURE_150: Ensure Machine Learning Compute Cluster Minimum Nodes
+    pretty_name: 'Ensure Machine Learning Compute Cluster Minimum Nodes
       Set To 0'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_151:
@@ -6387,7 +6387,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_151
-    pretty_name: 'CKV_AZURE_151: Ensure Windows VM enables encryption'
+    pretty_name: 'Ensure Windows VM enables encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_152:
     categories:
@@ -6397,7 +6397,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_152
-    pretty_name: 'CKV_AZURE_152: Ensure Client Certificates are enforced for API management'
+    pretty_name: 'Ensure Client Certificates are enforced for API management'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_153:
     categories:
@@ -6408,7 +6408,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_153
-    pretty_name: 'CKV_AZURE_153: Ensure web app redirects all HTTP traffic to HTTPS
+    pretty_name: 'Ensure web app redirects all HTTP traffic to HTTPS
       in Azure App Service Slot'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_154:
@@ -6420,7 +6420,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_154
-    pretty_name: 'CKV_AZURE_154: Ensure the App service slot is using the latest version
+    pretty_name: 'Ensure the App service slot is using the latest version
       of TLS encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_155:
@@ -6432,7 +6432,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_155
-    pretty_name: 'CKV_AZURE_155: Ensure debugging is disabled for the App service
+    pretty_name: 'Ensure debugging is disabled for the App service
       slot'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_156:
@@ -6444,7 +6444,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_156
-    pretty_name: 'CKV_AZURE_156: Ensure default Auditing policy for a SQL Server is
+    pretty_name: 'Ensure default Auditing policy for a SQL Server is
       configured to capture and retain the activity logs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_157:
@@ -6455,7 +6455,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_157
-    pretty_name: 'CKV_AZURE_157: Ensure that Synapse workspace has data_exfiltration_protection_enabled'
+    pretty_name: 'Ensure that Synapse workspace has data_exfiltration_protection_enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_158:
     categories:
@@ -6466,7 +6466,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_158
-    pretty_name: 'CKV_AZURE_158: Ensure that databricks workspace has not public'
+    pretty_name: 'Ensure that databricks workspace has not public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_159:
     categories:
@@ -6477,7 +6477,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_159
-    pretty_name: 'CKV_AZURE_159: Ensure function app builtin logging is enabled'
+    pretty_name: 'Ensure function app builtin logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_16:
     categories:
@@ -6488,7 +6488,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_16
-    pretty_name: 'CKV_AZURE_16: Ensure that Register with Azure Active Directory is
+    pretty_name: 'Ensure that Register with Azure Active Directory is
       enabled on App Service'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_160:
@@ -6500,7 +6500,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_160
-    pretty_name: 'CKV_AZURE_160: Ensure that HTTP (port 80) access is restricted from
+    pretty_name: 'Ensure that HTTP (port 80) access is restricted from
       the internet'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_161:
@@ -6512,7 +6512,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_161
-    pretty_name: 'CKV_AZURE_161: Ensures Spring Cloud API Portal is enabled on for
+    pretty_name: 'Ensures Spring Cloud API Portal is enabled on for
       HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_162:
@@ -6524,7 +6524,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_162
-    pretty_name: 'CKV_AZURE_162: Ensures Spring Cloud API Portal Public Access Is
+    pretty_name: 'Ensures Spring Cloud API Portal Public Access Is
       Disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_163:
@@ -6536,7 +6536,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_163
-    pretty_name: 'CKV_AZURE_163: Enable vulnerability scanning for container images.'
+    pretty_name: 'Enable vulnerability scanning for container images.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_164:
     categories:
@@ -6547,7 +6547,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_164
-    pretty_name: 'CKV_AZURE_164: Ensures that ACR uses signed/trusted images'
+    pretty_name: 'Ensures that ACR uses signed/trusted images'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_165:
     categories:
@@ -6558,7 +6558,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_165
-    pretty_name: 'CKV_AZURE_165: Ensure geo-replicated container registries to match
+    pretty_name: 'Ensure geo-replicated container registries to match
       multi-region container deployments.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_166:
@@ -6570,7 +6570,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_166
-    pretty_name: 'CKV_AZURE_166: Ensure container image quarantine, scan, and mark
+    pretty_name: 'Ensure container image quarantine, scan, and mark
       images verified'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_167:
@@ -6582,7 +6582,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_167
-    pretty_name: 'CKV_AZURE_167: Ensure a retention policy is set to cleanup untagged
+    pretty_name: 'Ensure a retention policy is set to cleanup untagged
       manifests.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_168:
@@ -6594,7 +6594,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_168
-    pretty_name: 'CKV_AZURE_168: Ensure Azure Kubernetes Cluster (AKS) nodes should
+    pretty_name: 'Ensure Azure Kubernetes Cluster (AKS) nodes should
       use a minimum number of 50 pods.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_169:
@@ -6606,7 +6606,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_169
-    pretty_name: 'CKV_AZURE_169: Ensure Azure Kubernetes Cluster (AKS) nodes use scale
+    pretty_name: 'Ensure Azure Kubernetes Cluster (AKS) nodes use scale
       sets'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_17:
@@ -6617,7 +6617,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_17
-    pretty_name: 'CKV_AZURE_17: Ensure the web app has ''Client Certificates (Incoming
+    pretty_name: 'Ensure the web app has ''Client Certificates (Incoming
       client certificates)'' set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_170:
@@ -6629,7 +6629,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_170
-    pretty_name: 'CKV_AZURE_170: Ensure that AKS use the Paid Sku for its SLA'
+    pretty_name: 'Ensure that AKS use the Paid Sku for its SLA'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_171:
     categories:
@@ -6640,7 +6640,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_171
-    pretty_name: 'CKV_AZURE_171: Ensure AKS cluster upgrade channel is chosen'
+    pretty_name: 'Ensure AKS cluster upgrade channel is chosen'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_172:
     categories:
@@ -6651,7 +6651,7 @@ rules:
     description: Check that ensures best practices in Azure secrets management.
     group: cloud-weak-secrets-management
     name: CKV_AZURE_172
-    pretty_name: 'CKV_AZURE_172: Ensure autorotation of Secrets Store CSI Driver secrets
+    pretty_name: 'Ensure autorotation of Secrets Store CSI Driver secrets
       for AKS clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_173:
@@ -6663,7 +6663,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_173
-    pretty_name: 'CKV_AZURE_173: Ensure API management uses at least TLS 1.2'
+    pretty_name: 'Ensure API management uses at least TLS 1.2'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_174:
     categories:
@@ -6674,7 +6674,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_174
-    pretty_name: 'CKV_AZURE_174: Ensure API management public access is disabled'
+    pretty_name: 'Ensure API management public access is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_175:
     categories:
@@ -6685,7 +6685,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_175
-    pretty_name: 'CKV_AZURE_175: Ensure Web PubSub uses a SKU with an SLA'
+    pretty_name: 'Ensure Web PubSub uses a SKU with an SLA'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_176:
     categories:
@@ -6696,7 +6696,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_176
-    pretty_name: 'CKV_AZURE_176: Ensure Web PubSub uses managed identities to access
+    pretty_name: 'Ensure Web PubSub uses managed identities to access
       Azure resources'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_177:
@@ -6708,7 +6708,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_177
-    pretty_name: 'CKV_AZURE_177: Ensure Windows VM enables automatic updates'
+    pretty_name: 'Ensure Windows VM enables automatic updates'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_178:
     categories:
@@ -6719,7 +6719,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_178
-    pretty_name: 'CKV_AZURE_178: Ensure linux VM enables SSH with keys for secure
+    pretty_name: 'Ensure linux VM enables SSH with keys for secure
       communication'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_179:
@@ -6731,7 +6731,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_179
-    pretty_name: 'CKV_AZURE_179: Ensure VM agent is installed'
+    pretty_name: 'Ensure VM agent is installed'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_18:
     categories:
@@ -6742,7 +6742,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_18
-    pretty_name: 'CKV_AZURE_18: Ensure that ''HTTP Version'' is the latest if used
+    pretty_name: 'Ensure that ''HTTP Version'' is the latest if used
       to run the web app'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_180:
@@ -6754,7 +6754,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_180
-    pretty_name: 'CKV_AZURE_180: Ensure that data explorer uses Sku with an SLA'
+    pretty_name: 'Ensure that data explorer uses Sku with an SLA'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_181:
     categories:
@@ -6765,7 +6765,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_181
-    pretty_name: 'CKV_AZURE_181: Ensure that data explorer/Kusto uses managed identities
+    pretty_name: 'Ensure that data explorer/Kusto uses managed identities
       to access Azure resources securely.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_182:
@@ -6777,7 +6777,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_182
-    pretty_name: 'CKV_AZURE_182: Ensure that VNET has at least 2 connected DNS Endpoints'
+    pretty_name: 'Ensure that VNET has at least 2 connected DNS Endpoints'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_183:
     categories:
@@ -6788,7 +6788,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_183
-    pretty_name: 'CKV_AZURE_183: Ensure that VNET uses local DNS addresses'
+    pretty_name: 'Ensure that VNET uses local DNS addresses'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_184:
     categories:
@@ -6799,7 +6799,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_184
-    pretty_name: 'CKV_AZURE_184: Ensure ''local_auth_enabled'' is set to ''False'''
+    pretty_name: 'Ensure ''local_auth_enabled'' is set to ''False'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_185:
     categories:
@@ -6810,7 +6810,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_185
-    pretty_name: 'CKV_AZURE_185: Ensure ''Public Access'' is not Enabled for App configuration'
+    pretty_name: 'Ensure ''Public Access'' is not Enabled for App configuration'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_186:
     categories:
@@ -6821,7 +6821,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_186
-    pretty_name: 'CKV_AZURE_186: Ensure App configuration encryption block is set.'
+    pretty_name: 'Ensure App configuration encryption block is set.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_187:
     categories:
@@ -6832,7 +6832,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_187
-    pretty_name: 'CKV_AZURE_187: Ensure App configuration purge protection is enabled'
+    pretty_name: 'Ensure App configuration purge protection is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_188:
     categories:
@@ -6843,7 +6843,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_188
-    pretty_name: 'CKV_AZURE_188: Ensure App configuration Sku is standard'
+    pretty_name: 'Ensure App configuration Sku is standard'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_189:
     categories:
@@ -6854,7 +6854,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_189
-    pretty_name: 'CKV_AZURE_189: Ensure that Azure Key Vault disables public network
+    pretty_name: 'Ensure that Azure Key Vault disables public network
       access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_19:
@@ -6864,7 +6864,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_19
-    pretty_name: 'CKV_AZURE_19: Ensure that standard pricing tier is selected'
+    pretty_name: 'Ensure that standard pricing tier is selected'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_190:
     categories:
@@ -6875,7 +6875,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_190
-    pretty_name: 'CKV_AZURE_190: Ensure that Storage blobs restrict public access'
+    pretty_name: 'Ensure that Storage blobs restrict public access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_191:
     categories:
@@ -6886,7 +6886,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_191
-    pretty_name: 'CKV_AZURE_191: Ensure that Managed identity provider is enabled
+    pretty_name: 'Ensure that Managed identity provider is enabled
       for Azure Event Grid Topic'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_192:
@@ -6898,7 +6898,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_192
-    pretty_name: 'CKV_AZURE_192: Ensure that Azure Event Grid Topic local Authentication
+    pretty_name: 'Ensure that Azure Event Grid Topic local Authentication
       is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_193:
@@ -6910,7 +6910,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_193
-    pretty_name: 'CKV_AZURE_193: Ensure public network access is disabled for Azure
+    pretty_name: 'Ensure public network access is disabled for Azure
       Event Grid Topic'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_194:
@@ -6922,7 +6922,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_194
-    pretty_name: 'CKV_AZURE_194: Ensure that Managed identity provider is enabled
+    pretty_name: 'Ensure that Managed identity provider is enabled
       for Azure Event Grid Domain'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_195:
@@ -6934,7 +6934,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_195
-    pretty_name: 'CKV_AZURE_195: Ensure that Azure Event Grid Domain local Authentication
+    pretty_name: 'Ensure that Azure Event Grid Domain local Authentication
       is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_196:
@@ -6946,7 +6946,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_196
-    pretty_name: 'CKV_AZURE_196: Ensure that SignalR uses a Paid Sku for its SLA'
+    pretty_name: 'Ensure that SignalR uses a Paid Sku for its SLA'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_197:
     categories:
@@ -6957,7 +6957,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_197
-    pretty_name: 'CKV_AZURE_197: Ensure the Azure CDN disables the HTTP endpoint'
+    pretty_name: 'Ensure the Azure CDN disables the HTTP endpoint'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_198:
     categories:
@@ -6968,7 +6968,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_198
-    pretty_name: 'CKV_AZURE_198: Ensure the Azure CDN enables the HTTPS endpoint'
+    pretty_name: 'Ensure the Azure CDN enables the HTTPS endpoint'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_199:
     categories:
@@ -6979,7 +6979,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_199
-    pretty_name: 'CKV_AZURE_199: Ensure that Azure Service Bus uses double encryption'
+    pretty_name: 'Ensure that Azure Service Bus uses double encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_2:
     categories:
@@ -6990,7 +6990,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_2
-    pretty_name: 'CKV_AZURE_2: Ensure Azure managed disk has encryption enabled'
+    pretty_name: 'Ensure Azure managed disk has encryption enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_20:
     categories:
@@ -7001,7 +7001,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_20
-    pretty_name: 'CKV_AZURE_20: Ensure that security contact ''Phone number'' is set'
+    pretty_name: 'Ensure that security contact ''Phone number'' is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_200:
     categories:
@@ -7012,7 +7012,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_200
-    pretty_name: 'CKV_AZURE_200: Ensure the Azure CDN endpoint is using the latest
+    pretty_name: 'Ensure the Azure CDN endpoint is using the latest
       version of TLS encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_201:
@@ -7024,7 +7024,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_201
-    pretty_name: 'CKV_AZURE_201: Ensure that Azure Service Bus uses a customer-managed
+    pretty_name: 'Ensure that Azure Service Bus uses a customer-managed
       key to encrypt data'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_202:
@@ -7036,7 +7036,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_202
-    pretty_name: 'CKV_AZURE_202: Ensure that Managed identity provider is enabled
+    pretty_name: 'Ensure that Managed identity provider is enabled
       for Azure Service Bus'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_203:
@@ -7048,7 +7048,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_203
-    pretty_name: 'CKV_AZURE_203: Ensure Azure Service Bus Local Authentication is
+    pretty_name: 'Ensure Azure Service Bus Local Authentication is
       disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_204:
@@ -7060,7 +7060,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_204
-    pretty_name: 'CKV_AZURE_204: Ensure ''public network access enabled'' is set to
+    pretty_name: 'Ensure ''public network access enabled'' is set to
       ''False'' for Azure Service Bus'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_205:
@@ -7072,7 +7072,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_205
-    pretty_name: 'CKV_AZURE_205: Ensure Azure Service Bus is using the latest version
+    pretty_name: 'Ensure Azure Service Bus is using the latest version
       of TLS encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_206:
@@ -7084,7 +7084,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_206
-    pretty_name: 'CKV_AZURE_206: Ensure that Storage Accounts use replication'
+    pretty_name: 'Ensure that Storage Accounts use replication'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_207:
     categories:
@@ -7095,7 +7095,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_207
-    pretty_name: 'CKV_AZURE_207: Ensure Azure Cognitive Search service uses managed
+    pretty_name: 'Ensure Azure Cognitive Search service uses managed
       identities to access Azure resources'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_208:
@@ -7107,7 +7107,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_208
-    pretty_name: 'CKV_AZURE_208: Ensure that Azure Cognitive Search maintains SLA
+    pretty_name: 'Ensure that Azure Cognitive Search maintains SLA
       for index updates'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_209:
@@ -7119,7 +7119,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_209
-    pretty_name: 'CKV_AZURE_209: Ensure that Azure Cognitive Search maintains SLA
+    pretty_name: 'Ensure that Azure Cognitive Search maintains SLA
       for search index queries'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_21:
@@ -7131,7 +7131,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_21
-    pretty_name: 'CKV_AZURE_21: Ensure that ''Send email notification for high severity
+    pretty_name: 'Ensure that ''Send email notification for high severity
       alerts'' is set to ''On'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_210:
@@ -7143,7 +7143,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_210
-    pretty_name: 'CKV_AZURE_210: Ensure Azure Cognitive Search service allowed IPS
+    pretty_name: 'Ensure Azure Cognitive Search service allowed IPS
       does not give public Access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_211:
@@ -7155,7 +7155,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_211
-    pretty_name: 'CKV_AZURE_211: Ensure App Service plan suitable for production use'
+    pretty_name: 'Ensure App Service plan suitable for production use'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_212:
     categories:
@@ -7166,7 +7166,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_212
-    pretty_name: 'CKV_AZURE_212: Ensure App Service has a minimum number of instances
+    pretty_name: 'Ensure App Service has a minimum number of instances
       for failover'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_213:
@@ -7178,7 +7178,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_213
-    pretty_name: 'CKV_AZURE_213: Ensure that App Service configures health check'
+    pretty_name: 'Ensure that App Service configures health check'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_214:
     categories:
@@ -7189,7 +7189,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_214
-    pretty_name: 'CKV_AZURE_214: Ensure App Service is set to be always on'
+    pretty_name: 'Ensure App Service is set to be always on'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_22:
     categories:
@@ -7200,7 +7200,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_22
-    pretty_name: 'CKV_AZURE_22: Ensure that ''Send email notification for high severity
+    pretty_name: 'Ensure that ''Send email notification for high severity
       alerts'' is set to ''On'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_23:
@@ -7212,7 +7212,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_23
-    pretty_name: 'CKV_AZURE_23: Ensure that ''Auditing'' is set to ''On'' for SQL
+    pretty_name: 'Ensure that ''Auditing'' is set to ''On'' for SQL
       servers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_24:
@@ -7223,7 +7223,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_24
-    pretty_name: 'CKV_AZURE_24: Ensure that ''Auditing'' Retention is ''greater than
+    pretty_name: 'Ensure that ''Auditing'' Retention is ''greater than
       90 days'' for SQL servers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_25:
@@ -7233,7 +7233,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_25
-    pretty_name: 'CKV_AZURE_25: Ensure that ''Threat Detection types'' is set to ''All'''
+    pretty_name: 'Ensure that ''Threat Detection types'' is set to ''All'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_26:
     categories:
@@ -7244,7 +7244,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_26
-    pretty_name: 'CKV_AZURE_26: Ensure that ''Send Alerts To'' is enabled for MSSQL
+    pretty_name: 'Ensure that ''Send Alerts To'' is enabled for MSSQL
       servers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_27:
@@ -7256,7 +7256,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_27
-    pretty_name: 'CKV_AZURE_27: Ensure that ''Email service and co-administrators''
+    pretty_name: 'Ensure that ''Email service and co-administrators''
       is ''Enabled'' for MSSQL servers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_28:
@@ -7268,7 +7268,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_28
-    pretty_name: 'CKV_AZURE_28: Ensure ''Enforce SSL connection'' is set to ''ENABLED''
+    pretty_name: 'Ensure ''Enforce SSL connection'' is set to ''ENABLED''
       for MySQL Database Server'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_29:
@@ -7279,7 +7279,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_29
-    pretty_name: 'CKV_AZURE_29: Ensure ''Enforce SSL connection'' is set to ''ENABLED''
+    pretty_name: 'Ensure ''Enforce SSL connection'' is set to ''ENABLED''
       for PostgreSQL Database Server'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_3:
@@ -7291,7 +7291,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_3
-    pretty_name: 'CKV_AZURE_3: Ensure that ''Secure transfer required'' is set to
+    pretty_name: 'Ensure that ''Secure transfer required'' is set to
       ''Enabled'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_30:
@@ -7302,7 +7302,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_30
-    pretty_name: 'CKV_AZURE_30: Ensure server parameter ''log_checkpoints'' is set
+    pretty_name: 'Ensure server parameter ''log_checkpoints'' is set
       to ''ON'' for PostgreSQL Database Server'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_31:
@@ -7312,7 +7312,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_31
-    pretty_name: 'CKV_AZURE_31: Ensure configuration ''log_connections'' is set to
+    pretty_name: 'Ensure configuration ''log_connections'' is set to
       ''ON'' for PostgreSQL Database Server'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_32:
@@ -7322,7 +7322,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_32
-    pretty_name: 'CKV_AZURE_32: Ensure server parameter ''connection_throttling''
+    pretty_name: 'Ensure server parameter ''connection_throttling''
       is set to ''ON'' for PostgreSQL Database Server'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_33:
@@ -7333,7 +7333,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_33
-    pretty_name: 'CKV_AZURE_33: Ensure Storage logging is enabled for Queue service
+    pretty_name: 'Ensure Storage logging is enabled for Queue service
       for read, write and delete requests'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_34:
@@ -7345,7 +7345,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_34
-    pretty_name: 'CKV_AZURE_34: Ensure that ''Public access level'' is set to Private
+    pretty_name: 'Ensure that ''Public access level'' is set to Private
       for blob containers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_35:
@@ -7357,7 +7357,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_35
-    pretty_name: 'CKV_AZURE_35: Ensure default network access rule for Storage Accounts
+    pretty_name: 'Ensure default network access rule for Storage Accounts
       is set to deny'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_36:
@@ -7369,7 +7369,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_36
-    pretty_name: 'CKV_AZURE_36: Ensure ''Trusted Microsoft Services'' is enabled for
+    pretty_name: 'Ensure ''Trusted Microsoft Services'' is enabled for
       Storage Account access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_37:
@@ -7380,7 +7380,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_37
-    pretty_name: 'CKV_AZURE_37: Ensure that Activity Log Retention is set 365 days
+    pretty_name: 'Ensure that Activity Log Retention is set 365 days
       or greater'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_38:
@@ -7391,7 +7391,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_38
-    pretty_name: 'CKV_AZURE_38: Ensure audit profile captures all the activities'
+    pretty_name: 'Ensure audit profile captures all the activities'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_39:
     categories:
@@ -7402,7 +7402,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_39
-    pretty_name: 'CKV_AZURE_39: Ensure that no custom subscription owner roles are
+    pretty_name: 'Ensure that no custom subscription owner roles are
       created'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_4:
@@ -7414,7 +7414,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_4
-    pretty_name: 'CKV_AZURE_4: Ensure AKS logging to Azure Monitoring is Configured'
+    pretty_name: 'Ensure AKS logging to Azure Monitoring is Configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_40:
     categories:
@@ -7424,7 +7424,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_40
-    pretty_name: 'CKV_AZURE_40: Ensure that the expiration date is set on all keys'
+    pretty_name: 'Ensure that the expiration date is set on all keys'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_41:
     categories:
@@ -7434,7 +7434,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_41
-    pretty_name: 'CKV_AZURE_41: Ensure that the expiration date is set on all secrets'
+    pretty_name: 'Ensure that the expiration date is set on all secrets'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_42:
     categories:
@@ -7445,7 +7445,7 @@ rules:
     description: Check that ensures best practices in Azure secrets management.
     group: cloud-weak-secrets-management
     name: CKV_AZURE_42
-    pretty_name: 'CKV_AZURE_42: Ensure the key vault is recoverable'
+    pretty_name: 'Ensure the key vault is recoverable'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_43:
     categories:
@@ -7454,7 +7454,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_43
-    pretty_name: 'CKV_AZURE_43: Ensure Storage Accounts adhere to the naming rules'
+    pretty_name: 'Ensure Storage Accounts adhere to the naming rules'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_44:
     categories:
@@ -7465,7 +7465,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_44
-    pretty_name: 'CKV_AZURE_44: Ensure Storage Account is using the latest version
+    pretty_name: 'Ensure Storage Account is using the latest version
       of TLS encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_45:
@@ -7477,7 +7477,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_45
-    pretty_name: 'CKV_AZURE_45: Ensure that no sensitive credentials are exposed in
+    pretty_name: 'Ensure that no sensitive credentials are exposed in
       VM custom_data'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_47:
@@ -7488,7 +7488,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_47
-    pretty_name: 'CKV_AZURE_47: Ensure ''Enforce SSL connection'' is set to ''ENABLED''
+    pretty_name: 'Ensure ''Enforce SSL connection'' is set to ''ENABLED''
       for MariaDB servers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_48:
@@ -7500,7 +7500,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_48
-    pretty_name: 'CKV_AZURE_48: Ensure ''public network access enabled'' is set to
+    pretty_name: 'Ensure ''public network access enabled'' is set to
       ''False'' for MariaDB servers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_49:
@@ -7512,7 +7512,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_49
-    pretty_name: 'CKV_AZURE_49: Ensure Azure linux scale set does not use basic authentication(Use
+    pretty_name: 'Ensure Azure linux scale set does not use basic authentication(Use
       SSH Key Instead)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_5:
@@ -7524,7 +7524,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_5
-    pretty_name: 'CKV_AZURE_5: Ensure RBAC is enabled on AKS clusters'
+    pretty_name: 'Ensure RBAC is enabled on AKS clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_50:
     categories:
@@ -7535,7 +7535,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_50
-    pretty_name: 'CKV_AZURE_50: Ensure Virtual Machine Extensions are not Installed'
+    pretty_name: 'Ensure Virtual Machine Extensions are not Installed'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_52:
     categories:
@@ -7545,7 +7545,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_52
-    pretty_name: 'CKV_AZURE_52: Ensure MSSQL is using the latest version of TLS encryption'
+    pretty_name: 'Ensure MSSQL is using the latest version of TLS encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_53:
     categories:
@@ -7556,7 +7556,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_53
-    pretty_name: 'CKV_AZURE_53: Ensure ''public network access enabled'' is set to
+    pretty_name: 'Ensure ''public network access enabled'' is set to
       ''False'' for mySQL servers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_54:
@@ -7567,7 +7567,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_54
-    pretty_name: 'CKV_AZURE_54: Ensure MySQL is using the latest version of TLS encryption'
+    pretty_name: 'Ensure MySQL is using the latest version of TLS encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_55:
     categories:
@@ -7577,7 +7577,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_55
-    pretty_name: 'CKV_AZURE_55: Ensure that Azure Defender is set to On for Servers'
+    pretty_name: 'Ensure that Azure Defender is set to On for Servers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_56:
     categories:
@@ -7588,7 +7588,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_56
-    pretty_name: 'CKV_AZURE_56: Ensure that function apps enables Authentication'
+    pretty_name: 'Ensure that function apps enables Authentication'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_57:
     categories:
@@ -7599,7 +7599,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_57
-    pretty_name: 'CKV_AZURE_57: Ensure that CORS disallows every resource to access
+    pretty_name: 'Ensure that CORS disallows every resource to access
       app services'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_58:
@@ -7610,7 +7610,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_58
-    pretty_name: 'CKV_AZURE_58: Ensure that Azure Synapse workspaces enables managed
+    pretty_name: 'Ensure that Azure Synapse workspaces enables managed
       virtual networks'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_59:
@@ -7622,7 +7622,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_59
-    pretty_name: 'CKV_AZURE_59: Ensure that Storage accounts disallow public access'
+    pretty_name: 'Ensure that Storage accounts disallow public access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_6:
     categories:
@@ -7632,7 +7632,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_6
-    pretty_name: 'CKV_AZURE_6: Ensure AKS has an API Server Authorized IP Ranges enabled'
+    pretty_name: 'Ensure AKS has an API Server Authorized IP Ranges enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_60:
     categories:
@@ -7643,7 +7643,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_60
-    pretty_name: 'CKV_AZURE_60: Ensure that storage account enables secure transfer'
+    pretty_name: 'Ensure that storage account enables secure transfer'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_61:
     categories:
@@ -7653,7 +7653,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_61
-    pretty_name: 'CKV_AZURE_61: Ensure that Azure Defender is set to On for App Service'
+    pretty_name: 'Ensure that Azure Defender is set to On for App Service'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_62:
     categories:
@@ -7662,7 +7662,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_62
-    pretty_name: 'CKV_AZURE_62: Ensure function apps are not accessible from all regions'
+    pretty_name: 'Ensure function apps are not accessible from all regions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_63:
     categories:
@@ -7673,7 +7673,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_63
-    pretty_name: 'CKV_AZURE_63: Ensure that App service enables HTTP logging'
+    pretty_name: 'Ensure that App service enables HTTP logging'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_64:
     categories:
@@ -7684,7 +7684,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_64
-    pretty_name: 'CKV_AZURE_64: Ensure that Azure File Sync disables public network
+    pretty_name: 'Ensure that Azure File Sync disables public network
       access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_65:
@@ -7696,7 +7696,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_65
-    pretty_name: 'CKV_AZURE_65: Ensure that App service enables detailed error messages'
+    pretty_name: 'Ensure that App service enables detailed error messages'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_66:
     categories:
@@ -7706,7 +7706,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_66
-    pretty_name: 'CKV_AZURE_66: Ensure that App service enables failed request tracing'
+    pretty_name: 'Ensure that App service enables failed request tracing'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_67:
     categories:
@@ -7715,7 +7715,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_67
-    pretty_name: 'CKV_AZURE_67: Ensure that ''HTTP Version'' is the latest, if used
+    pretty_name: 'Ensure that ''HTTP Version'' is the latest, if used
       to run the Function app'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_68:
@@ -7727,7 +7727,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_68
-    pretty_name: 'CKV_AZURE_68: Ensure that PostgreSQL server disables public network
+    pretty_name: 'Ensure that PostgreSQL server disables public network
       access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_69:
@@ -7738,7 +7738,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_69
-    pretty_name: 'CKV_AZURE_69: Ensure that Azure Defender is set to On for Azure
+    pretty_name: 'Ensure that Azure Defender is set to On for Azure
       SQL database servers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_7:
@@ -7749,7 +7749,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_7
-    pretty_name: 'CKV_AZURE_7: Ensure AKS cluster has Network Policy configured'
+    pretty_name: 'Ensure AKS cluster has Network Policy configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_70:
     categories:
@@ -7760,7 +7760,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_70
-    pretty_name: 'CKV_AZURE_70: Ensure that Function apps is only accessible over
+    pretty_name: 'Ensure that Function apps is only accessible over
       HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_71:
@@ -7772,7 +7772,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_71
-    pretty_name: 'CKV_AZURE_71: Ensure that Managed identity provider is enabled for
+    pretty_name: 'Ensure that Managed identity provider is enabled for
       app services'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_72:
@@ -7784,7 +7784,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_72
-    pretty_name: 'CKV_AZURE_72: Ensure that remote debugging is not enabled for app
+    pretty_name: 'Ensure that remote debugging is not enabled for app
       services'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_73:
@@ -7796,7 +7796,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_73
-    pretty_name: 'CKV_AZURE_73: Ensure that Automation account variables are encrypted'
+    pretty_name: 'Ensure that Automation account variables are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_74:
     categories:
@@ -7807,7 +7807,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_74
-    pretty_name: 'CKV_AZURE_74: Ensure that Azure Data Explorer uses disk encryption'
+    pretty_name: 'Ensure that Azure Data Explorer uses disk encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_75:
     categories:
@@ -7816,7 +7816,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_75
-    pretty_name: 'CKV_AZURE_75: Ensure that Azure Data Explorer uses double encryption'
+    pretty_name: 'Ensure that Azure Data Explorer uses double encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_76:
     categories:
@@ -7825,7 +7825,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_76
-    pretty_name: 'CKV_AZURE_76: Ensure that Azure Batch account uses key vault to
+    pretty_name: 'Ensure that Azure Batch account uses key vault to
       encrypt data'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_77:
@@ -7837,7 +7837,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_77
-    pretty_name: 'CKV_AZURE_77: Ensure that UDP Services are restricted from the Internet '
+    pretty_name: 'Ensure that UDP Services are restricted from the Internet '
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_78:
     categories:
@@ -7848,7 +7848,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_78
-    pretty_name: 'CKV_AZURE_78: Ensure FTP deployments are disabled'
+    pretty_name: 'Ensure FTP deployments are disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_79:
     categories:
@@ -7858,7 +7858,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_79
-    pretty_name: 'CKV_AZURE_79: Ensure that Azure Defender is set to On for SQL servers
+    pretty_name: 'Ensure that Azure Defender is set to On for SQL servers
       on machines'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_8:
@@ -7870,7 +7870,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_8
-    pretty_name: 'CKV_AZURE_8: Ensure Kubernetes Dashboard is disabled'
+    pretty_name: 'Ensure Kubernetes Dashboard is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_80:
     categories:
@@ -7881,7 +7881,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_80
-    pretty_name: 'CKV_AZURE_80: Ensure that ''Net Framework'' version is the latest,
+    pretty_name: 'Ensure that ''Net Framework'' version is the latest,
       if used as a part of the web app'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_81:
@@ -7893,7 +7893,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_81
-    pretty_name: 'CKV_AZURE_81: Ensure that ''PHP version'' is the latest, if used
+    pretty_name: 'Ensure that ''PHP version'' is the latest, if used
       to run the web app'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_82:
@@ -7905,7 +7905,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_82
-    pretty_name: 'CKV_AZURE_82: Ensure that ''Python version'' is the latest, if used
+    pretty_name: 'Ensure that ''Python version'' is the latest, if used
       to run the web app'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_83:
@@ -7917,7 +7917,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_83
-    pretty_name: 'CKV_AZURE_83: Ensure that ''Java version'' is the latest, if used
+    pretty_name: 'Ensure that ''Java version'' is the latest, if used
       to run the web app'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_84:
@@ -7928,7 +7928,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_84
-    pretty_name: 'CKV_AZURE_84: Ensure that Azure Defender is set to On for Storage'
+    pretty_name: 'Ensure that Azure Defender is set to On for Storage'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_85:
     categories:
@@ -7938,7 +7938,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_85
-    pretty_name: 'CKV_AZURE_85: Ensure that Azure Defender is set to On for Kubernetes'
+    pretty_name: 'Ensure that Azure Defender is set to On for Kubernetes'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_86:
     categories:
@@ -7948,7 +7948,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_86
-    pretty_name: 'CKV_AZURE_86: Ensure that Azure Defender is set to On for Container
+    pretty_name: 'Ensure that Azure Defender is set to On for Container
       Registries'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_87:
@@ -7959,7 +7959,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_87
-    pretty_name: 'CKV_AZURE_87: Ensure that Azure Defender is set to On for Key Vault'
+    pretty_name: 'Ensure that Azure Defender is set to On for Key Vault'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_88:
     categories:
@@ -7968,7 +7968,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_88
-    pretty_name: 'CKV_AZURE_88: Ensure that app services use Azure Files'
+    pretty_name: 'Ensure that app services use Azure Files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_89:
     categories:
@@ -7979,7 +7979,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_89
-    pretty_name: 'CKV_AZURE_89: Ensure that Azure Cache for Redis disables public
+    pretty_name: 'Ensure that Azure Cache for Redis disables public
       network access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_9:
@@ -7991,7 +7991,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_9
-    pretty_name: 'CKV_AZURE_9: Ensure that RDP access is restricted from the internet'
+    pretty_name: 'Ensure that RDP access is restricted from the internet'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_91:
     categories:
@@ -8001,7 +8001,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_91
-    pretty_name: 'CKV_AZURE_91: Ensure that only SSL are enabled for Cache for Redis'
+    pretty_name: 'Ensure that only SSL are enabled for Cache for Redis'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_92:
     categories:
@@ -8012,7 +8012,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_92
-    pretty_name: 'CKV_AZURE_92: Ensure that Virtual Machines use managed disks'
+    pretty_name: 'Ensure that Virtual Machines use managed disks'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_93:
     categories:
@@ -8021,7 +8021,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_93
-    pretty_name: 'CKV_AZURE_93: Ensure that managed disks use a specific set of disk
+    pretty_name: 'Ensure that managed disks use a specific set of disk
       encryption sets for the customer-managed key encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_94:
@@ -8032,7 +8032,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_94
-    pretty_name: 'CKV_AZURE_94: Ensure that My SQL server enables geo-redundant backups'
+    pretty_name: 'Ensure that My SQL server enables geo-redundant backups'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_95:
     categories:
@@ -8043,7 +8043,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_95
-    pretty_name: 'CKV_AZURE_95: Ensure that automatic OS image patching is enabled
+    pretty_name: 'Ensure that automatic OS image patching is enabled
       for Virtual Machine Scale Sets'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_96:
@@ -8054,7 +8054,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_96
-    pretty_name: 'CKV_AZURE_96: Ensure that MySQL server enables infrastructure encryption'
+    pretty_name: 'Ensure that MySQL server enables infrastructure encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_97:
     categories:
@@ -8065,7 +8065,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_97
-    pretty_name: 'CKV_AZURE_97: Ensure that Virtual machine scale sets have encryption
+    pretty_name: 'Ensure that Virtual machine scale sets have encryption
       at host enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_98:
@@ -8077,7 +8077,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_98
-    pretty_name: 'CKV_AZURE_98: Ensure that Azure Container group is deployed into
+    pretty_name: 'Ensure that Azure Container group is deployed into
       virtual network'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_99:
@@ -8089,7 +8089,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_99
-    pretty_name: 'CKV_AZURE_99: Ensure Cosmos DB accounts have restricted access'
+    pretty_name: 'Ensure Cosmos DB accounts have restricted access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_BCW_1:
     categories:
@@ -8100,7 +8100,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_BCW_1
-    pretty_name: 'CKV_BCW_1: Ensure no hard coded API token exist in the provider'
+    pretty_name: 'Ensure no hard coded API token exist in the provider'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_BITBUCKETPIPELINES_1:
     categories:
@@ -8110,7 +8110,7 @@ rules:
     description: Check for weak Bitbucket Pipelines configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_BITBUCKETPIPELINES_1
-    pretty_name: 'CKV_BITBUCKETPIPELINES_1: Ensure the pipeline image uses a non latest
+    pretty_name: 'Ensure the pipeline image uses a non latest
       version tag'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_BITBUCKET_1:
@@ -8120,7 +8120,7 @@ rules:
     description: Check for weak Bitbucket configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_BITBUCKET_1
-    pretty_name: 'CKV_BITBUCKET_1: Merge requests should require at least 2 approvals'
+    pretty_name: 'Merge requests should require at least 2 approvals'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_CIRCLECIPIPELINES_1:
     categories:
@@ -8130,7 +8130,7 @@ rules:
     description: Check for weak CircleCI configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_CIRCLECIPIPELINES_1
-    pretty_name: 'CKV_CIRCLECIPIPELINES_1: Ensure the pipeline image uses a non latest
+    pretty_name: 'Ensure the pipeline image uses a non latest
       version tag'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_CIRCLECIPIPELINES_2:
@@ -8141,7 +8141,7 @@ rules:
     description: Check for weak CircleCI configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_CIRCLECIPIPELINES_2
-    pretty_name: 'CKV_CIRCLECIPIPELINES_2: Ensure the pipeline image version is referenced
+    pretty_name: 'Ensure the pipeline image version is referenced
       via hash not arbitrary tag.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_CIRCLECIPIPELINES_3:
@@ -8152,7 +8152,7 @@ rules:
     description: Check for weak CircleCI configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_CIRCLECIPIPELINES_3
-    pretty_name: 'CKV_CIRCLECIPIPELINES_3: Ensure mutable development orbs are not
+    pretty_name: 'Ensure mutable development orbs are not
       used.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_CIRCLECIPIPELINES_4:
@@ -8164,7 +8164,7 @@ rules:
     description: Check for weak CircleCI configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_CIRCLECIPIPELINES_4
-    pretty_name: 'CKV_CIRCLECIPIPELINES_4: Ensure unversioned volatile orbs are not
+    pretty_name: 'Ensure unversioned volatile orbs are not
       used.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_CIRCLECIPIPELINES_5:
@@ -8176,7 +8176,7 @@ rules:
     description: Check for weak CircleCI configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_CIRCLECIPIPELINES_5
-    pretty_name: 'CKV_CIRCLECIPIPELINES_5: Suspicious use of netcat with IP address'
+    pretty_name: 'Suspicious use of netcat with IP address'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_CIRCLECIPIPELINES_6:
     categories:
@@ -8187,7 +8187,7 @@ rules:
     description: Check for weak CircleCI configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_CIRCLECIPIPELINES_6
-    pretty_name: 'CKV_CIRCLECIPIPELINES_6: Ensure run commands are not vulnerable
+    pretty_name: 'Ensure run commands are not vulnerable
       to shell injection'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_CIRCLECIPIPELINES_7:
@@ -8199,7 +8199,7 @@ rules:
     description: Check for weak CircleCI configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_CIRCLECIPIPELINES_7
-    pretty_name: 'CKV_CIRCLECIPIPELINES_7: Suspicious use of curl in run task'
+    pretty_name: 'Suspicious use of curl in run task'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DIO_1:
     categories:
@@ -8209,7 +8209,7 @@ rules:
     description: Check for misconfigurations in Digital Ocean resources.
     group: cloud-weak-configuration
     name: CKV_DIO_1
-    pretty_name: 'CKV_DIO_1: Ensure the Spaces bucket has versioning enabled'
+    pretty_name: 'Ensure the Spaces bucket has versioning enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DIO_2:
     categories:
@@ -8220,7 +8220,7 @@ rules:
     description: Check for misconfigurations in Digital Ocean resources.
     group: cloud-weak-configuration
     name: CKV_DIO_2
-    pretty_name: 'CKV_DIO_2: Ensure the droplet specifies an SSH key'
+    pretty_name: 'Ensure the droplet specifies an SSH key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DIO_3:
     categories:
@@ -8231,7 +8231,7 @@ rules:
     description: Check for publicly accessible Digital Ocean resources.
     group: cloud-resources-public-access
     name: CKV_DIO_3
-    pretty_name: 'CKV_DIO_3: Ensure the Spaces bucket is private'
+    pretty_name: 'Ensure the Spaces bucket is private'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DIO_4:
     categories:
@@ -8242,7 +8242,7 @@ rules:
     description: Check for misconfigurations in Digital Ocean resources.
     group: cloud-weak-configuration
     name: CKV_DIO_4
-    pretty_name: 'CKV_DIO_4: Ensure the firewall ingress is not wide open'
+    pretty_name: 'Ensure the firewall ingress is not wide open'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_1:
     categories:
@@ -8253,7 +8253,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_1
-    pretty_name: 'CKV_DOCKER_1: Ensure port 22 is not exposed'
+    pretty_name: 'Ensure port 22 is not exposed'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_10:
     categories:
@@ -8264,7 +8264,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_10
-    pretty_name: 'CKV_DOCKER_10: Ensure that WORKDIR values are absolute paths'
+    pretty_name: 'Ensure that WORKDIR values are absolute paths'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_11:
     categories:
@@ -8275,7 +8275,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_11
-    pretty_name: 'CKV_DOCKER_11: Ensure From Alias are unique for multistage builds.'
+    pretty_name: 'Ensure From Alias are unique for multistage builds.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_2:
     categories:
@@ -8284,7 +8284,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_2
-    pretty_name: 'CKV_DOCKER_2: Ensure that HEALTHCHECK instructions have been added
+    pretty_name: 'Ensure that HEALTHCHECK instructions have been added
       to container images'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_3:
@@ -8294,7 +8294,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_3
-    pretty_name: 'CKV_DOCKER_3: Ensure that a user for the container has been created'
+    pretty_name: 'Ensure that a user for the container has been created'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_4:
     categories:
@@ -8303,7 +8303,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_4
-    pretty_name: 'CKV_DOCKER_4: Ensure that COPY is used instead of ADD in Dockerfiles'
+    pretty_name: 'Ensure that COPY is used instead of ADD in Dockerfiles'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_5:
     categories:
@@ -8314,7 +8314,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_5
-    pretty_name: 'CKV_DOCKER_5: Ensure update instructions are not use alone in the
+    pretty_name: 'Ensure update instructions are not use alone in the
       Dockerfile'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_6:
@@ -8324,7 +8324,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_6
-    pretty_name: 'CKV_DOCKER_6: Ensure that LABEL maintainer is used instead of MAINTAINER
+    pretty_name: 'Ensure that LABEL maintainer is used instead of MAINTAINER
       (deprecated)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_7:
@@ -8336,7 +8336,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_7
-    pretty_name: 'CKV_DOCKER_7: Ensure the base image uses a non latest version tag'
+    pretty_name: 'Ensure the base image uses a non latest version tag'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_8:
     categories:
@@ -8346,7 +8346,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_8
-    pretty_name: 'CKV_DOCKER_8: Ensure the last USER is not root'
+    pretty_name: 'Ensure the last USER is not root'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_9:
     categories:
@@ -8355,7 +8355,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_9
-    pretty_name: 'CKV_DOCKER_9: Ensure that APT isn''t used'
+    pretty_name: 'Ensure that APT isn''t used'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_1:
     categories:
@@ -8366,7 +8366,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_1
-    pretty_name: 'CKV_GCP_1: Ensure Stackdriver Logging is set to Enabled on Kubernetes
+    pretty_name: 'Ensure Stackdriver Logging is set to Enabled on Kubernetes
       Engine Clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_10:
@@ -8378,7 +8378,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_10
-    pretty_name: 'CKV_GCP_10: Ensure ''Automatic node upgrade'' is enabled for Kubernetes
+    pretty_name: 'Ensure ''Automatic node upgrade'' is enabled for Kubernetes
       Clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_100:
@@ -8390,7 +8390,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_100
-    pretty_name: 'CKV_GCP_100: Ensure that BigQuery Tables are not anonymously or
+    pretty_name: 'Ensure that BigQuery Tables are not anonymously or
       publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_101:
@@ -8402,7 +8402,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_101
-    pretty_name: 'CKV_GCP_101: Ensure that Artifact Registry repositories are not
+    pretty_name: 'Ensure that Artifact Registry repositories are not
       anonymously or publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_102:
@@ -8414,7 +8414,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_102
-    pretty_name: 'CKV_GCP_102: Ensure that GCP Cloud Run services are not anonymously
+    pretty_name: 'Ensure that GCP Cloud Run services are not anonymously
       or publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_103:
@@ -8426,7 +8426,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_103
-    pretty_name: 'CKV_GCP_103: Ensure Dataproc Clusters do not have public IPs'
+    pretty_name: 'Ensure Dataproc Clusters do not have public IPs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_104:
     categories:
@@ -8437,7 +8437,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_104
-    pretty_name: 'CKV_GCP_104: Ensure Datafusion has stack driver logging enabled'
+    pretty_name: 'Ensure Datafusion has stack driver logging enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_105:
     categories:
@@ -8448,7 +8448,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_105
-    pretty_name: 'CKV_GCP_105: Ensure Datafusion has stack driver monitoring enabled'
+    pretty_name: 'Ensure Datafusion has stack driver monitoring enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_106:
     categories:
@@ -8459,7 +8459,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_106
-    pretty_name: 'CKV_GCP_106: Ensure Google compute firewall ingress does not allow
+    pretty_name: 'Ensure Google compute firewall ingress does not allow
       unrestricted http port 80 access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_107:
@@ -8469,7 +8469,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_107
-    pretty_name: 'CKV_GCP_107: Cloud functions should not be public'
+    pretty_name: 'Cloud functions should not be public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_108:
     categories:
@@ -8480,7 +8480,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_108
-    pretty_name: 'CKV_GCP_108: Ensure hostnames are logged for GCP PostgreSQL databases'
+    pretty_name: 'Ensure hostnames are logged for GCP PostgreSQL databases'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_109:
     categories:
@@ -8491,7 +8491,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_109
-    pretty_name: 'CKV_GCP_109: Ensure the GCP PostgreSQL database log levels are set
+    pretty_name: 'Ensure the GCP PostgreSQL database log levels are set
       to ERROR or lower'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_11:
@@ -8503,7 +8503,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_11
-    pretty_name: 'CKV_GCP_11: Ensure that Cloud SQL database Instances are not open
+    pretty_name: 'Ensure that Cloud SQL database Instances are not open
       to the world'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_110:
@@ -8514,7 +8514,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_110
-    pretty_name: 'CKV_GCP_110: Ensure pgAudit is enabled for your GCP PostgreSQL database'
+    pretty_name: 'Ensure pgAudit is enabled for your GCP PostgreSQL database'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_111:
     categories:
@@ -8523,7 +8523,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_111
-    pretty_name: 'CKV_GCP_111: Ensure GCP PostgreSQL logs SQL statements'
+    pretty_name: 'Ensure GCP PostgreSQL logs SQL statements'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_112:
     categories:
@@ -8534,7 +8534,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_112
-    pretty_name: 'CKV_GCP_112: Esnure KMS policy should not allow public access'
+    pretty_name: 'Esnure KMS policy should not allow public access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_113:
     categories:
@@ -8545,7 +8545,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_113
-    pretty_name: 'CKV_GCP_113: Ensure IAM policy should not define public access'
+    pretty_name: 'Ensure IAM policy should not define public access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_114:
     categories:
@@ -8556,7 +8556,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_114
-    pretty_name: 'CKV_GCP_114: Ensure public access prevention is enforced on Cloud
+    pretty_name: 'Ensure public access prevention is enforced on Cloud
       Storage bucket'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_115:
@@ -8568,7 +8568,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_115
-    pretty_name: 'CKV_GCP_115: Ensure basic roles are not used at organization level.'
+    pretty_name: 'Ensure basic roles are not used at organization level.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_116:
     categories:
@@ -8579,7 +8579,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_116
-    pretty_name: 'CKV_GCP_116: Ensure basic roles are not used at folder level.'
+    pretty_name: 'Ensure basic roles are not used at folder level.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_117:
     categories:
@@ -8590,7 +8590,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_117
-    pretty_name: 'CKV_GCP_117: Ensure basic roles are not used at project level.'
+    pretty_name: 'Ensure basic roles are not used at project level.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_12:
     categories:
@@ -8599,7 +8599,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_12
-    pretty_name: 'CKV_GCP_12: Ensure Network Policy is enabled on Kubernetes Engine
+    pretty_name: 'Ensure Network Policy is enabled on Kubernetes Engine
       Clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_13:
@@ -8611,7 +8611,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_13
-    pretty_name: 'CKV_GCP_13: Ensure client certificate authentication to Kubernetes
+    pretty_name: 'Ensure client certificate authentication to Kubernetes
       Engine Clusters is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_14:
@@ -8623,7 +8623,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_14
-    pretty_name: 'CKV_GCP_14: Ensure all Cloud SQL database instance have backup configuration
+    pretty_name: 'Ensure all Cloud SQL database instance have backup configuration
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_15:
@@ -8635,7 +8635,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_15
-    pretty_name: 'CKV_GCP_15: Ensure that BigQuery datasets are not anonymously or
+    pretty_name: 'Ensure that BigQuery datasets are not anonymously or
       publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_16:
@@ -8645,7 +8645,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_16
-    pretty_name: 'CKV_GCP_16: Ensure that DNSSEC is enabled for Cloud DNS'
+    pretty_name: 'Ensure that DNSSEC is enabled for Cloud DNS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_17:
     categories:
@@ -8656,7 +8656,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_17
-    pretty_name: 'CKV_GCP_17: Ensure that RSASHA1 is not used for the zone-signing
+    pretty_name: 'Ensure that RSASHA1 is not used for the zone-signing
       and key-signing keys in Cloud DNS DNSSEC'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_18:
@@ -8667,7 +8667,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_18
-    pretty_name: 'CKV_GCP_18: Ensure GKE Control Plane is not public'
+    pretty_name: 'Ensure GKE Control Plane is not public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_19:
     categories:
@@ -8678,7 +8678,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_19
-    pretty_name: 'CKV_GCP_19: Ensure GKE basic auth is disabled'
+    pretty_name: 'Ensure GKE basic auth is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_2:
     categories:
@@ -8689,7 +8689,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_2
-    pretty_name: 'CKV_GCP_2: Ensure Google compute firewall ingress does not allow
+    pretty_name: 'Ensure Google compute firewall ingress does not allow
       unrestricted ssh access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_20:
@@ -8700,7 +8700,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_20
-    pretty_name: 'CKV_GCP_20: Ensure master authorized networks is set to enabled
+    pretty_name: 'Ensure master authorized networks is set to enabled
       in GKE clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_21:
@@ -8710,7 +8710,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_21
-    pretty_name: 'CKV_GCP_21: Ensure Kubernetes Clusters are configured with Labels'
+    pretty_name: 'Ensure Kubernetes Clusters are configured with Labels'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_22:
     categories:
@@ -8721,7 +8721,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_22
-    pretty_name: 'CKV_GCP_22: Ensure Container-Optimized OS (cos) is used for Kubernetes
+    pretty_name: 'Ensure Container-Optimized OS (cos) is used for Kubernetes
       Engine Clusters Node image'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_23:
@@ -8731,7 +8731,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_23
-    pretty_name: 'CKV_GCP_23: Ensure Kubernetes Cluster is created with Alias IP ranges
+    pretty_name: 'Ensure Kubernetes Cluster is created with Alias IP ranges
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_24:
@@ -8741,7 +8741,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_24
-    pretty_name: 'CKV_GCP_24: Ensure PodSecurityPolicy controller is enabled on the
+    pretty_name: 'Ensure PodSecurityPolicy controller is enabled on the
       Kubernetes Engine Clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_25:
@@ -8751,7 +8751,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_25
-    pretty_name: 'CKV_GCP_25: Ensure Kubernetes Cluster is created with Private cluster
+    pretty_name: 'Ensure Kubernetes Cluster is created with Private cluster
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_26:
@@ -8761,7 +8761,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_26
-    pretty_name: 'CKV_GCP_26: Ensure that VPC Flow Logs is enabled for every subnet
+    pretty_name: 'Ensure that VPC Flow Logs is enabled for every subnet
       in a VPC Network'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_27:
@@ -8772,7 +8772,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_27
-    pretty_name: 'CKV_GCP_27: Ensure that the default network does not exist in a
+    pretty_name: 'Ensure that the default network does not exist in a
       project'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_28:
@@ -8784,7 +8784,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_28
-    pretty_name: 'CKV_GCP_28: Ensure that Cloud Storage bucket is not anonymously
+    pretty_name: 'Ensure that Cloud Storage bucket is not anonymously
       or publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_29:
@@ -8796,7 +8796,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_29
-    pretty_name: 'CKV_GCP_29: Ensure that Cloud Storage buckets have uniform bucket-level
+    pretty_name: 'Ensure that Cloud Storage buckets have uniform bucket-level
       access enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_3:
@@ -8808,7 +8808,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_3
-    pretty_name: 'CKV_GCP_3: Ensure Google compute firewall ingress does not allow
+    pretty_name: 'Ensure Google compute firewall ingress does not allow
       unrestricted rdp access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_30:
@@ -8820,7 +8820,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_30
-    pretty_name: 'CKV_GCP_30: Ensure that instances are not configured to use the
+    pretty_name: 'Ensure that instances are not configured to use the
       default service account'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_31:
@@ -8832,7 +8832,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_31
-    pretty_name: 'CKV_GCP_31: Ensure that instances are not configured to use the
+    pretty_name: 'Ensure that instances are not configured to use the
       default service account with full access to all Cloud APIs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_32:
@@ -8844,7 +8844,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_32
-    pretty_name: 'CKV_GCP_32: Ensure ''Block Project-wide SSH keys'' is enabled for
+    pretty_name: 'Ensure ''Block Project-wide SSH keys'' is enabled for
       VM instances'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_33:
@@ -8856,7 +8856,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_33
-    pretty_name: 'CKV_GCP_33: Ensure oslogin is enabled for a Project'
+    pretty_name: 'Ensure oslogin is enabled for a Project'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_34:
     categories:
@@ -8867,7 +8867,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_34
-    pretty_name: 'CKV_GCP_34: Ensure that no instance in the project overrides the
+    pretty_name: 'Ensure that no instance in the project overrides the
       project setting for enabling OSLogin'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_35:
@@ -8879,7 +8879,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_35
-    pretty_name: 'CKV_GCP_35: Ensure ''Enable connecting to serial ports'' is not
+    pretty_name: 'Ensure ''Enable connecting to serial ports'' is not
       enabled for VM Instance'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_36:
@@ -8891,7 +8891,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_36
-    pretty_name: 'CKV_GCP_36: Ensure that IP forwarding is not enabled on Instances'
+    pretty_name: 'Ensure that IP forwarding is not enabled on Instances'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_37:
     categories:
@@ -8900,7 +8900,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_37
-    pretty_name: 'CKV_GCP_37: Ensure VM disks for critical VMs are encrypted with
+    pretty_name: 'Ensure VM disks for critical VMs are encrypted with
       Customer Supplied Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_38:
@@ -8910,7 +8910,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_38
-    pretty_name: 'CKV_GCP_38: Ensure VM disks for critical VMs are encrypted with
+    pretty_name: 'Ensure VM disks for critical VMs are encrypted with
       Customer Supplied Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_39:
@@ -8921,7 +8921,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_39
-    pretty_name: 'CKV_GCP_39: Ensure Compute instances are launched with Shielded
+    pretty_name: 'Ensure Compute instances are launched with Shielded
       VM enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_4:
@@ -8933,7 +8933,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_4
-    pretty_name: 'CKV_GCP_4: Ensure no HTTPS or SSL proxy load balancers permit SSL
+    pretty_name: 'Ensure no HTTPS or SSL proxy load balancers permit SSL
       policies with weak cipher suites'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_40:
@@ -8945,7 +8945,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_40
-    pretty_name: 'CKV_GCP_40: Ensure that Compute instances do not have public IP
+    pretty_name: 'Ensure that Compute instances do not have public IP
       addresses'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_41:
@@ -8957,7 +8957,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_41
-    pretty_name: 'CKV_GCP_41: Ensure that IAM users are not assigned the Service Account
+    pretty_name: 'Ensure that IAM users are not assigned the Service Account
       User or Service Account Token Creator roles at project level'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_42:
@@ -8969,7 +8969,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_42
-    pretty_name: 'CKV_GCP_42: Ensure that Service Account has no Admin privileges'
+    pretty_name: 'Ensure that Service Account has no Admin privileges'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_43:
     categories:
@@ -8979,7 +8979,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_43
-    pretty_name: 'CKV_GCP_43: Ensure KMS encryption keys are rotated within a period
+    pretty_name: 'Ensure KMS encryption keys are rotated within a period
       of 90 days'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_44:
@@ -8991,7 +8991,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_44
-    pretty_name: 'CKV_GCP_44: Ensure no roles that enable to impersonate and manage
+    pretty_name: 'Ensure no roles that enable to impersonate and manage
       all service accounts are used at a folder level'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_45:
@@ -9003,7 +9003,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_45
-    pretty_name: 'CKV_GCP_45: Ensure no roles that enable to impersonate and manage
+    pretty_name: 'Ensure no roles that enable to impersonate and manage
       all service accounts are used at an organization level'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_46:
@@ -9015,7 +9015,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_46
-    pretty_name: 'CKV_GCP_46: Ensure Default Service account is not used at a project
+    pretty_name: 'Ensure Default Service account is not used at a project
       level'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_47:
@@ -9027,7 +9027,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_47
-    pretty_name: 'CKV_GCP_47: Ensure default service account is not used at an organization
+    pretty_name: 'Ensure default service account is not used at an organization
       level'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_48:
@@ -9039,7 +9039,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_48
-    pretty_name: 'CKV_GCP_48: Ensure Default Service account is not used at a folder
+    pretty_name: 'Ensure Default Service account is not used at a folder
       level'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_49:
@@ -9051,7 +9051,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_49
-    pretty_name: 'CKV_GCP_49: Ensure roles do not impersonate or manage Service Accounts
+    pretty_name: 'Ensure roles do not impersonate or manage Service Accounts
       used at project level'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_50:
@@ -9063,7 +9063,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_50
-    pretty_name: 'CKV_GCP_50: Ensure MySQL database ''local_infile'' flag is set to
+    pretty_name: 'Ensure MySQL database ''local_infile'' flag is set to
       ''off'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_51:
@@ -9075,7 +9075,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_51
-    pretty_name: 'CKV_GCP_51: Ensure PostgreSQL database ''log_checkpoints'' flag
+    pretty_name: 'Ensure PostgreSQL database ''log_checkpoints'' flag
       is set to ''on'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_52:
@@ -9087,7 +9087,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_52
-    pretty_name: 'CKV_GCP_52: Ensure PostgreSQL database ''log_connections'' flag
+    pretty_name: 'Ensure PostgreSQL database ''log_connections'' flag
       is set to ''on'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_53:
@@ -9098,7 +9098,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_53
-    pretty_name: 'CKV_GCP_53: Ensure PostgreSQL database ''log_disconnections'' flag
+    pretty_name: 'Ensure PostgreSQL database ''log_disconnections'' flag
       is set to ''on'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_54:
@@ -9109,7 +9109,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_54
-    pretty_name: 'CKV_GCP_54: Ensure PostgreSQL database ''log_lock_waits'' flag is
+    pretty_name: 'Ensure PostgreSQL database ''log_lock_waits'' flag is
       set to ''on'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_55:
@@ -9119,7 +9119,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_55
-    pretty_name: 'CKV_GCP_55: Ensure PostgreSQL database ''log_min_messages'' flag
+    pretty_name: 'Ensure PostgreSQL database ''log_min_messages'' flag
       is set to a valid value'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_56:
@@ -9130,7 +9130,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_56
-    pretty_name: 'CKV_GCP_56: Ensure PostgreSQL database ''log_temp_files flag is
+    pretty_name: 'Ensure PostgreSQL database ''log_temp_files flag is
       set to ''0'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_57:
@@ -9140,7 +9140,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_57
-    pretty_name: 'CKV_GCP_57: Ensure PostgreSQL database ''log_min_duration_statement''
+    pretty_name: 'Ensure PostgreSQL database ''log_min_duration_statement''
       flag is set to ''-1'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_58:
@@ -9152,7 +9152,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_58
-    pretty_name: 'CKV_GCP_58: Ensure SQL database ''cross db ownership chaining''
+    pretty_name: 'Ensure SQL database ''cross db ownership chaining''
       flag is set to ''off'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_59:
@@ -9164,7 +9164,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_59
-    pretty_name: 'CKV_GCP_59: Ensure SQL database ''contained database authentication''
+    pretty_name: 'Ensure SQL database ''contained database authentication''
       flag is set to ''off'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_6:
@@ -9176,7 +9176,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_6
-    pretty_name: 'CKV_GCP_6: Ensure all Cloud SQL database instance requires all incoming
+    pretty_name: 'Ensure all Cloud SQL database instance requires all incoming
       connections to use SSL'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_60:
@@ -9188,7 +9188,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_60
-    pretty_name: 'CKV_GCP_60: Ensure Cloud SQL database does not have public IP'
+    pretty_name: 'Ensure Cloud SQL database does not have public IP'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_61:
     categories:
@@ -9197,7 +9197,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_61
-    pretty_name: 'CKV_GCP_61: Enable VPC Flow Logs and Intranode Visibility'
+    pretty_name: 'Enable VPC Flow Logs and Intranode Visibility'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_62:
     categories:
@@ -9207,7 +9207,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_62
-    pretty_name: 'CKV_GCP_62: Bucket should log access'
+    pretty_name: 'Bucket should log access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_63:
     categories:
@@ -9218,7 +9218,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_63
-    pretty_name: 'CKV_GCP_63: Bucket should not log to itself'
+    pretty_name: 'Bucket should not log to itself'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_64:
     categories:
@@ -9227,7 +9227,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_64
-    pretty_name: 'CKV_GCP_64: Ensure clusters are created with Private Nodes'
+    pretty_name: 'Ensure clusters are created with Private Nodes'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_65:
     categories:
@@ -9238,7 +9238,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_65
-    pretty_name: 'CKV_GCP_65: Manage Kubernetes RBAC users with Google Groups for
+    pretty_name: 'Manage Kubernetes RBAC users with Google Groups for
       GKE'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_66:
@@ -9249,7 +9249,7 @@ rules:
     description: Check for weak Google Cloud configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_GCP_66
-    pretty_name: 'CKV_GCP_66: Ensure use of Binary Authorization'
+    pretty_name: 'Ensure use of Binary Authorization'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_67:
     categories:
@@ -9260,7 +9260,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_67
-    pretty_name: 'CKV_GCP_67: Ensure legacy Compute Engine instance metadata APIs
+    pretty_name: 'Ensure legacy Compute Engine instance metadata APIs
       are Disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_68:
@@ -9271,7 +9271,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_68
-    pretty_name: 'CKV_GCP_68: Ensure Secure Boot for Shielded GKE Nodes is Enabled'
+    pretty_name: 'Ensure Secure Boot for Shielded GKE Nodes is Enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_69:
     categories:
@@ -9282,7 +9282,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_69
-    pretty_name: 'CKV_GCP_69: Ensure the GKE Metadata Server is Enabled'
+    pretty_name: 'Ensure the GKE Metadata Server is Enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_7:
     categories:
@@ -9293,7 +9293,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_7
-    pretty_name: 'CKV_GCP_7: Ensure Legacy Authorization is set to Disabled on Kubernetes
+    pretty_name: 'Ensure Legacy Authorization is set to Disabled on Kubernetes
       Engine Clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_70:
@@ -9305,7 +9305,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_70
-    pretty_name: 'CKV_GCP_70: Ensure the GKE Release Channel is set'
+    pretty_name: 'Ensure the GKE Release Channel is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_71:
     categories:
@@ -9315,7 +9315,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_71
-    pretty_name: 'CKV_GCP_71: Ensure Shielded GKE Nodes are Enabled'
+    pretty_name: 'Ensure Shielded GKE Nodes are Enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_72:
     categories:
@@ -9325,7 +9325,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_72
-    pretty_name: 'CKV_GCP_72: Ensure Integrity Monitoring for Shielded GKE Nodes is
+    pretty_name: 'Ensure Integrity Monitoring for Shielded GKE Nodes is
       Enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_73:
@@ -9337,7 +9337,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_73
-    pretty_name: 'CKV_GCP_73: Ensure Cloud Armor prevents message lookup in Log4j2.
+    pretty_name: 'Ensure Cloud Armor prevents message lookup in Log4j2.
       See CVE-2021-44228 aka log4jshell'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_74:
@@ -9349,7 +9349,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_74
-    pretty_name: 'CKV_GCP_74: Ensure that private_ip_google_access is enabled for
+    pretty_name: 'Ensure that private_ip_google_access is enabled for
       Subnet'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_75:
@@ -9361,7 +9361,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_75
-    pretty_name: 'CKV_GCP_75: Ensure Google compute firewall ingress does not allow
+    pretty_name: 'Ensure Google compute firewall ingress does not allow
       unrestricted FTP access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_76:
@@ -9373,7 +9373,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_76
-    pretty_name: 'CKV_GCP_76: Ensure that Private google access is enabled for IPV6'
+    pretty_name: 'Ensure that Private google access is enabled for IPV6'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_77:
     categories:
@@ -9384,7 +9384,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_77
-    pretty_name: 'CKV_GCP_77: Ensure Google compute firewall ingress does not allow
+    pretty_name: 'Ensure Google compute firewall ingress does not allow
       on ftp port'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_78:
@@ -9394,7 +9394,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_78
-    pretty_name: 'CKV_GCP_78: Ensure Cloud storage has versioning enabled'
+    pretty_name: 'Ensure Cloud storage has versioning enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_79:
     categories:
@@ -9405,7 +9405,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_79
-    pretty_name: 'CKV_GCP_79: Ensure SQL database is using latest Major version'
+    pretty_name: 'Ensure SQL database is using latest Major version'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_8:
     categories:
@@ -9416,7 +9416,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_8
-    pretty_name: 'CKV_GCP_8: Ensure Stackdriver Monitoring is set to Enabled on Kubernetes
+    pretty_name: 'Ensure Stackdriver Monitoring is set to Enabled on Kubernetes
       Engine Clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_80:
@@ -9426,7 +9426,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_80
-    pretty_name: 'CKV_GCP_80: Ensure Big Query Tables are encrypted with Customer
+    pretty_name: 'Ensure Big Query Tables are encrypted with Customer
       Supplied Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_81:
@@ -9436,7 +9436,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_81
-    pretty_name: 'CKV_GCP_81: Ensure Big Query Tables are encrypted with Customer
+    pretty_name: 'Ensure Big Query Tables are encrypted with Customer
       Supplied Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_82:
@@ -9448,7 +9448,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_82
-    pretty_name: 'CKV_GCP_82: Ensure KMS keys are protected from deletion'
+    pretty_name: 'Ensure KMS keys are protected from deletion'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_83:
     categories:
@@ -9457,7 +9457,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_83
-    pretty_name: 'CKV_GCP_83: Ensure PubSub Topics are encrypted with Customer Supplied
+    pretty_name: 'Ensure PubSub Topics are encrypted with Customer Supplied
       Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_84:
@@ -9467,7 +9467,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_84
-    pretty_name: 'CKV_GCP_84: Ensure Artifact Registry Repositories are encrypted
+    pretty_name: 'Ensure Artifact Registry Repositories are encrypted
       with Customer Supplied Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_85:
@@ -9477,7 +9477,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_85
-    pretty_name: 'CKV_GCP_85: Ensure Big Table Instances are encrypted with Customer
+    pretty_name: 'Ensure Big Table Instances are encrypted with Customer
       Supplied Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_86:
@@ -9489,7 +9489,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_86
-    pretty_name: 'CKV_GCP_86: Ensure Cloud build workers are private'
+    pretty_name: 'Ensure Cloud build workers are private'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_87:
     categories:
@@ -9500,7 +9500,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_87
-    pretty_name: 'CKV_GCP_87: Ensure Data fusion instances are private'
+    pretty_name: 'Ensure Data fusion instances are private'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_88:
     categories:
@@ -9511,7 +9511,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_88
-    pretty_name: 'CKV_GCP_88: Ensure Google compute firewall ingress does not allow
+    pretty_name: 'Ensure Google compute firewall ingress does not allow
       unrestricted mysql access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_89:
@@ -9523,7 +9523,7 @@ rules:
     description: Check that ensures best practices in Google Cloud secrets management.
     group: cloud-weak-secrets-management
     name: CKV_GCP_89
-    pretty_name: 'CKV_GCP_89: Ensure Vertex AI instances are private'
+    pretty_name: 'Ensure Vertex AI instances are private'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_9:
     categories:
@@ -9532,7 +9532,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_9
-    pretty_name: 'CKV_GCP_9: Ensure ''Automatic node repair'' is enabled for Kubernetes
+    pretty_name: 'Ensure ''Automatic node repair'' is enabled for Kubernetes
       Clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_90:
@@ -9542,7 +9542,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_90
-    pretty_name: 'CKV_GCP_90: Ensure data flow jobs are encrypted with Customer Supplied
+    pretty_name: 'Ensure data flow jobs are encrypted with Customer Supplied
       Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_91:
@@ -9552,7 +9552,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_91
-    pretty_name: 'CKV_GCP_91: Ensure Dataproc cluster is encrypted with Customer Supplied
+    pretty_name: 'Ensure Dataproc cluster is encrypted with Customer Supplied
       Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_92:
@@ -9562,7 +9562,7 @@ rules:
     description: Check that ensures best practices in Google Cloud secrets management.
     group: cloud-weak-secrets-management
     name: CKV_GCP_92
-    pretty_name: 'CKV_GCP_92: Ensure Vertex AI datasets uses a CMK (Customer Manager
+    pretty_name: 'Ensure Vertex AI datasets uses a CMK (Customer Manager
       Key)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_93:
@@ -9572,7 +9572,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_93
-    pretty_name: 'CKV_GCP_93: Ensure Spanner Database is encrypted with Customer Supplied
+    pretty_name: 'Ensure Spanner Database is encrypted with Customer Supplied
       Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_94:
@@ -9584,7 +9584,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_94
-    pretty_name: 'CKV_GCP_94: Ensure Dataflow jobs are private'
+    pretty_name: 'Ensure Dataflow jobs are private'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_95:
     categories:
@@ -9595,7 +9595,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_95
-    pretty_name: 'CKV_GCP_95: Ensure Memorystore for Redis has AUTH enabled'
+    pretty_name: 'Ensure Memorystore for Redis has AUTH enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_96:
     categories:
@@ -9604,7 +9604,7 @@ rules:
     description: Check that ensures best practices in Google Cloud secrets management.
     group: cloud-weak-secrets-management
     name: CKV_GCP_96
-    pretty_name: 'CKV_GCP_96: Ensure Vertex AI Metadata Store uses a CMK (Customer
+    pretty_name: 'Ensure Vertex AI Metadata Store uses a CMK (Customer
       Manager Key)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_97:
@@ -9614,7 +9614,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_97
-    pretty_name: 'CKV_GCP_97: Ensure Memorystore for Redis uses intransit encryption'
+    pretty_name: 'Ensure Memorystore for Redis uses intransit encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_98:
     categories:
@@ -9625,7 +9625,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_98
-    pretty_name: 'CKV_GCP_98: Ensure that Dataproc clusters are not anonymously or
+    pretty_name: 'Ensure that Dataproc clusters are not anonymously or
       publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_99:
@@ -9637,7 +9637,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_99
-    pretty_name: 'CKV_GCP_99: Ensure that Pub/Sub Topics are not anonymously or publicly
+    pretty_name: 'Ensure that Pub/Sub Topics are not anonymously or publicly
       accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GHA_1:
@@ -9649,7 +9649,7 @@ rules:
     description: Check for weak GitHub Action configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_GHA_1
-    pretty_name: 'CKV_GHA_1: Ensure ACTIONS_ALLOW_UNSECURE_COMMANDS isn''t true on
+    pretty_name: 'Ensure ACTIONS_ALLOW_UNSECURE_COMMANDS isn''t true on
       environment variables'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GHA_2:
@@ -9661,7 +9661,7 @@ rules:
     description: Check for weak GitHub Action configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_GHA_2
-    pretty_name: 'CKV_GHA_2: Ensure run commands are not vulnerable to shell injection'
+    pretty_name: 'Ensure run commands are not vulnerable to shell injection'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GHA_3:
     categories:
@@ -9672,7 +9672,7 @@ rules:
     description: Check for weak GitHub Action configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_GHA_3
-    pretty_name: 'CKV_GHA_3: Suspicious use of curl with secrets'
+    pretty_name: 'Suspicious use of curl with secrets'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GHA_4:
     categories:
@@ -9683,7 +9683,7 @@ rules:
     description: Check for weak GitHub Action configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_GHA_4
-    pretty_name: 'CKV_GHA_4: Suspicious use of netcat with IP address'
+    pretty_name: 'Suspicious use of netcat with IP address'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GHA_5:
     categories:
@@ -9692,7 +9692,7 @@ rules:
     description: Check for weak GitHub Action configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_GHA_5
-    pretty_name: 'CKV_GHA_5: Found artifact build without evidence of cosign sign
+    pretty_name: 'Found artifact build without evidence of cosign sign
       execution in pipeline'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GHA_6:
@@ -9702,7 +9702,7 @@ rules:
     description: Check for weak GitHub Action configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_GHA_6
-    pretty_name: 'CKV_GHA_6: Found artifact build without evidence of cosign sbom
+    pretty_name: 'Found artifact build without evidence of cosign sbom
       attestation in pipeline'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GHA_7:
@@ -9712,7 +9712,7 @@ rules:
     description: Check for weak GitHub Action configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_GHA_7
-    pretty_name: 'CKV_GHA_7: The build output cannot be affected by user parameters
+    pretty_name: 'The build output cannot be affected by user parameters
       other than the build entry point and the top-level source location. GitHub Actions
       workflow_dispatch inputs MUST be empty. '
     ref: https://www.checkov.io/5.Policy%20Index/all.html
@@ -9725,7 +9725,7 @@ rules:
     description: Check for misconfigurations in GitHub resources.
     group: cloud-weak-configuration
     name: CKV_GITHUB_1
-    pretty_name: 'CKV_GITHUB_1: Ensure GitHub organization security settings require
+    pretty_name: 'Ensure GitHub organization security settings require
       2FA'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITHUB_10:
@@ -9737,7 +9737,7 @@ rules:
     description: Check for weak GitHub configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_GITHUB_10
-    pretty_name: 'CKV_GITHUB_10: Ensure branch protection rules are enforced on administrators'
+    pretty_name: 'Ensure branch protection rules are enforced on administrators'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITHUB_2:
     categories:
@@ -9746,7 +9746,7 @@ rules:
     description: Check for misconfigurations in GitHub resources.
     group: cloud-weak-configuration
     name: CKV_GITHUB_2
-    pretty_name: 'CKV_GITHUB_2: Ensure GitHub organization security settings require
+    pretty_name: 'Ensure GitHub organization security settings require
       SSO'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITHUB_3:
@@ -9756,7 +9756,7 @@ rules:
     description: Check for misconfigurations in GitHub resources.
     group: cloud-weak-configuration
     name: CKV_GITHUB_3
-    pretty_name: 'CKV_GITHUB_3: Ensure GitHub organization security settings has IP
+    pretty_name: 'Ensure GitHub organization security settings has IP
       allow list enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITHUB_4:
@@ -9767,7 +9767,7 @@ rules:
     description: Check for weak GitHub configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GITHUB_4
-    pretty_name: 'CKV_GITHUB_4: Ensure GitHub branch protection rules requires signed
+    pretty_name: 'Ensure GitHub branch protection rules requires signed
       commits'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITHUB_5:
@@ -9779,7 +9779,7 @@ rules:
     description: Check for weak GitHub configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GITHUB_5
-    pretty_name: 'CKV_GITHUB_5: Ensure GitHub branch protection rules does not allow
+    pretty_name: 'Ensure GitHub branch protection rules does not allow
       force pushes'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITHUB_6:
@@ -9791,7 +9791,7 @@ rules:
     description: Check for unencrypted GitHub resources.
     group: cloud-unencrypted-resources
     name: CKV_GITHUB_6
-    pretty_name: 'CKV_GITHUB_6: Ensure GitHub organization webhooks are using HTTPS'
+    pretty_name: 'Ensure GitHub organization webhooks are using HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITHUB_7:
     categories:
@@ -9802,7 +9802,7 @@ rules:
     description: Check for unencrypted GitHub resources.
     group: cloud-unencrypted-resources
     name: CKV_GITHUB_7
-    pretty_name: 'CKV_GITHUB_7: Ensure GitHub repository webhooks are using HTTPS'
+    pretty_name: 'Ensure GitHub repository webhooks are using HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITHUB_8:
     categories:
@@ -9812,7 +9812,7 @@ rules:
     description: Check for weak GitHub configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GITHUB_8
-    pretty_name: 'CKV_GITHUB_8: Ensure GitHub branch protection rules requires linear
+    pretty_name: 'Ensure GitHub branch protection rules requires linear
       history'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITHUB_9:
@@ -9822,7 +9822,7 @@ rules:
     description: Check for weak GitHub configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GITHUB_9
-    pretty_name: 'CKV_GITHUB_9: Ensure 2 admins are set for each repository'
+    pretty_name: 'Ensure 2 admins are set for each repository'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITLABCI_1:
     categories:
@@ -9833,7 +9833,7 @@ rules:
     description: Check for weak GitLab CI configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_GITLABCI_1
-    pretty_name: 'CKV_GITLABCI_1: Suspicious use of curl with CI environment variables
+    pretty_name: 'Suspicious use of curl with CI environment variables
       in script'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITLABCI_2:
@@ -9845,7 +9845,7 @@ rules:
     description: Check for misconfigurations in GitLab CI resources.
     group: cloud-weak-configuration
     name: CKV_GITLABCI_2
-    pretty_name: 'CKV_GITLABCI_2: Avoid creating rules that generate double pipelines'
+    pretty_name: 'Avoid creating rules that generate double pipelines'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITLABCI_3:
     categories:
@@ -9854,7 +9854,7 @@ rules:
     description: Check for weak GitLab CI configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_GITLABCI_3
-    pretty_name: 'CKV_GITLABCI_3: Detecting image usages in gitlab workflows'
+    pretty_name: 'Detecting image usages in gitlab workflows'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITLAB_1:
     categories:
@@ -9863,7 +9863,7 @@ rules:
     description: Check for weak GitLab configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GITLAB_1
-    pretty_name: 'CKV_GITLAB_1: Merge requests should require at least 2 approvals'
+    pretty_name: 'Merge requests should require at least 2 approvals'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITLAB_2:
     categories:
@@ -9874,7 +9874,7 @@ rules:
     description: Check for weak GitLab configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GITLAB_2
-    pretty_name: 'CKV_GITLAB_2: Ensure all Gitlab groups require two factor authentication'
+    pretty_name: 'Ensure all Gitlab groups require two factor authentication'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GIT_1:
     categories:
@@ -9883,7 +9883,7 @@ rules:
     description: Check for publicly accessible GitHub resources.
     group: cloud-resources-public-access
     name: CKV_GIT_1
-    pretty_name: 'CKV_GIT_1: Ensure GitHub repository is Private'
+    pretty_name: 'Ensure GitHub repository is Private'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GIT_2:
     categories:
@@ -9894,7 +9894,7 @@ rules:
     description: Check for unencrypted GitHub resources.
     group: cloud-unencrypted-resources
     name: CKV_GIT_2
-    pretty_name: 'CKV_GIT_2: Ensure GitHub repository webhooks are using HTTPS'
+    pretty_name: 'Ensure GitHub repository webhooks are using HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GIT_3:
     categories:
@@ -9905,7 +9905,7 @@ rules:
     description: Check for weak GitHub configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_GIT_3
-    pretty_name: 'CKV_GIT_3: Ensure GitHub repository has vulnerability alerts enabled'
+    pretty_name: 'Ensure GitHub repository has vulnerability alerts enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GIT_4:
     categories:
@@ -9916,7 +9916,7 @@ rules:
     description: Check for unencrypted GitHub resources.
     group: cloud-unencrypted-resources
     name: CKV_GIT_4
-    pretty_name: 'CKV_GIT_4: Ensure GitHub Actions secrets are encrypted'
+    pretty_name: 'Ensure GitHub Actions secrets are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GIT_5:
     categories:
@@ -9925,7 +9925,7 @@ rules:
     description: Check for weak GitHub configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GIT_5
-    pretty_name: 'CKV_GIT_5: GitHub pull requests should require at least 2 approvals'
+    pretty_name: 'GitHub pull requests should require at least 2 approvals'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GIT_6:
     categories:
@@ -9935,7 +9935,7 @@ rules:
     description: Check for weak GitHub configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GIT_6
-    pretty_name: 'CKV_GIT_6: Ensure GitHub branch protection rules requires signed
+    pretty_name: 'Ensure GitHub branch protection rules requires signed
       commits'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GLB_1:
@@ -9945,7 +9945,7 @@ rules:
     description: Check for weak GitLab configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GLB_1
-    pretty_name: 'CKV_GLB_1: Ensure at least two approving reviews are required to
+    pretty_name: 'Ensure at least two approving reviews are required to
       merge a GitLab MR'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GLB_2:
@@ -9957,7 +9957,7 @@ rules:
     description: Check for weak GitLab configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GLB_2
-    pretty_name: 'CKV_GLB_2: Ensure GitLab branch protection rules does not allow
+    pretty_name: 'Ensure GitLab branch protection rules does not allow
       force pushes'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GLB_3:
@@ -9969,7 +9969,7 @@ rules:
     description: Check for weak GitLab configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GLB_3
-    pretty_name: 'CKV_GLB_3: Ensure GitLab prevent secrets is enabled'
+    pretty_name: 'Ensure GitLab prevent secrets is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GLB_4:
     categories:
@@ -9979,7 +9979,7 @@ rules:
     description: Check for weak GitLab configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GLB_4
-    pretty_name: 'CKV_GLB_4: Ensure GitLab commits are signed'
+    pretty_name: 'Ensure GitLab commits are signed'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_1:
     categories:
@@ -9990,7 +9990,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_1
-    pretty_name: 'CKV_K8S_1: Do not admit containers wishing to share the host process
+    pretty_name: 'Do not admit containers wishing to share the host process
       ID namespace'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_10:
@@ -10001,7 +10001,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_10
-    pretty_name: 'CKV_K8S_10: CPU requests should be set'
+    pretty_name: 'CPU requests should be set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_100:
     categories:
@@ -10012,7 +10012,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_100
-    pretty_name: 'CKV_K8S_100: Ensure that the --tls-cert-file and --tls-private-key-file
+    pretty_name: 'Ensure that the --tls-cert-file and --tls-private-key-file
       arguments are set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_102:
@@ -10024,7 +10024,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_102
-    pretty_name: 'CKV_K8S_102: Ensure that the --etcd-cafile argument is set as appropriate'
+    pretty_name: 'Ensure that the --etcd-cafile argument is set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_104:
     categories:
@@ -10035,7 +10035,7 @@ rules:
     description: Check for unencrypted Kubernetes resources.
     group: cloud-unencrypted-resources
     name: CKV_K8S_104
-    pretty_name: 'CKV_K8S_104: Ensure that encryption providers are appropriately
+    pretty_name: 'Ensure that encryption providers are appropriately
       configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_105:
@@ -10047,7 +10047,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_105
-    pretty_name: 'CKV_K8S_105: Ensure that the API Server only makes use of Strong
+    pretty_name: 'Ensure that the API Server only makes use of Strong
       Cryptographic Ciphers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_106:
@@ -10059,7 +10059,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_106
-    pretty_name: 'CKV_K8S_106: Ensure that the --terminated-pod-gc-threshold argument
+    pretty_name: 'Ensure that the --terminated-pod-gc-threshold argument
       is set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_107:
@@ -10071,7 +10071,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_107
-    pretty_name: 'CKV_K8S_107: Ensure that the --profiling argument is set to false'
+    pretty_name: 'Ensure that the --profiling argument is set to false'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_108:
     categories:
@@ -10082,7 +10082,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_108
-    pretty_name: 'CKV_K8S_108: Ensure that the --use-service-account-credentials argument
+    pretty_name: 'Ensure that the --use-service-account-credentials argument
       is set to true'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_11:
@@ -10093,7 +10093,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_11
-    pretty_name: 'CKV_K8S_11: CPU Limits should be set'
+    pretty_name: 'CPU Limits should be set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_110:
     categories:
@@ -10104,7 +10104,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_110
-    pretty_name: 'CKV_K8S_110: Ensure that the --service-account-private-key-file
+    pretty_name: 'Ensure that the --service-account-private-key-file
       argument is set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_111:
@@ -10116,7 +10116,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_111
-    pretty_name: 'CKV_K8S_111: Ensure that the --root-ca-file argument is set as appropriate'
+    pretty_name: 'Ensure that the --root-ca-file argument is set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_112:
     categories:
@@ -10127,7 +10127,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_112
-    pretty_name: 'CKV_K8S_112: Ensure that the RotateKubeletServerCertificate argument
+    pretty_name: 'Ensure that the RotateKubeletServerCertificate argument
       is set to true'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_113:
@@ -10139,7 +10139,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_113
-    pretty_name: 'CKV_K8S_113: Ensure that the --bind-address argument is set to 127.0.0.1'
+    pretty_name: 'Ensure that the --bind-address argument is set to 127.0.0.1'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_114:
     categories:
@@ -10150,7 +10150,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_114
-    pretty_name: 'CKV_K8S_114: Ensure that the --profiling argument is set to false'
+    pretty_name: 'Ensure that the --profiling argument is set to false'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_115:
     categories:
@@ -10161,7 +10161,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_115
-    pretty_name: 'CKV_K8S_115: Ensure that the --bind-address argument is set to 127.0.0.1'
+    pretty_name: 'Ensure that the --bind-address argument is set to 127.0.0.1'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_116:
     categories:
@@ -10172,7 +10172,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_116
-    pretty_name: 'CKV_K8S_116: Ensure that the --cert-file and --key-file arguments
+    pretty_name: 'Ensure that the --cert-file and --key-file arguments
       are set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_117:
@@ -10184,7 +10184,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_117
-    pretty_name: 'CKV_K8S_117: Ensure that the --client-cert-auth argument is set
+    pretty_name: 'Ensure that the --client-cert-auth argument is set
       to true'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_118:
@@ -10196,7 +10196,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_118
-    pretty_name: 'CKV_K8S_118: Ensure that the --auto-tls argument is not set to true'
+    pretty_name: 'Ensure that the --auto-tls argument is not set to true'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_119:
     categories:
@@ -10207,7 +10207,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_119
-    pretty_name: 'CKV_K8S_119: Ensure that the --peer-cert-file and --peer-key-file
+    pretty_name: 'Ensure that the --peer-cert-file and --peer-key-file
       arguments are set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_12:
@@ -10218,7 +10218,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_12
-    pretty_name: 'CKV_K8S_12: Memory Limits should be set'
+    pretty_name: 'Memory Limits should be set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_121:
     categories:
@@ -10229,7 +10229,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_121
-    pretty_name: 'CKV_K8S_121: Ensure that the --peer-client-cert-auth argument is
+    pretty_name: 'Ensure that the --peer-client-cert-auth argument is
       set to true'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_13:
@@ -10240,7 +10240,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_13
-    pretty_name: 'CKV_K8S_13: Memory requests should be set'
+    pretty_name: 'Memory requests should be set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_138:
     categories:
@@ -10251,7 +10251,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_138
-    pretty_name: 'CKV_K8S_138: Ensure that the --anonymous-auth argument is set to
+    pretty_name: 'Ensure that the --anonymous-auth argument is set to
       false'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_139:
@@ -10263,7 +10263,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_139
-    pretty_name: 'CKV_K8S_139: Ensure that the --authorization-mode argument is not
+    pretty_name: 'Ensure that the --authorization-mode argument is not
       set to AlwaysAllow'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_14:
@@ -10274,7 +10274,7 @@ rules:
     description: Check for weak Kubernetes configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_K8S_14
-    pretty_name: 'CKV_K8S_14: Image Tag should be fixed - not latest or blank'
+    pretty_name: 'Image Tag should be fixed - not latest or blank'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_140:
     categories:
@@ -10285,7 +10285,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_140
-    pretty_name: 'CKV_K8S_140: Ensure that the --client-ca-file argument is set as
+    pretty_name: 'Ensure that the --client-ca-file argument is set as
       appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_141:
@@ -10297,7 +10297,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_141
-    pretty_name: 'CKV_K8S_141: Ensure that the --read-only-port argument is set to
+    pretty_name: 'Ensure that the --read-only-port argument is set to
       0'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_143:
@@ -10309,7 +10309,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_143
-    pretty_name: 'CKV_K8S_143: Ensure that the --streaming-connection-idle-timeout
+    pretty_name: 'Ensure that the --streaming-connection-idle-timeout
       argument is not set to 0'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_144:
@@ -10321,7 +10321,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_144
-    pretty_name: 'CKV_K8S_144: Ensure that the --protect-kernel-defaults argument
+    pretty_name: 'Ensure that the --protect-kernel-defaults argument
       is set to true'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_145:
@@ -10333,7 +10333,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_145
-    pretty_name: 'CKV_K8S_145: Ensure that the --make-iptables-util-chains argument
+    pretty_name: 'Ensure that the --make-iptables-util-chains argument
       is set to true'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_146:
@@ -10345,7 +10345,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_146
-    pretty_name: 'CKV_K8S_146: Ensure that the --hostname-override argument is not
+    pretty_name: 'Ensure that the --hostname-override argument is not
       set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_147:
@@ -10357,7 +10357,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_147
-    pretty_name: 'CKV_K8S_147: Ensure that the --event-qps argument is set to 0 or
+    pretty_name: 'Ensure that the --event-qps argument is set to 0 or
       a level which ensures appropriate event capture'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_148:
@@ -10369,7 +10369,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_148
-    pretty_name: 'CKV_K8S_148: Ensure that the --tls-cert-file and --tls-private-key-file
+    pretty_name: 'Ensure that the --tls-cert-file and --tls-private-key-file
       arguments are set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_149:
@@ -10381,7 +10381,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_149
-    pretty_name: 'CKV_K8S_149: Ensure that the --rotate-certificates argument is not
+    pretty_name: 'Ensure that the --rotate-certificates argument is not
       set to false'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_15:
@@ -10392,7 +10392,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_15
-    pretty_name: 'CKV_K8S_15: Image Pull Policy should be Always'
+    pretty_name: 'Image Pull Policy should be Always'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_151:
     categories:
@@ -10403,7 +10403,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_151
-    pretty_name: 'CKV_K8S_151: Ensure that the Kubelet only makes use of Strong Cryptographic
+    pretty_name: 'Ensure that the Kubelet only makes use of Strong Cryptographic
       Ciphers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_152:
@@ -10415,7 +10415,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_152
-    pretty_name: 'CKV_K8S_152: Prevent NGINX Ingress annotation snippets which contain
+    pretty_name: 'Prevent NGINX Ingress annotation snippets which contain
       LUA code execution. See CVE-2021-25742'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_153:
@@ -10427,7 +10427,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_153
-    pretty_name: 'CKV_K8S_153: Prevent All NGINX Ingress annotation snippets. See
+    pretty_name: 'Prevent All NGINX Ingress annotation snippets. See
       CVE-2021-25742'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_154:
@@ -10439,7 +10439,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_154
-    pretty_name: 'CKV_K8S_154: Prevent NGINX Ingress annotation snippets which contain
+    pretty_name: 'Prevent NGINX Ingress annotation snippets which contain
       alias statements See CVE-2021-25742'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_155:
@@ -10451,7 +10451,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV_K8S_155
-    pretty_name: 'CKV_K8S_155: Minimize ClusterRoles that grant control over validating
+    pretty_name: 'Minimize ClusterRoles that grant control over validating
       or mutating admission webhook configurations'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_156:
@@ -10463,7 +10463,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV_K8S_156
-    pretty_name: 'CKV_K8S_156: Minimize ClusterRoles that grant permissions to approve
+    pretty_name: 'Minimize ClusterRoles that grant permissions to approve
       CertificateSigningRequests'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_157:
@@ -10475,7 +10475,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV_K8S_157
-    pretty_name: 'CKV_K8S_157: Minimize Roles and ClusterRoles that grant permissions
+    pretty_name: 'Minimize Roles and ClusterRoles that grant permissions
       to bind RoleBindings or ClusterRoleBindings'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_158:
@@ -10487,7 +10487,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV_K8S_158
-    pretty_name: 'CKV_K8S_158: Minimize Roles and ClusterRoles that grant permissions
+    pretty_name: 'Minimize Roles and ClusterRoles that grant permissions
       to escalate Roles or ClusterRoles'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_16:
@@ -10499,7 +10499,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_16
-    pretty_name: 'CKV_K8S_16: Do not admit privileged containers'
+    pretty_name: 'Do not admit privileged containers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_17:
     categories:
@@ -10510,7 +10510,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_17
-    pretty_name: 'CKV_K8S_17: Do not admit containers wishing to share the host process
+    pretty_name: 'Do not admit containers wishing to share the host process
       ID namespace'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_18:
@@ -10522,7 +10522,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_18
-    pretty_name: 'CKV_K8S_18: Do not admit containers wishing to share the host IPC
+    pretty_name: 'Do not admit containers wishing to share the host IPC
       namespace'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_19:
@@ -10534,7 +10534,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_19
-    pretty_name: 'CKV_K8S_19: Do not admit containers wishing to share the host network
+    pretty_name: 'Do not admit containers wishing to share the host network
       namespace'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_2:
@@ -10546,7 +10546,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_2
-    pretty_name: 'CKV_K8S_2: Do not admit privileged containers'
+    pretty_name: 'Do not admit privileged containers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_20:
     categories:
@@ -10557,7 +10557,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_20
-    pretty_name: 'CKV_K8S_20: Containers should not run with allowPrivilegeEscalation'
+    pretty_name: 'Containers should not run with allowPrivilegeEscalation'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_21:
     categories:
@@ -10567,7 +10567,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_21
-    pretty_name: 'CKV_K8S_21: The default namespace should not be used'
+    pretty_name: 'The default namespace should not be used'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_22:
     categories:
@@ -10576,7 +10576,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_22
-    pretty_name: 'CKV_K8S_22: Use read-only filesystem for containers where possible'
+    pretty_name: 'Use read-only filesystem for containers where possible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_23:
     categories:
@@ -10586,7 +10586,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_23
-    pretty_name: 'CKV_K8S_23: Minimize the admission of root containers'
+    pretty_name: 'Minimize the admission of root containers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_24:
     categories:
@@ -10597,7 +10597,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_24
-    pretty_name: 'CKV_K8S_24: Do not allow containers with added capability'
+    pretty_name: 'Do not allow containers with added capability'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_25:
     categories:
@@ -10608,7 +10608,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_25
-    pretty_name: 'CKV_K8S_25: Minimize the admission of containers with added capability'
+    pretty_name: 'Minimize the admission of containers with added capability'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_26:
     categories:
@@ -10619,7 +10619,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_26
-    pretty_name: 'CKV_K8S_26: Do not specify hostPort unless absolutely necessary'
+    pretty_name: 'Do not specify hostPort unless absolutely necessary'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_27:
     categories:
@@ -10630,7 +10630,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_27
-    pretty_name: 'CKV_K8S_27: Do not expose the docker daemon socket to containers'
+    pretty_name: 'Do not expose the docker daemon socket to containers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_28:
     categories:
@@ -10641,7 +10641,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_28
-    pretty_name: 'CKV_K8S_28: Minimize the admission of containers with the NET_RAW
+    pretty_name: 'Minimize the admission of containers with the NET_RAW
       capability'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_29:
@@ -10652,7 +10652,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_29
-    pretty_name: 'CKV_K8S_29: Apply security context to your pods and containers'
+    pretty_name: 'Apply security context to your pods and containers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_3:
     categories:
@@ -10663,7 +10663,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_3
-    pretty_name: 'CKV_K8S_3: Do not admit containers wishing to share the host IPC
+    pretty_name: 'Do not admit containers wishing to share the host IPC
       namespace'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_30:
@@ -10674,7 +10674,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_30
-    pretty_name: 'CKV_K8S_30: Apply security context to your pods and containers'
+    pretty_name: 'Apply security context to your pods and containers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_31:
     categories:
@@ -10684,7 +10684,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_31
-    pretty_name: 'CKV_K8S_31: Ensure that the seccomp profile is set to docker/default
+    pretty_name: 'Ensure that the seccomp profile is set to docker/default
       or runtime/default'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_32:
@@ -10695,7 +10695,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_32
-    pretty_name: 'CKV_K8S_32: Ensure default seccomp profile set to docker/default
+    pretty_name: 'Ensure default seccomp profile set to docker/default
       or runtime/default'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_33:
@@ -10707,7 +10707,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_33
-    pretty_name: 'CKV_K8S_33: Ensure the Kubernetes dashboard is not deployed'
+    pretty_name: 'Ensure the Kubernetes dashboard is not deployed'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_34:
     categories:
@@ -10718,7 +10718,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_34
-    pretty_name: 'CKV_K8S_34: Ensure that Tiller (Helm v2) is not deployed'
+    pretty_name: 'Ensure that Tiller (Helm v2) is not deployed'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_35:
     categories:
@@ -10727,7 +10727,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_35
-    pretty_name: 'CKV_K8S_35: Prefer using secrets as files over secrets as environment
+    pretty_name: 'Prefer using secrets as files over secrets as environment
       variables'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_36:
@@ -10739,7 +10739,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_36
-    pretty_name: 'CKV_K8S_36: Minimise the admission of containers with capabilities
+    pretty_name: 'Minimise the admission of containers with capabilities
       assigned'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_37:
@@ -10751,7 +10751,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_37
-    pretty_name: 'CKV_K8S_37: Minimise the admission of containers with capabilities
+    pretty_name: 'Minimise the admission of containers with capabilities
       assigned'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_38:
@@ -10762,7 +10762,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_38
-    pretty_name: 'CKV_K8S_38: Ensure that Service Account Tokens are only mounted
+    pretty_name: 'Ensure that Service Account Tokens are only mounted
       where necessary'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_39:
@@ -10774,7 +10774,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_39
-    pretty_name: 'CKV_K8S_39: Do not use the CAP_SYS_ADMIN linux capability'
+    pretty_name: 'Do not use the CAP_SYS_ADMIN linux capability'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_4:
     categories:
@@ -10785,7 +10785,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_4
-    pretty_name: 'CKV_K8S_4: Do not admit containers wishing to share the host network
+    pretty_name: 'Do not admit containers wishing to share the host network
       namespace'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_40:
@@ -10796,7 +10796,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_40
-    pretty_name: 'CKV_K8S_40: Containers should run as a high UID to avoid host conflict'
+    pretty_name: 'Containers should run as a high UID to avoid host conflict'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_41:
     categories:
@@ -10807,7 +10807,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV_K8S_41
-    pretty_name: 'CKV_K8S_41: Ensure that default service accounts are not actively
+    pretty_name: 'Ensure that default service accounts are not actively
       used'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_42:
@@ -10819,7 +10819,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV_K8S_42
-    pretty_name: 'CKV_K8S_42: Ensure that default service accounts are not actively
+    pretty_name: 'Ensure that default service accounts are not actively
       used'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_43:
@@ -10830,7 +10830,7 @@ rules:
     description: Check for weak Kubernetes configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_K8S_43
-    pretty_name: 'CKV_K8S_43: Image should use digest'
+    pretty_name: 'Image should use digest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_44:
     categories:
@@ -10841,7 +10841,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_44
-    pretty_name: 'CKV_K8S_44: Ensure that the Tiller Service (Helm v2) is deleted'
+    pretty_name: 'Ensure that the Tiller Service (Helm v2) is deleted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_45:
     categories:
@@ -10852,7 +10852,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_45
-    pretty_name: 'CKV_K8S_45: Ensure the Tiller Deployment (Helm V2) is not accessible
+    pretty_name: 'Ensure the Tiller Deployment (Helm V2) is not accessible
       from within the cluster'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_49:
@@ -10864,7 +10864,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_49
-    pretty_name: 'CKV_K8S_49: Minimize wildcard use in Roles and ClusterRoles'
+    pretty_name: 'Minimize wildcard use in Roles and ClusterRoles'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_5:
     categories:
@@ -10875,7 +10875,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_5
-    pretty_name: 'CKV_K8S_5: Containers should not run with allowPrivilegeEscalation'
+    pretty_name: 'Containers should not run with allowPrivilegeEscalation'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_6:
     categories:
@@ -10886,7 +10886,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_6
-    pretty_name: 'CKV_K8S_6: Do not admit root containers'
+    pretty_name: 'Do not admit root containers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_68:
     categories:
@@ -10897,7 +10897,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_68
-    pretty_name: 'CKV_K8S_68: Ensure that the --anonymous-auth argument is set to
+    pretty_name: 'Ensure that the --anonymous-auth argument is set to
       false'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_69:
@@ -10909,7 +10909,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_69
-    pretty_name: 'CKV_K8S_69: Ensure that the --basic-auth-file argument is not set'
+    pretty_name: 'Ensure that the --basic-auth-file argument is not set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_7:
     categories:
@@ -10920,7 +10920,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_7
-    pretty_name: 'CKV_K8S_7: Do not admit containers with the NET_RAW capability'
+    pretty_name: 'Do not admit containers with the NET_RAW capability'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_70:
     categories:
@@ -10931,7 +10931,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_70
-    pretty_name: 'CKV_K8S_70: Ensure that the --token-auth-file argument is not set'
+    pretty_name: 'Ensure that the --token-auth-file argument is not set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_71:
     categories:
@@ -10942,7 +10942,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_71
-    pretty_name: 'CKV_K8S_71: Ensure that the --kubelet-https argument is set to true'
+    pretty_name: 'Ensure that the --kubelet-https argument is set to true'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_72:
     categories:
@@ -10953,7 +10953,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_72
-    pretty_name: 'CKV_K8S_72: Ensure that the --kubelet-client-certificate and --kubelet-client-key
+    pretty_name: 'Ensure that the --kubelet-client-certificate and --kubelet-client-key
       arguments are set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_73:
@@ -10965,7 +10965,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_73
-    pretty_name: 'CKV_K8S_73: Ensure that the --kubelet-certificate-authority argument
+    pretty_name: 'Ensure that the --kubelet-certificate-authority argument
       is set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_74:
@@ -10977,7 +10977,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_74
-    pretty_name: 'CKV_K8S_74: Ensure that the --authorization-mode argument is not
+    pretty_name: 'Ensure that the --authorization-mode argument is not
       set to AlwaysAllow'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_75:
@@ -10989,7 +10989,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_75
-    pretty_name: 'CKV_K8S_75: Ensure that the --authorization-mode argument includes
+    pretty_name: 'Ensure that the --authorization-mode argument includes
       Node'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_77:
@@ -11001,7 +11001,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_77
-    pretty_name: 'CKV_K8S_77: Ensure that the --authorization-mode argument includes
+    pretty_name: 'Ensure that the --authorization-mode argument includes
       RBAC'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_78:
@@ -11011,7 +11011,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_78
-    pretty_name: 'CKV_K8S_78: Ensure that the admission control plugin EventRateLimit
+    pretty_name: 'Ensure that the admission control plugin EventRateLimit
       is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_79:
@@ -11023,7 +11023,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_79
-    pretty_name: 'CKV_K8S_79: Ensure that the admission control plugin AlwaysAdmit
+    pretty_name: 'Ensure that the admission control plugin AlwaysAdmit
       is not set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_8:
@@ -11034,7 +11034,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_8
-    pretty_name: 'CKV_K8S_8: Liveness Probe Should be Configured'
+    pretty_name: 'Liveness Probe Should be Configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_80:
     categories:
@@ -11044,7 +11044,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_80
-    pretty_name: 'CKV_K8S_80: Ensure that the admission control plugin AlwaysPullImages
+    pretty_name: 'Ensure that the admission control plugin AlwaysPullImages
       is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_81:
@@ -11055,7 +11055,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_81
-    pretty_name: 'CKV_K8S_81: Ensure that the admission control plugin SecurityContextDeny
+    pretty_name: 'Ensure that the admission control plugin SecurityContextDeny
       is set if PodSecurityPolicy is not used'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_82:
@@ -11066,7 +11066,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_82
-    pretty_name: 'CKV_K8S_82: Ensure that the admission control plugin ServiceAccount
+    pretty_name: 'Ensure that the admission control plugin ServiceAccount
       is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_83:
@@ -11077,7 +11077,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_83
-    pretty_name: 'CKV_K8S_83: Ensure that the admission control plugin NamespaceLifecycle
+    pretty_name: 'Ensure that the admission control plugin NamespaceLifecycle
       is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_84:
@@ -11088,7 +11088,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_84
-    pretty_name: 'CKV_K8S_84: Ensure that the admission control plugin PodSecurityPolicy
+    pretty_name: 'Ensure that the admission control plugin PodSecurityPolicy
       is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_85:
@@ -11099,7 +11099,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_85
-    pretty_name: 'CKV_K8S_85: Ensure that the admission control plugin NodeRestriction
+    pretty_name: 'Ensure that the admission control plugin NodeRestriction
       is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_86:
@@ -11111,7 +11111,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_86
-    pretty_name: 'CKV_K8S_86: Ensure that the --insecure-bind-address argument is
+    pretty_name: 'Ensure that the --insecure-bind-address argument is
       not set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_88:
@@ -11123,7 +11123,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_88
-    pretty_name: 'CKV_K8S_88: Ensure that the --insecure-port argument is set to 0'
+    pretty_name: 'Ensure that the --insecure-port argument is set to 0'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_89:
     categories:
@@ -11134,7 +11134,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_89
-    pretty_name: 'CKV_K8S_89: Ensure that the --secure-port argument is not set to
+    pretty_name: 'Ensure that the --secure-port argument is not set to
       0'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_9:
@@ -11145,7 +11145,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_9
-    pretty_name: 'CKV_K8S_9: Readiness Probe Should be Configured'
+    pretty_name: 'Readiness Probe Should be Configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_90:
     categories:
@@ -11156,7 +11156,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_90
-    pretty_name: 'CKV_K8S_90: Ensure that the --profiling argument is set to false'
+    pretty_name: 'Ensure that the --profiling argument is set to false'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_91:
     categories:
@@ -11167,7 +11167,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_91
-    pretty_name: 'CKV_K8S_91: Ensure that the --audit-log-path argument is set'
+    pretty_name: 'Ensure that the --audit-log-path argument is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_92:
     categories:
@@ -11178,7 +11178,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_92
-    pretty_name: 'CKV_K8S_92: Ensure that the --audit-log-maxage argument is set to
+    pretty_name: 'Ensure that the --audit-log-maxage argument is set to
       30 or as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_93:
@@ -11190,7 +11190,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_93
-    pretty_name: 'CKV_K8S_93: Ensure that the --audit-log-maxbackup argument is set
+    pretty_name: 'Ensure that the --audit-log-maxbackup argument is set
       to 10 or as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_94:
@@ -11202,7 +11202,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_94
-    pretty_name: 'CKV_K8S_94: Ensure that the --audit-log-maxsize argument is set
+    pretty_name: 'Ensure that the --audit-log-maxsize argument is set
       to 100 or as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_95:
@@ -11214,7 +11214,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_95
-    pretty_name: 'CKV_K8S_95: Ensure that the --request-timeout argument is set as
+    pretty_name: 'Ensure that the --request-timeout argument is set as
       appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_96:
@@ -11226,7 +11226,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_96
-    pretty_name: 'CKV_K8S_96: Ensure that the --service-account-lookup argument is
+    pretty_name: 'Ensure that the --service-account-lookup argument is
       set to true'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_97:
@@ -11238,7 +11238,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_97
-    pretty_name: 'CKV_K8S_97: Ensure that the --service-account-key-file argument
+    pretty_name: 'Ensure that the --service-account-key-file argument
       is set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_99:
@@ -11250,7 +11250,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_99
-    pretty_name: 'CKV_K8S_99: Ensure that the --etcd-certfile and --etcd-keyfile arguments
+    pretty_name: 'Ensure that the --etcd-certfile and --etcd-keyfile arguments
       are set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_LIN_1:
@@ -11262,7 +11262,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_LIN_1
-    pretty_name: 'CKV_LIN_1: Ensure no hard coded Linode tokens exist in provider'
+    pretty_name: 'Ensure no hard coded Linode tokens exist in provider'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_LIN_2:
     categories:
@@ -11273,7 +11273,7 @@ rules:
     description: Check for misconfigurations in Linode resources.
     group: cloud-weak-configuration
     name: CKV_LIN_2
-    pretty_name: 'CKV_LIN_2: Ensure SSH key set in authorized_keys'
+    pretty_name: 'Ensure SSH key set in authorized_keys'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_LIN_3:
     categories:
@@ -11284,7 +11284,7 @@ rules:
     description: Check for misconfigurations in Linode resources.
     group: cloud-weak-configuration
     name: CKV_LIN_3
-    pretty_name: 'CKV_LIN_3: Ensure email is set'
+    pretty_name: 'Ensure email is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_LIN_4:
     categories:
@@ -11295,7 +11295,7 @@ rules:
     description: Check for misconfigurations in Linode resources.
     group: cloud-weak-configuration
     name: CKV_LIN_4
-    pretty_name: 'CKV_LIN_4: Ensure username is set'
+    pretty_name: 'Ensure username is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_LIN_5:
     categories:
@@ -11306,7 +11306,7 @@ rules:
     description: Check for misconfigurations in Linode resources.
     group: cloud-weak-configuration
     name: CKV_LIN_5
-    pretty_name: 'CKV_LIN_5: Ensure Inbound Firewall Policy is not set to ACCEPT'
+    pretty_name: 'Ensure Inbound Firewall Policy is not set to ACCEPT'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_LIN_6:
     categories:
@@ -11317,7 +11317,7 @@ rules:
     description: Check for misconfigurations in Linode resources.
     group: cloud-weak-configuration
     name: CKV_LIN_6
-    pretty_name: 'CKV_LIN_6: Ensure Outbound Firewall Policy is not set to ACCEPT'
+    pretty_name: 'Ensure Outbound Firewall Policy is not set to ACCEPT'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_1:
     categories:
@@ -11327,7 +11327,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_1
-    pretty_name: 'CKV_NCP_1: Ensure HTTP HTTPS Target group defines Healthcheck'
+    pretty_name: 'Ensure HTTP HTTPS Target group defines Healthcheck'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_10:
     categories:
@@ -11338,7 +11338,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_10
-    pretty_name: 'CKV_NCP_10: Ensure no NACL allow inbound from 0.0.0.0:0 to port
+    pretty_name: 'Ensure no NACL allow inbound from 0.0.0.0:0 to port
       22'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_11:
@@ -11350,7 +11350,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_11
-    pretty_name: 'CKV_NCP_11: Ensure no NACL allow inbound from 0.0.0.0:0 to port
+    pretty_name: 'Ensure no NACL allow inbound from 0.0.0.0:0 to port
       3389'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_12:
@@ -11362,7 +11362,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_12
-    pretty_name: 'CKV_NCP_12: An inbound Network ACL rule should not allow ALL ports.'
+    pretty_name: 'An inbound Network ACL rule should not allow ALL ports.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_13:
     categories:
@@ -11373,7 +11373,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_13
-    pretty_name: 'CKV_NCP_13: Ensure LB Listener uses only secure protocols'
+    pretty_name: 'Ensure LB Listener uses only secure protocols'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_14:
     categories:
@@ -11383,7 +11383,7 @@ rules:
     description: Check for unencrypted Ncloud resources.
     group: cloud-unencrypted-resources
     name: CKV_NCP_14
-    pretty_name: 'CKV_NCP_14: Ensure NAS is securely encrypted'
+    pretty_name: 'Ensure NAS is securely encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_15:
     categories:
@@ -11394,7 +11394,7 @@ rules:
     description: Check for unencrypted Ncloud resources.
     group: cloud-unencrypted-resources
     name: CKV_NCP_15
-    pretty_name: 'CKV_NCP_15: Ensure Load Balancer Target Group is not using HTTP'
+    pretty_name: 'Ensure Load Balancer Target Group is not using HTTP'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_16:
     categories:
@@ -11405,7 +11405,7 @@ rules:
     description: Check for publicly accessible Ncloud resources.
     group: cloud-resources-public-access
     name: CKV_NCP_16
-    pretty_name: 'CKV_NCP_16: Ensure Load Balancer isn''t exposed to the internet'
+    pretty_name: 'Ensure Load Balancer isn''t exposed to the internet'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_19:
     categories:
@@ -11416,7 +11416,7 @@ rules:
     description: Check for publicly accessible Ncloud resources.
     group: cloud-resources-public-access
     name: CKV_NCP_19
-    pretty_name: 'CKV_NCP_19: Ensure Naver Kubernetes Service public endpoint disabled'
+    pretty_name: 'Ensure Naver Kubernetes Service public endpoint disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_2:
     categories:
@@ -11427,7 +11427,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_2
-    pretty_name: 'CKV_NCP_2: Ensure every access control groups rule has a description'
+    pretty_name: 'Ensure every access control groups rule has a description'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_20:
     categories:
@@ -11438,7 +11438,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_20
-    pretty_name: 'CKV_NCP_20: Ensure Routing Table associated with Web tier subnet
+    pretty_name: 'Ensure Routing Table associated with Web tier subnet
       have the default route (0.0.0.0/0) defined to allow connectivity'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_22:
@@ -11450,7 +11450,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_22
-    pretty_name: 'CKV_NCP_22: Ensure NKS control plane logging enabled for all log
+    pretty_name: 'Ensure NKS control plane logging enabled for all log
       types'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_23:
@@ -11462,7 +11462,7 @@ rules:
     description: Check for publicly accessible Ncloud resources.
     group: cloud-resources-public-access
     name: CKV_NCP_23
-    pretty_name: 'CKV_NCP_23: Ensure Server instance should not have public IP.'
+    pretty_name: 'Ensure Server instance should not have public IP.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_24:
     categories:
@@ -11473,7 +11473,7 @@ rules:
     description: Check for unencrypted Ncloud resources.
     group: cloud-unencrypted-resources
     name: CKV_NCP_24
-    pretty_name: 'CKV_NCP_24: Ensure Load Balancer Listener Using HTTPS'
+    pretty_name: 'Ensure Load Balancer Listener Using HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_25:
     categories:
@@ -11484,7 +11484,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_25
-    pretty_name: 'CKV_NCP_25: Ensure no access control groups allow inbound from 0.0.0.0:0
+    pretty_name: 'Ensure no access control groups allow inbound from 0.0.0.0:0
       to port 80'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_3:
@@ -11495,7 +11495,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_3
-    pretty_name: 'CKV_NCP_3: Ensure no security group rules allow outbound traffic
+    pretty_name: 'Ensure no security group rules allow outbound traffic
       to 0.0.0.0/0'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_4:
@@ -11507,7 +11507,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_4
-    pretty_name: 'CKV_NCP_4: Ensure no access control groups allow inbound from 0.0.0.0:0
+    pretty_name: 'Ensure no access control groups allow inbound from 0.0.0.0:0
       to port 22'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_5:
@@ -11519,7 +11519,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_5
-    pretty_name: 'CKV_NCP_5: Ensure no access control groups allow inbound from 0.0.0.0:0
+    pretty_name: 'Ensure no access control groups allow inbound from 0.0.0.0:0
       to port 3389'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_6:
@@ -11531,7 +11531,7 @@ rules:
     description: Check for unencrypted Ncloud resources.
     group: cloud-unencrypted-resources
     name: CKV_NCP_6
-    pretty_name: 'CKV_NCP_6: Ensure Server instance is encrypted.'
+    pretty_name: 'Ensure Server instance is encrypted.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_7:
     categories:
@@ -11541,7 +11541,7 @@ rules:
     description: Check for unencrypted Ncloud resources.
     group: cloud-unencrypted-resources
     name: CKV_NCP_7
-    pretty_name: 'CKV_NCP_7: Ensure Basic Block storage is encrypted.'
+    pretty_name: 'Ensure Basic Block storage is encrypted.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_8:
     categories:
@@ -11552,7 +11552,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_8
-    pretty_name: 'CKV_NCP_8: Ensure no NACL allow inbound from 0.0.0.0:0 to port 20'
+    pretty_name: 'Ensure no NACL allow inbound from 0.0.0.0:0 to port 20'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_9:
     categories:
@@ -11563,7 +11563,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_9
-    pretty_name: 'CKV_NCP_9: Ensure no NACL allow inbound from 0.0.0.0:0 to port 21'
+    pretty_name: 'Ensure no NACL allow inbound from 0.0.0.0:0 to port 21'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_1:
     categories:
@@ -11574,7 +11574,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_OCI_1
-    pretty_name: 'CKV_OCI_1: Ensure no hard coded OCI private key in provider'
+    pretty_name: 'Ensure no hard coded OCI private key in provider'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_10:
     categories:
@@ -11585,7 +11585,7 @@ rules:
     description: Check for publicly accessible Oracle Cloud Infrastructure resources.
     group: cloud-resources-public-access
     name: CKV_OCI_10
-    pretty_name: 'CKV_OCI_10: Ensure OCI Object Storage is not Public'
+    pretty_name: 'Ensure OCI Object Storage is not Public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_11:
     categories:
@@ -11596,7 +11596,7 @@ rules:
     description: Check for weak Oracle Cloud Infrastructure permissions.
     group: cloud-insecure-iam
     name: CKV_OCI_11
-    pretty_name: 'CKV_OCI_11: OCI IAM password policy - must contain lower case'
+    pretty_name: 'OCI IAM password policy - must contain lower case'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_12:
     categories:
@@ -11607,7 +11607,7 @@ rules:
     description: Check for weak Oracle Cloud Infrastructure permissions.
     group: cloud-insecure-iam
     name: CKV_OCI_12
-    pretty_name: 'CKV_OCI_12: OCI IAM password policy - must contain Numeric characters'
+    pretty_name: 'OCI IAM password policy - must contain Numeric characters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_13:
     categories:
@@ -11618,7 +11618,7 @@ rules:
     description: Check for weak Oracle Cloud Infrastructure permissions.
     group: cloud-insecure-iam
     name: CKV_OCI_13
-    pretty_name: 'CKV_OCI_13: OCI IAM password policy - must contain Special characters'
+    pretty_name: 'OCI IAM password policy - must contain Special characters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_14:
     categories:
@@ -11629,7 +11629,7 @@ rules:
     description: Check for weak Oracle Cloud Infrastructure permissions.
     group: cloud-insecure-iam
     name: CKV_OCI_14
-    pretty_name: 'CKV_OCI_14: OCI IAM password policy - must contain Uppercase characters'
+    pretty_name: 'OCI IAM password policy - must contain Uppercase characters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_15:
     categories:
@@ -11638,7 +11638,7 @@ rules:
     description: Check for unencrypted Oracle Cloud Infrastructure resources.
     group: cloud-unencrypted-resources
     name: CKV_OCI_15
-    pretty_name: 'CKV_OCI_15: Ensure OCI File System is Encrypted with a customer
+    pretty_name: 'Ensure OCI File System is Encrypted with a customer
       Managed Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_16:
@@ -11650,7 +11650,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_16
-    pretty_name: 'CKV_OCI_16: Ensure VCN has an inbound security list'
+    pretty_name: 'Ensure VCN has an inbound security list'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_17:
     categories:
@@ -11661,7 +11661,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_17
-    pretty_name: 'CKV_OCI_17: Ensure VCN inbound security lists are stateless'
+    pretty_name: 'Ensure VCN inbound security lists are stateless'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_18:
     categories:
@@ -11672,7 +11672,7 @@ rules:
     description: Check for weak Oracle Cloud Infrastructure permissions.
     group: cloud-insecure-iam
     name: CKV_OCI_18
-    pretty_name: 'CKV_OCI_18: OCI IAM password policy for local (non-federated) users
+    pretty_name: 'OCI IAM password policy for local (non-federated) users
       has a minimum length of 14 characters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_19:
@@ -11684,7 +11684,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_19
-    pretty_name: 'CKV_OCI_19: Ensure no security list allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security list allow ingress from 0.0.0.0:0
       to port 22.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_2:
@@ -11695,7 +11695,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_2
-    pretty_name: 'CKV_OCI_2: Ensure OCI Block Storage Block Volume has backup enabled'
+    pretty_name: 'Ensure OCI Block Storage Block Volume has backup enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_20:
     categories:
@@ -11706,7 +11706,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_20
-    pretty_name: 'CKV_OCI_20: Ensure no security list allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security list allow ingress from 0.0.0.0:0
       to port 3389.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_21:
@@ -11718,7 +11718,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_21
-    pretty_name: 'CKV_OCI_21: Ensure security group has stateless ingress security
+    pretty_name: 'Ensure security group has stateless ingress security
       rules'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_22:
@@ -11730,7 +11730,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_22
-    pretty_name: 'CKV_OCI_22: Ensure no security groups rules allow ingress from 0.0.0.0/0
+    pretty_name: 'Ensure no security groups rules allow ingress from 0.0.0.0/0
       to port 22'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_3:
@@ -11740,7 +11740,7 @@ rules:
     description: Check for unencrypted Oracle Cloud Infrastructure resources.
     group: cloud-unencrypted-resources
     name: CKV_OCI_3
-    pretty_name: 'CKV_OCI_3: OCI Block Storage Block Volumes are not encrypted with
+    pretty_name: 'OCI Block Storage Block Volumes are not encrypted with
       a Customer Managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_4:
@@ -11750,7 +11750,7 @@ rules:
     description: Check for unencrypted Oracle Cloud Infrastructure resources.
     group: cloud-unencrypted-resources
     name: CKV_OCI_4
-    pretty_name: 'CKV_OCI_4: Ensure OCI Compute Instance boot volume has in-transit
+    pretty_name: 'Ensure OCI Compute Instance boot volume has in-transit
       data encryption enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_5:
@@ -11762,7 +11762,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_5
-    pretty_name: 'CKV_OCI_5: Ensure OCI Compute Instance has Legacy MetaData service
+    pretty_name: 'Ensure OCI Compute Instance has Legacy MetaData service
       endpoint disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_6:
@@ -11774,7 +11774,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_6
-    pretty_name: 'CKV_OCI_6: Ensure OCI Compute Instance has monitoring enabled'
+    pretty_name: 'Ensure OCI Compute Instance has monitoring enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_7:
     categories:
@@ -11783,7 +11783,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_7
-    pretty_name: 'CKV_OCI_7: Ensure OCI Object Storage bucket can emit object events'
+    pretty_name: 'Ensure OCI Object Storage bucket can emit object events'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_8:
     categories:
@@ -11792,7 +11792,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_8
-    pretty_name: 'CKV_OCI_8: Ensure OCI Object Storage has versioning enabled'
+    pretty_name: 'Ensure OCI Object Storage has versioning enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_9:
     categories:
@@ -11801,7 +11801,7 @@ rules:
     description: Check for unencrypted Oracle Cloud Infrastructure resources.
     group: cloud-unencrypted-resources
     name: CKV_OCI_9
-    pretty_name: 'CKV_OCI_9: Ensure OCI Object Storage is encrypted with Customer
+    pretty_name: 'Ensure OCI Object Storage is encrypted with Customer
       Managed Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_1:
@@ -11813,7 +11813,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_1
-    pretty_name: 'CKV_OPENAPI_1: Ensure that securityDefinitions is defined and not
+    pretty_name: 'Ensure that securityDefinitions is defined and not
       empty - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_10:
@@ -11825,7 +11825,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_10
-    pretty_name: 'CKV_OPENAPI_10: Ensure that operation object does not use ''password''
+    pretty_name: 'Ensure that operation object does not use ''password''
       flow in OAuth2 authentication - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_11:
@@ -11837,7 +11837,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_11
-    pretty_name: 'CKV_OPENAPI_11: Ensure that operation object does not use ''password''
+    pretty_name: 'Ensure that operation object does not use ''password''
       flow in OAuth2 authentication - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_12:
@@ -11849,7 +11849,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_12
-    pretty_name: 'CKV_OPENAPI_12: Ensure no security definition is using implicit
+    pretty_name: 'Ensure no security definition is using implicit
       flow on OAuth2, which is deprecated - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_13:
@@ -11861,7 +11861,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_13
-    pretty_name: 'CKV_OPENAPI_13: Ensure security definitions do not use basic auth
+    pretty_name: 'Ensure security definitions do not use basic auth
       - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_14:
@@ -11873,7 +11873,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_14
-    pretty_name: 'CKV_OPENAPI_14: Ensure that operation objects do not use ''implicit''
+    pretty_name: 'Ensure that operation objects do not use ''implicit''
       flow, which is deprecated - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_15:
@@ -11885,7 +11885,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_15
-    pretty_name: 'CKV_OPENAPI_15: Ensure that operation objects do not use basic auth
+    pretty_name: 'Ensure that operation objects do not use basic auth
       - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_16:
@@ -11897,7 +11897,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_16
-    pretty_name: 'CKV_OPENAPI_16: Ensure that operation objects have ''produces''
+    pretty_name: 'Ensure that operation objects have ''produces''
       field defined for GET operations - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_17:
@@ -11909,7 +11909,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_17
-    pretty_name: 'CKV_OPENAPI_17: Ensure that operation objects have ''consumes''
+    pretty_name: 'Ensure that operation objects have ''consumes''
       field defined for PUT, POST and PATCH operations - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_18:
@@ -11921,7 +11921,7 @@ rules:
     description: Check for unencrypted OpenAPI resources.
     group: cloud-unencrypted-resources
     name: CKV_OPENAPI_18
-    pretty_name: 'CKV_OPENAPI_18: Ensure that global schemes use ''https'' protocol
+    pretty_name: 'Ensure that global schemes use ''https'' protocol
       instead of ''http''- version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_19:
@@ -11933,7 +11933,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_19
-    pretty_name: 'CKV_OPENAPI_19: Ensure that global security scope is defined in
+    pretty_name: 'Ensure that global security scope is defined in
       securityDefinitions - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_2:
@@ -11945,7 +11945,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_2
-    pretty_name: 'CKV_OPENAPI_2: Ensure that if the security scheme is not of type
+    pretty_name: 'Ensure that if the security scheme is not of type
       ''oauth2'', the array value must be empty - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_3:
@@ -11957,7 +11957,7 @@ rules:
     description: Check for unencrypted OpenAPI resources.
     group: cloud-unencrypted-resources
     name: CKV_OPENAPI_3
-    pretty_name: 'CKV_OPENAPI_3: Ensure that security schemes don''t allow cleartext
+    pretty_name: 'Ensure that security schemes don''t allow cleartext
       credentials over unencrypted channel - version 3.x.y files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_4:
@@ -11969,7 +11969,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_4
-    pretty_name: 'CKV_OPENAPI_4: Ensure that the global security field has rules defined'
+    pretty_name: 'Ensure that the global security field has rules defined'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_5:
     categories:
@@ -11980,7 +11980,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_5
-    pretty_name: 'CKV_OPENAPI_5: Ensure that security operations is not empty.'
+    pretty_name: 'Ensure that security operations is not empty.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_6:
     categories:
@@ -11991,7 +11991,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_6
-    pretty_name: 'CKV_OPENAPI_6: Ensure that security requirement defined in securityDefinitions
+    pretty_name: 'Ensure that security requirement defined in securityDefinitions
       - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_7:
@@ -12003,7 +12003,7 @@ rules:
     description: Check for unencrypted OpenAPI resources.
     group: cloud-unencrypted-resources
     name: CKV_OPENAPI_7
-    pretty_name: 'CKV_OPENAPI_7: Ensure that the path scheme does not support unencrypted
+    pretty_name: 'Ensure that the path scheme does not support unencrypted
       HTTP connection - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_8:
@@ -12015,7 +12015,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_8
-    pretty_name: 'CKV_OPENAPI_8: Ensure that security is not using ''password'' flow
+    pretty_name: 'Ensure that security is not using ''password'' flow
       in OAuth2 authentication - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_9:
@@ -12027,7 +12027,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_9
-    pretty_name: 'CKV_OPENAPI_9: Ensure that security scopes of operations are defined
+    pretty_name: 'Ensure that security scopes of operations are defined
       in securityDefinitions - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENSTACK_1:
@@ -12039,7 +12039,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_OPENSTACK_1
-    pretty_name: 'CKV_OPENSTACK_1: Ensure no hard coded OpenStack password, token,
+    pretty_name: 'Ensure no hard coded OpenStack password, token,
       or application_credential_secret exists in provider'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENSTACK_2:
@@ -12051,7 +12051,7 @@ rules:
     description: Check for misconfigurations in OpenStack resources.
     group: cloud-weak-configuration
     name: CKV_OPENSTACK_2
-    pretty_name: 'CKV_OPENSTACK_2: Ensure no security groups allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security groups allow ingress from 0.0.0.0:0
       to port 22 (tcp / udp)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENSTACK_3:
@@ -12063,7 +12063,7 @@ rules:
     description: Check for misconfigurations in OpenStack resources.
     group: cloud-weak-configuration
     name: CKV_OPENSTACK_3
-    pretty_name: 'CKV_OPENSTACK_3: Ensure no security groups allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security groups allow ingress from 0.0.0.0:0
       to port 3389 (tcp / udp)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENSTACK_4:
@@ -12075,7 +12075,7 @@ rules:
     description: Check for misconfigurations in OpenStack resources.
     group: cloud-weak-configuration
     name: CKV_OPENSTACK_4
-    pretty_name: 'CKV_OPENSTACK_4: Ensure that instance does not use basic credentials'
+    pretty_name: 'Ensure that instance does not use basic credentials'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENSTACK_5:
     categories:
@@ -12086,7 +12086,7 @@ rules:
     description: Check for misconfigurations in OpenStack resources.
     group: cloud-weak-configuration
     name: CKV_OPENSTACK_5
-    pretty_name: 'CKV_OPENSTACK_5: Ensure firewall rule set a destination IP'
+    pretty_name: 'Ensure firewall rule set a destination IP'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_1:
     categories:
@@ -12097,7 +12097,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_PAN_1
-    pretty_name: 'CKV_PAN_1: Ensure no hard coded PAN-OS credentials exist in provider'
+    pretty_name: 'Ensure no hard coded PAN-OS credentials exist in provider'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_10:
     categories:
@@ -12108,7 +12108,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_10
-    pretty_name: 'CKV_PAN_10: Ensure logging at session end is enabled within security
+    pretty_name: 'Ensure logging at session end is enabled within security
       policies'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_11:
@@ -12120,7 +12120,7 @@ rules:
     description: Check for unencrypted PAN-OS resources.
     group: cloud-unencrypted-resources
     name: CKV_PAN_11
-    pretty_name: 'CKV_PAN_11: Ensure IPsec profiles do not specify use of insecure
+    pretty_name: 'Ensure IPsec profiles do not specify use of insecure
       encryption algorithms'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_12:
@@ -12132,7 +12132,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_12
-    pretty_name: 'CKV_PAN_12: Ensure IPsec profiles do not specify use of insecure
+    pretty_name: 'Ensure IPsec profiles do not specify use of insecure
       authentication algorithms'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_13:
@@ -12144,7 +12144,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_13
-    pretty_name: 'CKV_PAN_13: Ensure IPsec profiles do not specify use of insecure
+    pretty_name: 'Ensure IPsec profiles do not specify use of insecure
       protocols'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_14:
@@ -12156,7 +12156,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_14
-    pretty_name: 'CKV_PAN_14: Ensure a Zone Protection Profile is defined within Security
+    pretty_name: 'Ensure a Zone Protection Profile is defined within Security
       Zones'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_15:
@@ -12168,7 +12168,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_15
-    pretty_name: 'CKV_PAN_15: Ensure an Include ACL is defined for a Zone when User-ID
+    pretty_name: 'Ensure an Include ACL is defined for a Zone when User-ID
       is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_2:
@@ -12180,7 +12180,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_2
-    pretty_name: 'CKV_PAN_2: Ensure plain-text management HTTP is not enabled for
+    pretty_name: 'Ensure plain-text management HTTP is not enabled for
       an Interface Management Profile'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_3:
@@ -12192,7 +12192,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_3
-    pretty_name: 'CKV_PAN_3: Ensure plain-text management Telnet is not enabled for
+    pretty_name: 'Ensure plain-text management Telnet is not enabled for
       an Interface Management Profile'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_4:
@@ -12204,7 +12204,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_4
-    pretty_name: 'CKV_PAN_4: Ensure DSRI is not enabled within security policies'
+    pretty_name: 'Ensure DSRI is not enabled within security policies'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_5:
     categories:
@@ -12215,7 +12215,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_5
-    pretty_name: 'CKV_PAN_5: Ensure security rules do not have ''applications'' set
+    pretty_name: 'Ensure security rules do not have ''applications'' set
       to ''any'' '
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_6:
@@ -12227,7 +12227,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_6
-    pretty_name: 'CKV_PAN_6: Ensure security rules do not have ''services'' set to
+    pretty_name: 'Ensure security rules do not have ''services'' set to
       ''any'' '
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_7:
@@ -12239,7 +12239,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_7
-    pretty_name: 'CKV_PAN_7: Ensure security rules do not have ''source_addresses''
+    pretty_name: 'Ensure security rules do not have ''source_addresses''
       and ''destination_addresses'' both containing values of ''any'' '
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_8:
@@ -12251,7 +12251,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_8
-    pretty_name: 'CKV_PAN_8: Ensure description is populated within security policies'
+    pretty_name: 'Ensure description is populated within security policies'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_9:
     categories:
@@ -12260,7 +12260,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_9
-    pretty_name: 'CKV_PAN_9: Ensure a Log Forwarding Profile is selected for each
+    pretty_name: 'Ensure a Log Forwarding Profile is selected for each
       security policy rule'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_1:
@@ -12272,7 +12272,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_1
-    pretty_name: 'CKV_SECRET_1: Artifactory Credentials'
+    pretty_name: 'Artifactory Credentials'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_10:
     categories:
@@ -12283,7 +12283,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_10
-    pretty_name: 'CKV_SECRET_10: Secret Keyword'
+    pretty_name: 'Secret Keyword'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_11:
     categories:
@@ -12294,7 +12294,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_11
-    pretty_name: 'CKV_SECRET_11: Mailchimp Access Key'
+    pretty_name: 'Mailchimp Access Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_12:
     categories:
@@ -12305,7 +12305,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_12
-    pretty_name: 'CKV_SECRET_12: NPM tokens'
+    pretty_name: 'NPM tokens'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_13:
     categories:
@@ -12316,7 +12316,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_13
-    pretty_name: 'CKV_SECRET_13: Private Key'
+    pretty_name: 'Private Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_14:
     categories:
@@ -12327,7 +12327,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_14
-    pretty_name: 'CKV_SECRET_14: Slack Token'
+    pretty_name: 'Slack Token'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_15:
     categories:
@@ -12338,7 +12338,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_15
-    pretty_name: 'CKV_SECRET_15: SoftLayer Credentials'
+    pretty_name: 'SoftLayer Credentials'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_16:
     categories:
@@ -12349,7 +12349,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_16
-    pretty_name: 'CKV_SECRET_16: Square OAuth Secret'
+    pretty_name: 'Square OAuth Secret'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_17:
     categories:
@@ -12360,7 +12360,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_17
-    pretty_name: 'CKV_SECRET_17: Stripe Access Key'
+    pretty_name: 'Stripe Access Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_18:
     categories:
@@ -12371,7 +12371,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_18
-    pretty_name: 'CKV_SECRET_18: Twilio API Key'
+    pretty_name: 'Twilio API Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_19:
     categories:
@@ -12380,7 +12380,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_19
-    pretty_name: 'CKV_SECRET_19: Hex High Entropy String'
+    pretty_name: 'Hex High Entropy String'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_2:
     categories:
@@ -12389,7 +12389,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_2
-    pretty_name: 'CKV_SECRET_2: AWS Access Key'
+    pretty_name: 'AWS Access Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_3:
     categories:
@@ -12400,7 +12400,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_3
-    pretty_name: 'CKV_SECRET_3: Azure Storage Account access key'
+    pretty_name: 'Azure Storage Account access key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_4:
     categories:
@@ -12411,7 +12411,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_4
-    pretty_name: 'CKV_SECRET_4: Basic Auth Credentials'
+    pretty_name: 'Basic Auth Credentials'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_5:
     categories:
@@ -12422,7 +12422,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_5
-    pretty_name: 'CKV_SECRET_5: Cloudant Credentials'
+    pretty_name: 'Cloudant Credentials'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_6:
     categories:
@@ -12431,7 +12431,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_6
-    pretty_name: 'CKV_SECRET_6: Base64 High Entropy String'
+    pretty_name: 'Base64 High Entropy String'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_7:
     categories:
@@ -12442,7 +12442,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_7
-    pretty_name: 'CKV_SECRET_7: IBM Cloud IAM Key'
+    pretty_name: 'IBM Cloud IAM Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_8:
     categories:
@@ -12453,7 +12453,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_8
-    pretty_name: 'CKV_SECRET_8: IBM COS HMAC Credentials'
+    pretty_name: 'IBM COS HMAC Credentials'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_9:
     categories:
@@ -12464,7 +12464,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_9
-    pretty_name: 'CKV_SECRET_9: JSON Web Token'
+    pretty_name: 'JSON Web Token'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_1:
     categories:
@@ -12475,7 +12475,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_1
-    pretty_name: 'CKV_YC_1: Ensure security group is assigned to database cluster.'
+    pretty_name: 'Ensure security group is assigned to database cluster.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_10:
     categories:
@@ -12486,7 +12486,7 @@ rules:
     description: Check for unencrypted Yandex Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_YC_10
-    pretty_name: 'CKV_YC_10: Ensure etcd database is encrypted with KMS key.'
+    pretty_name: 'Ensure etcd database is encrypted with KMS key.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_11:
     categories:
@@ -12497,7 +12497,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_11
-    pretty_name: 'CKV_YC_11: Ensure security group is assigned to network interface.'
+    pretty_name: 'Ensure security group is assigned to network interface.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_12:
     categories:
@@ -12508,7 +12508,7 @@ rules:
     description: Check for publicly accessible Yandex Cloud resources.
     group: cloud-resources-public-access
     name: CKV_YC_12
-    pretty_name: 'CKV_YC_12: Ensure public IP is not assigned to database cluster.'
+    pretty_name: 'Ensure public IP is not assigned to database cluster.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_13:
     categories:
@@ -12519,7 +12519,7 @@ rules:
     description: Check for weak Yandex Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_YC_13
-    pretty_name: 'CKV_YC_13: Ensure cloud member does not have elevated access.'
+    pretty_name: 'Ensure cloud member does not have elevated access.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_14:
     categories:
@@ -12530,7 +12530,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_14
-    pretty_name: 'CKV_YC_14: Ensure security group is assigned to Kubernetes cluster.'
+    pretty_name: 'Ensure security group is assigned to Kubernetes cluster.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_15:
     categories:
@@ -12541,7 +12541,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_15
-    pretty_name: 'CKV_YC_15: Ensure security group is assigned to Kubernetes node
+    pretty_name: 'Ensure security group is assigned to Kubernetes node
       group.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_16:
@@ -12552,7 +12552,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_16
-    pretty_name: 'CKV_YC_16: Ensure network policy is assigned to Kubernetes cluster.'
+    pretty_name: 'Ensure network policy is assigned to Kubernetes cluster.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_17:
     categories:
@@ -12563,7 +12563,7 @@ rules:
     description: Check for publicly accessible Yandex Cloud resources.
     group: cloud-resources-public-access
     name: CKV_YC_17
-    pretty_name: 'CKV_YC_17: Ensure storage bucket does not have public access permissions.'
+    pretty_name: 'Ensure storage bucket does not have public access permissions.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_18:
     categories:
@@ -12574,7 +12574,7 @@ rules:
     description: Check for publicly accessible Yandex Cloud resources.
     group: cloud-resources-public-access
     name: CKV_YC_18
-    pretty_name: 'CKV_YC_18: Ensure compute instance group does not have public IP.'
+    pretty_name: 'Ensure compute instance group does not have public IP.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_19:
     categories:
@@ -12585,7 +12585,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_19
-    pretty_name: 'CKV_YC_19: Ensure security group does not contain allow-all rules.'
+    pretty_name: 'Ensure security group does not contain allow-all rules.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_2:
     categories:
@@ -12596,7 +12596,7 @@ rules:
     description: Check for publicly accessible Yandex Cloud resources.
     group: cloud-resources-public-access
     name: CKV_YC_2
-    pretty_name: 'CKV_YC_2: Ensure compute instance does not have public IP.'
+    pretty_name: 'Ensure compute instance does not have public IP.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_20:
     categories:
@@ -12607,7 +12607,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_20
-    pretty_name: 'CKV_YC_20: Ensure security group rule is not allow-all.'
+    pretty_name: 'Ensure security group rule is not allow-all.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_21:
     categories:
@@ -12618,7 +12618,7 @@ rules:
     description: Check for weak Yandex Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_YC_21
-    pretty_name: 'CKV_YC_21: Ensure organization member does not have elevated access.'
+    pretty_name: 'Ensure organization member does not have elevated access.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_22:
     categories:
@@ -12629,7 +12629,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_22
-    pretty_name: 'CKV_YC_22: Ensure compute instance group has security group assigned.'
+    pretty_name: 'Ensure compute instance group has security group assigned.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_23:
     categories:
@@ -12640,7 +12640,7 @@ rules:
     description: Check for weak Yandex Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_YC_23
-    pretty_name: 'CKV_YC_23: Ensure folder member does not have elevated access.'
+    pretty_name: 'Ensure folder member does not have elevated access.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_24:
     categories:
@@ -12651,7 +12651,7 @@ rules:
     description: Check for weak Yandex Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_YC_24
-    pretty_name: 'CKV_YC_24: Ensure passport account is not used for assignment. Use
+    pretty_name: 'Ensure passport account is not used for assignment. Use
       service accounts and federated accounts where possible.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_3:
@@ -12662,7 +12662,7 @@ rules:
     description: Check for unencrypted Yandex Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_YC_3
-    pretty_name: 'CKV_YC_3: Ensure storage bucket is encrypted.'
+    pretty_name: 'Ensure storage bucket is encrypted.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_4:
     categories:
@@ -12673,7 +12673,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_4
-    pretty_name: 'CKV_YC_4: Ensure compute instance does not have serial console enabled.'
+    pretty_name: 'Ensure compute instance does not have serial console enabled.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_5:
     categories:
@@ -12684,7 +12684,7 @@ rules:
     description: Check for publicly accessible Yandex Cloud resources.
     group: cloud-resources-public-access
     name: CKV_YC_5
-    pretty_name: 'CKV_YC_5: Ensure Kubernetes cluster does not have public IP address.'
+    pretty_name: 'Ensure Kubernetes cluster does not have public IP address.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_6:
     categories:
@@ -12695,7 +12695,7 @@ rules:
     description: Check for publicly accessible Yandex Cloud resources.
     group: cloud-resources-public-access
     name: CKV_YC_6
-    pretty_name: 'CKV_YC_6: Ensure Kubernetes cluster node group does not have public
+    pretty_name: 'Ensure Kubernetes cluster node group does not have public
       IP addresses.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_7:
@@ -12707,7 +12707,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_7
-    pretty_name: 'CKV_YC_7: Ensure Kubernetes cluster auto-upgrade is enabled.'
+    pretty_name: 'Ensure Kubernetes cluster auto-upgrade is enabled.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_8:
     categories:
@@ -12718,7 +12718,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_8
-    pretty_name: 'CKV_YC_8: Ensure Kubernetes node group auto-upgrade is enabled.'
+    pretty_name: 'Ensure Kubernetes node group auto-upgrade is enabled.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_9:
     categories:
@@ -12729,6 +12729,6 @@ rules:
     description: Check that ensures best practices in Yandex Cloud secrets management.
     group: cloud-weak-secrets-management
     name: CKV_YC_9
-    pretty_name: 'CKV_YC_9: Ensure KMS symmetric key is rotated.'
+    pretty_name: 'Ensure KMS symmetric key is rotated.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
 

--- a/scanners/boostsecurityio/checkov/rules.yaml
+++ b/scanners/boostsecurityio/checkov/rules.yaml
@@ -8,7 +8,7 @@ rules:
     description: Check for unencrypted Ansible resources.
     group: cloud-unencrypted-resources
     name: CKV2_ANSIBLE_1
-    pretty_name: 'CKV2_ANSIBLE_1: Ensure that HTTPS url is used with uri'
+    pretty_name: 'Ensure that HTTPS url is used with uri'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_ANSIBLE_2:
     categories:
@@ -19,7 +19,7 @@ rules:
     description: Check for unencrypted Ansible resources.
     group: cloud-unencrypted-resources
     name: CKV2_ANSIBLE_2
-    pretty_name: 'CKV2_ANSIBLE_2: Ensure that HTTPS url is used with get_url'
+    pretty_name: 'Ensure that HTTPS url is used with get_url'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_ANSIBLE_3:
     categories:
@@ -30,7 +30,7 @@ rules:
     description: Check for misconfigurations in Ansible resources.
     group: cloud-weak-configuration
     name: CKV2_ANSIBLE_3
-    pretty_name: 'CKV2_ANSIBLE_3: Ensure block is handling task errors properly'
+    pretty_name: 'Ensure block is handling task errors properly'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_ANSIBLE_4:
     categories:
@@ -41,7 +41,7 @@ rules:
     description: Check for weak Ansible configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_ANSIBLE_4
-    pretty_name: 'CKV2_ANSIBLE_4: Ensure that packages with untrusted or missing GPG
+    pretty_name: 'Ensure that packages with untrusted or missing GPG
       signatures are not used by dnf'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_ANSIBLE_5:
@@ -53,7 +53,7 @@ rules:
     description: Check for weak Ansible configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_ANSIBLE_5
-    pretty_name: 'CKV2_ANSIBLE_5: Ensure that SSL validation isn''t disabled with
+    pretty_name: 'Ensure that SSL validation isn''t disabled with
       dnf'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_ANSIBLE_6:
@@ -65,7 +65,7 @@ rules:
     description: Check for weak Ansible configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_ANSIBLE_6
-    pretty_name: 'CKV2_ANSIBLE_6: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with dnf'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_1:
@@ -77,7 +77,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_1
-    pretty_name: 'CKV2_AWS_1: Ensure that all NACL are attached to subnets'
+    pretty_name: 'Ensure that all NACL are attached to subnets'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_10:
     categories:
@@ -87,7 +87,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_10
-    pretty_name: 'CKV2_AWS_10: Ensure CloudTrail trails are integrated with CloudWatch
+    pretty_name: 'Ensure CloudTrail trails are integrated with CloudWatch
       Logs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_11:
@@ -97,7 +97,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_11
-    pretty_name: 'CKV2_AWS_11: Ensure VPC flow logging is enabled in all VPCs'
+    pretty_name: 'Ensure VPC flow logging is enabled in all VPCs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_12:
     categories:
@@ -108,7 +108,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_12
-    pretty_name: 'CKV2_AWS_12: Ensure the default security group of every VPC restricts
+    pretty_name: 'Ensure the default security group of every VPC restricts
       all traffic'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_14:
@@ -120,7 +120,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV2_AWS_14
-    pretty_name: 'CKV2_AWS_14: Ensure that IAM groups includes at least one IAM user'
+    pretty_name: 'Ensure that IAM groups includes at least one IAM user'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_15:
     categories:
@@ -130,7 +130,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_15
-    pretty_name: 'CKV2_AWS_15: Ensure that auto Scaling groups that are associated
+    pretty_name: 'Ensure that auto Scaling groups that are associated
       with a load balancer, are using Elastic Load Balancing health checks.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_16:
@@ -141,7 +141,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_16
-    pretty_name: 'CKV2_AWS_16: Ensure that Auto Scaling is enabled on your DynamoDB
+    pretty_name: 'Ensure that Auto Scaling is enabled on your DynamoDB
       tables'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_18:
@@ -153,7 +153,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_18
-    pretty_name: 'CKV2_AWS_18: Ensure that Elastic File System (Amazon EFS) file systems
+    pretty_name: 'Ensure that Elastic File System (Amazon EFS) file systems
       are added in the backup plans of AWS Backup'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_19:
@@ -165,7 +165,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_19
-    pretty_name: 'CKV2_AWS_19: Ensure that all EIP addresses allocated to a VPC are
+    pretty_name: 'Ensure that all EIP addresses allocated to a VPC are
       attached to EC2 instances'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_2:
@@ -177,7 +177,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV2_AWS_2
-    pretty_name: 'CKV2_AWS_2: Ensure that only encrypted EBS volumes are attached
+    pretty_name: 'Ensure that only encrypted EBS volumes are attached
       to EC2 instances'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_20:
@@ -189,7 +189,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_20
-    pretty_name: 'CKV2_AWS_20: Ensure that ALB redirects HTTP requests into HTTPS
+    pretty_name: 'Ensure that ALB redirects HTTP requests into HTTPS
       ones'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_21:
@@ -201,7 +201,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV2_AWS_21
-    pretty_name: 'CKV2_AWS_21: Ensure that all IAM users are members of at least one
+    pretty_name: 'Ensure that all IAM users are members of at least one
       IAM group.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_22:
@@ -212,7 +212,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV2_AWS_22
-    pretty_name: 'CKV2_AWS_22: Ensure an IAM User does not have access to the console'
+    pretty_name: 'Ensure an IAM User does not have access to the console'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_23:
     categories:
@@ -222,7 +222,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_23
-    pretty_name: 'CKV2_AWS_23: Route53 A Record has Attached Resource'
+    pretty_name: 'Route53 A Record has Attached Resource'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_27:
     categories:
@@ -232,7 +232,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_27
-    pretty_name: 'CKV2_AWS_27: Ensure Postgres RDS as aws_rds_cluster has Query Logging
+    pretty_name: 'Ensure Postgres RDS as aws_rds_cluster has Query Logging
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_28:
@@ -242,7 +242,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_28
-    pretty_name: 'CKV2_AWS_28: Ensure public facing ALB are protected by WAF'
+    pretty_name: 'Ensure public facing ALB are protected by WAF'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_29:
     categories:
@@ -251,7 +251,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_29
-    pretty_name: 'CKV2_AWS_29: Ensure public API gateway are protected by WAF'
+    pretty_name: 'Ensure public API gateway are protected by WAF'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_3:
     categories:
@@ -260,7 +260,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_3
-    pretty_name: 'CKV2_AWS_3: Ensure GuardDuty is enabled to specific org/region'
+    pretty_name: 'Ensure GuardDuty is enabled to specific org/region'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_30:
     categories:
@@ -270,7 +270,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_30
-    pretty_name: 'CKV2_AWS_30: Ensure Postgres RDS as aws_db_instance has Query Logging
+    pretty_name: 'Ensure Postgres RDS as aws_db_instance has Query Logging
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_31:
@@ -280,7 +280,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_31
-    pretty_name: 'CKV2_AWS_31: Ensure WAF2 has a Logging Configuration'
+    pretty_name: 'Ensure WAF2 has a Logging Configuration'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_32:
     categories:
@@ -290,7 +290,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_32
-    pretty_name: 'CKV2_AWS_32: Ensure CloudFront distribution has a response headers
+    pretty_name: 'Ensure CloudFront distribution has a response headers
       policy attached'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_33:
@@ -300,7 +300,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_33
-    pretty_name: 'CKV2_AWS_33: Ensure AppSync is protected by WAF'
+    pretty_name: 'Ensure AppSync is protected by WAF'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_34:
     categories:
@@ -311,7 +311,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV2_AWS_34
-    pretty_name: 'CKV2_AWS_34: AWS SSM Parameter should be Encrypted'
+    pretty_name: 'AWS SSM Parameter should be Encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_35:
     categories:
@@ -321,7 +321,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_35
-    pretty_name: 'CKV2_AWS_35: AWS NAT Gateways should be utilized for the default
+    pretty_name: 'AWS NAT Gateways should be utilized for the default
       route'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_36:
@@ -333,7 +333,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV2_AWS_36
-    pretty_name: 'CKV2_AWS_36: Ensure terraform is not sending SSM secrets to untrusted
+    pretty_name: 'Ensure terraform is not sending SSM secrets to untrusted
       domains over HTTP'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_37:
@@ -345,7 +345,7 @@ rules:
     description: Check for weak AWS configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV2_AWS_37
-    pretty_name: 'CKV2_AWS_37: Ensure Codecommit associates an approval rule'
+    pretty_name: 'Ensure Codecommit associates an approval rule'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_38:
     categories:
@@ -356,7 +356,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_38
-    pretty_name: 'CKV2_AWS_38: Ensure Domain Name System Security Extensions (DNSSEC)
+    pretty_name: 'Ensure Domain Name System Security Extensions (DNSSEC)
       signing is enabled for Amazon Route 53 public hosted zones'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_39:
@@ -367,7 +367,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_39
-    pretty_name: 'CKV2_AWS_39: Ensure Domain Name System (DNS) query logging is enabled
+    pretty_name: 'Ensure Domain Name System (DNS) query logging is enabled
       for Amazon Route 53 hosted zones'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_4:
@@ -378,7 +378,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_4
-    pretty_name: 'CKV2_AWS_4: Ensure API Gateway stage have logging level defined
+    pretty_name: 'Ensure API Gateway stage have logging level defined
       as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_40:
@@ -390,7 +390,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV2_AWS_40
-    pretty_name: 'CKV2_AWS_40: Ensure AWS IAM policy does not allow full IAM privileges'
+    pretty_name: 'Ensure AWS IAM policy does not allow full IAM privileges'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_41:
     categories:
@@ -401,7 +401,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV2_AWS_41
-    pretty_name: 'CKV2_AWS_41: Ensure an IAM role is attached to EC2 instance'
+    pretty_name: 'Ensure an IAM role is attached to EC2 instance'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_42:
     categories:
@@ -412,7 +412,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV2_AWS_42
-    pretty_name: 'CKV2_AWS_42: Ensure AWS CloudFront distribution uses custom SSL
+    pretty_name: 'Ensure AWS CloudFront distribution uses custom SSL
       certificate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_43:
@@ -424,7 +424,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV2_AWS_43
-    pretty_name: 'CKV2_AWS_43: Ensure S3 Bucket does not allow access to all Authenticated
+    pretty_name: 'Ensure S3 Bucket does not allow access to all Authenticated
       users'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_44:
@@ -436,7 +436,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_44
-    pretty_name: 'CKV2_AWS_44: Ensure AWS route table with VPC peering does not contain
+    pretty_name: 'Ensure AWS route table with VPC peering does not contain
       routes overly permissive to all traffic'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_45:
@@ -448,7 +448,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_45
-    pretty_name: 'CKV2_AWS_45: Ensure AWS Config recorder is enabled to record all
+    pretty_name: 'Ensure AWS Config recorder is enabled to record all
       supported resources'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_46:
@@ -460,7 +460,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_46
-    pretty_name: 'CKV2_AWS_46: Ensure AWS Cloudfront Distribution with S3 have Origin
+    pretty_name: 'Ensure AWS Cloudfront Distribution with S3 have Origin
       Access set to enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_47:
@@ -472,7 +472,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_47
-    pretty_name: 'CKV2_AWS_47: Ensure AWS CloudFront attached WAFv2 WebACL is configured
+    pretty_name: 'Ensure AWS CloudFront attached WAFv2 WebACL is configured
       with AMR for Log4j Vulnerability'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_48:
@@ -484,7 +484,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_48
-    pretty_name: 'CKV2_AWS_48: Ensure AWS Config must record all possible resources'
+    pretty_name: 'Ensure AWS Config must record all possible resources'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_49:
     categories:
@@ -495,7 +495,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV2_AWS_49
-    pretty_name: 'CKV2_AWS_49: Ensure AWS Database Migration Service endpoints have
+    pretty_name: 'Ensure AWS Database Migration Service endpoints have
       SSL configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_5:
@@ -507,7 +507,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_5
-    pretty_name: 'CKV2_AWS_5: Ensure that Security Groups are attached to another
+    pretty_name: 'Ensure that Security Groups are attached to another
       resource'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_50:
@@ -519,7 +519,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_50
-    pretty_name: 'CKV2_AWS_50: Ensure AWS ElastiCache Redis cluster with Multi-AZ
+    pretty_name: 'Ensure AWS ElastiCache Redis cluster with Multi-AZ
       Automatic Failover feature set to enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_51:
@@ -531,7 +531,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_51
-    pretty_name: 'CKV2_AWS_51: Ensure AWS API Gateway endpoints uses client certificate
+    pretty_name: 'Ensure AWS API Gateway endpoints uses client certificate
       authentication'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_52:
@@ -543,7 +543,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV2_AWS_52
-    pretty_name: 'CKV2_AWS_52: Ensure AWS ElasticSearch/OpenSearch Fine-grained access
+    pretty_name: 'Ensure AWS ElasticSearch/OpenSearch Fine-grained access
       control is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_53:
@@ -555,7 +555,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_53
-    pretty_name: 'CKV2_AWS_53: Ensure AWS API gateway request is validated'
+    pretty_name: 'Ensure AWS API gateway request is validated'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_54:
     categories:
@@ -566,7 +566,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_54
-    pretty_name: 'CKV2_AWS_54: Ensure AWS CloudFront distribution is using secure
+    pretty_name: 'Ensure AWS CloudFront distribution is using secure
       SSL protocols for HTTPS communication'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_55:
@@ -578,7 +578,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_55
-    pretty_name: 'CKV2_AWS_55: Ensure AWS EMR cluster is configured with security
+    pretty_name: 'Ensure AWS EMR cluster is configured with security
       configuration'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_56:
@@ -590,7 +590,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV2_AWS_56
-    pretty_name: 'CKV2_AWS_56: Ensure AWS Managed IAMFullAccess IAM policy is not
+    pretty_name: 'Ensure AWS Managed IAMFullAccess IAM policy is not
       used.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_57:
@@ -602,7 +602,7 @@ rules:
     description: Check that ensures best practices in AWS secrets management.
     group: cloud-weak-secrets-management
     name: CKV2_AWS_57
-    pretty_name: 'CKV2_AWS_57: Ensure Secrets Manager secrets should have automatic
+    pretty_name: 'Ensure Secrets Manager secrets should have automatic
       rotation enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_58:
@@ -614,7 +614,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_58
-    pretty_name: 'CKV2_AWS_58: Ensure AWS Neptune cluster deletion protection is enabled'
+    pretty_name: 'Ensure AWS Neptune cluster deletion protection is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_59:
     categories:
@@ -625,7 +625,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_59
-    pretty_name: 'CKV2_AWS_59: Ensure ElasticSearch/OpenSearch has dedicated master
+    pretty_name: 'Ensure ElasticSearch/OpenSearch has dedicated master
       node enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_6:
@@ -637,7 +637,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV2_AWS_6
-    pretty_name: 'CKV2_AWS_6: Ensure that S3 bucket has a Public Access block'
+    pretty_name: 'Ensure that S3 bucket has a Public Access block'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_60:
     categories:
@@ -648,7 +648,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_60
-    pretty_name: 'CKV2_AWS_60: Ensure RDS instance with copy tags to snapshots is
+    pretty_name: 'Ensure RDS instance with copy tags to snapshots is
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_61:
@@ -660,7 +660,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_61
-    pretty_name: 'CKV2_AWS_61: Ensure that an S3 bucket has a lifecycle configuration'
+    pretty_name: 'Ensure that an S3 bucket has a lifecycle configuration'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_62:
     categories:
@@ -671,7 +671,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_62
-    pretty_name: 'CKV2_AWS_62: Ensure S3 buckets should have event notifications enabled'
+    pretty_name: 'Ensure S3 buckets should have event notifications enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_7:
     categories:
@@ -682,7 +682,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_7
-    pretty_name: 'CKV2_AWS_7: Ensure that Amazon EMR clusters'' security groups are
+    pretty_name: 'Ensure that Amazon EMR clusters'' security groups are
       not open to the world'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_8:
@@ -694,7 +694,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_8
-    pretty_name: 'CKV2_AWS_8: Ensure that RDS clusters has backup plan of AWS Backup'
+    pretty_name: 'Ensure that RDS clusters has backup plan of AWS Backup'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AWS_9:
     categories:
@@ -705,7 +705,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV2_AWS_9
-    pretty_name: 'CKV2_AWS_9: Ensure that EBS are added in the backup plans of AWS
+    pretty_name: 'Ensure that EBS are added in the backup plans of AWS
       Backup'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_1:
@@ -715,7 +715,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_1
-    pretty_name: 'CKV2_AZURE_1: Ensure storage for critical data are encrypted with
+    pretty_name: 'Ensure storage for critical data are encrypted with
       Customer Managed Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_10:
@@ -727,7 +727,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_10
-    pretty_name: 'CKV2_AZURE_10: Ensure that Microsoft Antimalware is configured to
+    pretty_name: 'Ensure that Microsoft Antimalware is configured to
       automatically updates for Virtual Machines'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_11:
@@ -737,7 +737,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_11
-    pretty_name: 'CKV2_AZURE_11: Ensure that Azure Data Explorer encryption at rest
+    pretty_name: 'Ensure that Azure Data Explorer encryption at rest
       uses a customer-managed key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_12:
@@ -748,7 +748,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_12
-    pretty_name: 'CKV2_AZURE_12: Ensure that virtual machines are backed up using
+    pretty_name: 'Ensure that virtual machines are backed up using
       Azure Backup'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_13:
@@ -760,7 +760,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_13
-    pretty_name: 'CKV2_AZURE_13: Ensure that sql servers enables data security policy'
+    pretty_name: 'Ensure that sql servers enables data security policy'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_14:
     categories:
@@ -771,7 +771,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_14
-    pretty_name: 'CKV2_AZURE_14: Ensure that Unattached disks are encrypted'
+    pretty_name: 'Ensure that Unattached disks are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_15:
     categories:
@@ -780,7 +780,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_15
-    pretty_name: 'CKV2_AZURE_15: Ensure that Azure data factories are encrypted with
+    pretty_name: 'Ensure that Azure data factories are encrypted with
       a customer-managed key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_16:
@@ -790,7 +790,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_16
-    pretty_name: 'CKV2_AZURE_16: Ensure that MySQL server enables customer-managed
+    pretty_name: 'Ensure that MySQL server enables customer-managed
       key for encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_17:
@@ -800,7 +800,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_17
-    pretty_name: 'CKV2_AZURE_17: Ensure that PostgreSQL server enables customer-managed
+    pretty_name: 'Ensure that PostgreSQL server enables customer-managed
       key for encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_18:
@@ -810,7 +810,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_18
-    pretty_name: 'CKV2_AZURE_18: Ensure that Storage Accounts use customer-managed
+    pretty_name: 'Ensure that Storage Accounts use customer-managed
       key for encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_19:
@@ -822,7 +822,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_19
-    pretty_name: 'CKV2_AZURE_19: Ensure that Azure Synapse workspaces have no IP firewall
+    pretty_name: 'Ensure that Azure Synapse workspaces have no IP firewall
       rules attached'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_2:
@@ -834,7 +834,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_2
-    pretty_name: 'CKV2_AZURE_2: Ensure that Vulnerability Assessment (VA) is enabled
+    pretty_name: 'Ensure that Vulnerability Assessment (VA) is enabled
       on a SQL server by setting a Storage Account'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_20:
@@ -845,7 +845,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_20
-    pretty_name: 'CKV2_AZURE_20: Ensure Storage logging is enabled for Table service
+    pretty_name: 'Ensure Storage logging is enabled for Table service
       for read requests'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_21:
@@ -856,7 +856,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_21
-    pretty_name: 'CKV2_AZURE_21: Ensure Storage logging is enabled for Blob service
+    pretty_name: 'Ensure Storage logging is enabled for Blob service
       for read requests'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_22:
@@ -866,7 +866,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_22
-    pretty_name: 'CKV2_AZURE_22: Ensure that Cognitive Services enables customer-managed
+    pretty_name: 'Ensure that Cognitive Services enables customer-managed
       key for encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_23:
@@ -878,7 +878,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_23
-    pretty_name: 'CKV2_AZURE_23: Ensure Azure spring cloud is configured with Virtual
+    pretty_name: 'Ensure Azure spring cloud is configured with Virtual
       network (Vnet)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_24:
@@ -890,7 +890,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_24
-    pretty_name: 'CKV2_AZURE_24: Ensure Azure automation account does NOT have overly
+    pretty_name: 'Ensure Azure automation account does NOT have overly
       permissive network access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_25:
@@ -902,7 +902,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_25
-    pretty_name: 'CKV2_AZURE_25: Ensure Azure SQL database Transparent Data Encryption
+    pretty_name: 'Ensure Azure SQL database Transparent Data Encryption
       (TDE) is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_26:
@@ -914,7 +914,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_26
-    pretty_name: 'CKV2_AZURE_26: Ensure Azure PostgreSQL Flexible server is not configured
+    pretty_name: 'Ensure Azure PostgreSQL Flexible server is not configured
       with overly permissive network access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_27:
@@ -926,7 +926,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV2_AZURE_27
-    pretty_name: 'CKV2_AZURE_27: Ensure Azure AD authentication is enabled for Azure
+    pretty_name: 'Ensure Azure AD authentication is enabled for Azure
       SQL (MSSQL)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_28:
@@ -938,7 +938,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV2_AZURE_28
-    pretty_name: 'CKV2_AZURE_28: Ensure Container Instance is configured with managed
+    pretty_name: 'Ensure Container Instance is configured with managed
       identity'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_29:
@@ -950,7 +950,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_29
-    pretty_name: 'CKV2_AZURE_29: Ensure AKS cluster has Azure CNI networking enabled'
+    pretty_name: 'Ensure AKS cluster has Azure CNI networking enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_3:
     categories:
@@ -961,7 +961,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_3
-    pretty_name: 'CKV2_AZURE_3: Ensure that VA setting Periodic Recurring Scans is
+    pretty_name: 'Ensure that VA setting Periodic Recurring Scans is
       enabled on a SQL server'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_30:
@@ -973,7 +973,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV2_AZURE_30
-    pretty_name: 'CKV2_AZURE_30: Ensure Azure Container Registry (ACR) has HTTPS enabled
+    pretty_name: 'Ensure Azure Container Registry (ACR) has HTTPS enabled
       for webhook'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_31:
@@ -985,7 +985,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_31
-    pretty_name: 'CKV2_AZURE_31: Ensure VNET subnet is configured with a Network Security
+    pretty_name: 'Ensure VNET subnet is configured with a Network Security
       Group (NSG)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_32:
@@ -997,7 +997,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_32
-    pretty_name: 'CKV2_AZURE_32: Ensure private endpoint is configured to key vault'
+    pretty_name: 'Ensure private endpoint is configured to key vault'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_33:
     categories:
@@ -1008,7 +1008,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_33
-    pretty_name: 'CKV2_AZURE_33: Ensure storage account is configured with private
+    pretty_name: 'Ensure storage account is configured with private
       endpoint'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_4:
@@ -1020,7 +1020,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_4
-    pretty_name: 'CKV2_AZURE_4: Ensure Azure SQL server ADS VA Send scan reports to
+    pretty_name: 'Ensure Azure SQL server ADS VA Send scan reports to
       is configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_5:
@@ -1030,7 +1030,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_5
-    pretty_name: 'CKV2_AZURE_5: Ensure that VA setting ''Also send email notifications
+    pretty_name: 'Ensure that VA setting ''Also send email notifications
       to admins and subscription owners'' is set for a SQL server'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_6:
@@ -1042,7 +1042,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_6
-    pretty_name: 'CKV2_AZURE_6: Ensure ''Allow access to Azure services'' for PostgreSQL
+    pretty_name: 'Ensure ''Allow access to Azure services'' for PostgreSQL
       Database Server is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_7:
@@ -1054,7 +1054,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_7
-    pretty_name: 'CKV2_AZURE_7: Ensure that Azure Active Directory Admin is configured'
+    pretty_name: 'Ensure that Azure Active Directory Admin is configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_8:
     categories:
@@ -1065,7 +1065,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV2_AZURE_8
-    pretty_name: 'CKV2_AZURE_8: Ensure the storage container storing the activity
+    pretty_name: 'Ensure the storage container storing the activity
       logs is not publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_AZURE_9:
@@ -1077,7 +1077,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV2_AZURE_9
-    pretty_name: 'CKV2_AZURE_9: Ensure Virtual Machines are utilizing Managed Disks'
+    pretty_name: 'Ensure Virtual Machines are utilizing Managed Disks'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_1:
     categories:
@@ -1088,7 +1088,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV2_DOCKER_1
-    pretty_name: 'CKV2_DOCKER_1: Ensure that sudo isn''t used'
+    pretty_name: 'Ensure that sudo isn''t used'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_10:
     categories:
@@ -1099,7 +1099,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_10
-    pretty_name: 'CKV2_DOCKER_10: Ensure that packages with untrusted or missing signatures
+    pretty_name: 'Ensure that packages with untrusted or missing signatures
       are not used by rpm via the ''--nodigest'', ''--nosignature'', ''--noverify'',
       or ''--nofiledigest'' options'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
@@ -1112,7 +1112,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_11
-    pretty_name: 'CKV2_DOCKER_11: Ensure that the ''--force-yes'' option is not used,
+    pretty_name: 'Ensure that the ''--force-yes'' option is not used,
       as it disables signature validation and allows packages to be downgraded which
       can leave the system in a broken or inconsistent state'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
@@ -1125,7 +1125,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_12
-    pretty_name: 'CKV2_DOCKER_12: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       for npm via the ''NPM_CONFIG_STRICT_SSL'' environmnet variable'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_13:
@@ -1137,7 +1137,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_13
-    pretty_name: 'CKV2_DOCKER_13: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       for npm or yarn by setting the option strict-ssl to false'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_14:
@@ -1149,7 +1149,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_14
-    pretty_name: 'CKV2_DOCKER_14: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       for git by setting the environment variable ''GIT_SSL_NO_VERIFY'' to any value'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_15:
@@ -1161,7 +1161,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_15
-    pretty_name: 'CKV2_DOCKER_15: Ensure that the yum and dnf package managers are
+    pretty_name: 'Ensure that the yum and dnf package managers are
       not configured to disable SSL certificate validation via the ''sslverify'' configuration
       option'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
@@ -1174,7 +1174,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_16
-    pretty_name: 'CKV2_DOCKER_16: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with pip via the ''PIP_TRUSTED_HOST'' environment variable'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_2:
@@ -1186,7 +1186,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_2
-    pretty_name: 'CKV2_DOCKER_2: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with curl'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_3:
@@ -1198,7 +1198,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_3
-    pretty_name: 'CKV2_DOCKER_3: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with wget'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_4:
@@ -1210,7 +1210,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_4
-    pretty_name: 'CKV2_DOCKER_4: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with the pip ''--trusted-host'' option'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_5:
@@ -1222,7 +1222,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_5
-    pretty_name: 'CKV2_DOCKER_5: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with the PYTHONHTTPSVERIFY environmnet variable'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_6:
@@ -1234,7 +1234,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_6
-    pretty_name: 'CKV2_DOCKER_6: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with the NODE_TLS_REJECT_UNAUTHORIZED environmnet variable'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_7:
@@ -1246,7 +1246,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_7
-    pretty_name: 'CKV2_DOCKER_7: Ensure that packages with untrusted or missing signatures
+    pretty_name: 'Ensure that packages with untrusted or missing signatures
       are not used by apk via the ''--allow-untrusted'' option'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_8:
@@ -1258,7 +1258,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_8
-    pretty_name: 'CKV2_DOCKER_8: Ensure that packages with untrusted or missing signatures
+    pretty_name: 'Ensure that packages with untrusted or missing signatures
       are not used by apt-get via the ''--allow-unauthenticated'' option'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_DOCKER_9:
@@ -1270,7 +1270,7 @@ rules:
     description: Check for weak Docker configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_DOCKER_9
-    pretty_name: 'CKV2_DOCKER_9: Ensure that packages with untrusted or missing GPG
+    pretty_name: 'Ensure that packages with untrusted or missing GPG
       signatures are not used by dnf, tdnf, or yum via the ''--nogpgcheck'' option'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_1:
@@ -1282,7 +1282,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV2_GCP_1
-    pretty_name: 'CKV2_GCP_1: Ensure GKE clusters are not running using the Compute
+    pretty_name: 'Ensure GKE clusters are not running using the Compute
       Engine default service account '
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_10:
@@ -1294,7 +1294,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_10
-    pretty_name: 'CKV2_GCP_10: Ensure GCP Cloud Function HTTP trigger is secured'
+    pretty_name: 'Ensure GCP Cloud Function HTTP trigger is secured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_11:
     categories:
@@ -1305,7 +1305,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_11
-    pretty_name: 'CKV2_GCP_11: Ensure GCP GCR Container Vulnerability Scanning is
+    pretty_name: 'Ensure GCP GCR Container Vulnerability Scanning is
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_12:
@@ -1317,7 +1317,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_12
-    pretty_name: 'CKV2_GCP_12: Ensure GCP compute firewall ingress does not allow
+    pretty_name: 'Ensure GCP compute firewall ingress does not allow
       unrestricted access to all ports'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_13:
@@ -1329,7 +1329,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_13
-    pretty_name: 'CKV2_GCP_13: Ensure PostgreSQL database flag ''log_duration'' is
+    pretty_name: 'Ensure PostgreSQL database flag ''log_duration'' is
       set to ''on'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_14:
@@ -1341,7 +1341,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_14
-    pretty_name: 'CKV2_GCP_14: Ensure PostgreSQL database flag ''log_executor_stats''
+    pretty_name: 'Ensure PostgreSQL database flag ''log_executor_stats''
       is set to ''off'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_15:
@@ -1353,7 +1353,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_15
-    pretty_name: 'CKV2_GCP_15: Ensure PostgreSQL database flag ''log_parser_stats''
+    pretty_name: 'Ensure PostgreSQL database flag ''log_parser_stats''
       is set to ''off'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_16:
@@ -1365,7 +1365,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_16
-    pretty_name: 'CKV2_GCP_16: Ensure PostgreSQL database flag ''log_planner_stats''
+    pretty_name: 'Ensure PostgreSQL database flag ''log_planner_stats''
       is set to ''off'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_17:
@@ -1377,7 +1377,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_17
-    pretty_name: 'CKV2_GCP_17: Ensure PostgreSQL database flag ''log_statement_stats''
+    pretty_name: 'Ensure PostgreSQL database flag ''log_statement_stats''
       is set to ''off'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_18:
@@ -1389,7 +1389,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_18
-    pretty_name: 'CKV2_GCP_18: Ensure GCP network defines a firewall and does not
+    pretty_name: 'Ensure GCP network defines a firewall and does not
       use the default firewall'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_19:
@@ -1401,7 +1401,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_19
-    pretty_name: 'CKV2_GCP_19: Ensure GCP Kubernetes engine clusters have ''alpha
+    pretty_name: 'Ensure GCP Kubernetes engine clusters have ''alpha
       cluster'' feature disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_2:
@@ -1413,7 +1413,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_2
-    pretty_name: 'CKV2_GCP_2: Ensure legacy networks do not exist for a project'
+    pretty_name: 'Ensure legacy networks do not exist for a project'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_20:
     categories:
@@ -1424,7 +1424,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_20
-    pretty_name: 'CKV2_GCP_20: Ensure MySQL DB instance has point-in-time recovery
+    pretty_name: 'Ensure MySQL DB instance has point-in-time recovery
       backup configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_3:
@@ -1436,7 +1436,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV2_GCP_3
-    pretty_name: 'CKV2_GCP_3: Ensure that there are only GCP-managed service account
+    pretty_name: 'Ensure that there are only GCP-managed service account
       keys for each service account'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_4:
@@ -1447,7 +1447,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_4
-    pretty_name: 'CKV2_GCP_4: Ensure that retention policies on log buckets are configured
+    pretty_name: 'Ensure that retention policies on log buckets are configured
       using Bucket Lock'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_5:
@@ -1459,7 +1459,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_5
-    pretty_name: 'CKV2_GCP_5: Ensure that Cloud Audit Logging is configured properly
+    pretty_name: 'Ensure that Cloud Audit Logging is configured properly
       across all services and all users from a project'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_6:
@@ -1471,7 +1471,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV2_GCP_6
-    pretty_name: 'CKV2_GCP_6: Ensure that Cloud KMS cryptokeys are not anonymously
+    pretty_name: 'Ensure that Cloud KMS cryptokeys are not anonymously
       or publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_7:
@@ -1483,7 +1483,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV2_GCP_7
-    pretty_name: 'CKV2_GCP_7: Ensure that a MySQL database instance does not allow
+    pretty_name: 'Ensure that a MySQL database instance does not allow
       anyone to connect with administrative privileges'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_8:
@@ -1495,7 +1495,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV2_GCP_8
-    pretty_name: 'CKV2_GCP_8: Ensure that Cloud KMS Key Rings are not anonymously
+    pretty_name: 'Ensure that Cloud KMS Key Rings are not anonymously
       or publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GCP_9:
@@ -1507,7 +1507,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV2_GCP_9
-    pretty_name: 'CKV2_GCP_9: Ensure that Container Registry repositories are not
+    pretty_name: 'Ensure that Container Registry repositories are not
       anonymously or publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_GHA_1:
@@ -1519,7 +1519,7 @@ rules:
     description: Check for weak GitHub Action configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV2_GHA_1
-    pretty_name: 'CKV2_GHA_1: Ensure top-level permissions are not set to write-all'
+    pretty_name: 'Ensure top-level permissions are not set to write-all'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_K8S_1:
     categories:
@@ -1530,7 +1530,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV2_K8S_1
-    pretty_name: 'CKV2_K8S_1: RoleBinding should not allow privilege escalation to
+    pretty_name: 'RoleBinding should not allow privilege escalation to
       a ServiceAccount or Node on other RoleBinding'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_K8S_2:
@@ -1542,7 +1542,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV2_K8S_2
-    pretty_name: 'CKV2_K8S_2: Granting `create` permissions to `nodes/proxy` or `pods/exec`
+    pretty_name: 'Granting `create` permissions to `nodes/proxy` or `pods/exec`
       sub resources allows potential privilege escalation'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_K8S_3:
@@ -1554,7 +1554,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV2_K8S_3
-    pretty_name: 'CKV2_K8S_3: No ServiceAccount/Node should have `impersonate` permissions
+    pretty_name: 'No ServiceAccount/Node should have `impersonate` permissions
       for groups/users/service-accounts'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_K8S_4:
@@ -1566,7 +1566,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV2_K8S_4
-    pretty_name: 'CKV2_K8S_4: ServiceAccounts and nodes that can modify services/status
+    pretty_name: 'ServiceAccounts and nodes that can modify services/status
       may set the `status.loadBalancer.ingress.ip` field to exploit the unfixed CVE-2020-8554
       and launch MiTM attacks against the cluster.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
@@ -1579,7 +1579,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV2_K8S_5
-    pretty_name: 'CKV2_K8S_5: No ServiceAccount/Node should be able to read all secrets'
+    pretty_name: 'No ServiceAccount/Node should be able to read all secrets'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV2_K8S_6:
     categories:
@@ -1590,7 +1590,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV2_K8S_6
-    pretty_name: 'CKV2_K8S_6: Minimize the admission of pods which lack an associated
+    pretty_name: 'Minimize the admission of pods which lack an associated
       NetworkPolicy'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_1:
@@ -1602,7 +1602,7 @@ rules:
     description: Check for publicly accessible Alibaba Cloud resources.
     group: cloud-resources-public-access
     name: CKV_ALI_1
-    pretty_name: 'CKV_ALI_1: Alibaba Cloud OSS bucket accessible to public'
+    pretty_name: 'Alibaba Cloud OSS bucket accessible to public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_10:
     categories:
@@ -1611,7 +1611,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_10
-    pretty_name: 'CKV_ALI_10: Ensure OSS bucket has versioning enabled'
+    pretty_name: 'Ensure OSS bucket has versioning enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_11:
     categories:
@@ -1620,7 +1620,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_11
-    pretty_name: 'CKV_ALI_11: Ensure OSS bucket has transfer Acceleration enabled'
+    pretty_name: 'Ensure OSS bucket has transfer Acceleration enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_12:
     categories:
@@ -1631,7 +1631,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_12
-    pretty_name: 'CKV_ALI_12: Ensure the OSS bucket has access logging enabled'
+    pretty_name: 'Ensure the OSS bucket has access logging enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_13:
     categories:
@@ -1642,7 +1642,7 @@ rules:
     description: Check for weak Alibaba Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_ALI_13
-    pretty_name: 'CKV_ALI_13: Ensure RAM password policy requires minimum length of
+    pretty_name: 'Ensure RAM password policy requires minimum length of
       14 or greater'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_14:
@@ -1652,7 +1652,7 @@ rules:
     description: Check for weak Alibaba Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_ALI_14
-    pretty_name: 'CKV_ALI_14: Ensure RAM password policy requires at least one number'
+    pretty_name: 'Ensure RAM password policy requires at least one number'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_15:
     categories:
@@ -1661,7 +1661,7 @@ rules:
     description: Check for weak Alibaba Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_ALI_15
-    pretty_name: 'CKV_ALI_15: Ensure RAM password policy requires at least one symbol'
+    pretty_name: 'Ensure RAM password policy requires at least one symbol'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_16:
     categories:
@@ -1670,7 +1670,7 @@ rules:
     description: Check for weak Alibaba Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_ALI_16
-    pretty_name: 'CKV_ALI_16: Ensure RAM password policy expires passwords within
+    pretty_name: 'Ensure RAM password policy expires passwords within
       90 days or less'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_17:
@@ -1680,7 +1680,7 @@ rules:
     description: Check for weak Alibaba Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_ALI_17
-    pretty_name: 'CKV_ALI_17: Ensure RAM password policy requires at least one lowercase
+    pretty_name: 'Ensure RAM password policy requires at least one lowercase
       letter'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_18:
@@ -1692,7 +1692,7 @@ rules:
     description: Check for weak Alibaba Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_ALI_18
-    pretty_name: 'CKV_ALI_18: Ensure RAM password policy prevents password reuse'
+    pretty_name: 'Ensure RAM password policy prevents password reuse'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_19:
     categories:
@@ -1701,7 +1701,7 @@ rules:
     description: Check for weak Alibaba Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_ALI_19
-    pretty_name: 'CKV_ALI_19: Ensure RAM password policy requires at least one uppercase
+    pretty_name: 'Ensure RAM password policy requires at least one uppercase
       letter'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_2:
@@ -1713,7 +1713,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_2
-    pretty_name: 'CKV_ALI_2: Ensure no security groups allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security groups allow ingress from 0.0.0.0:0
       to port 22'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_20:
@@ -1725,7 +1725,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_20
-    pretty_name: 'CKV_ALI_20: Ensure RDS instance uses SSL'
+    pretty_name: 'Ensure RDS instance uses SSL'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_21:
     categories:
@@ -1736,7 +1736,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_21
-    pretty_name: 'CKV_ALI_21: Ensure API Gateway API Protocol HTTPS'
+    pretty_name: 'Ensure API Gateway API Protocol HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_22:
     categories:
@@ -1747,7 +1747,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_22
-    pretty_name: 'CKV_ALI_22: Ensure Transparent Data Encryption is Enabled on instance'
+    pretty_name: 'Ensure Transparent Data Encryption is Enabled on instance'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_23:
     categories:
@@ -1756,7 +1756,7 @@ rules:
     description: Check for weak Alibaba Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_ALI_23
-    pretty_name: 'CKV_ALI_23: Ensure Ram Account Password Policy Max Login Attempts
+    pretty_name: 'Ensure Ram Account Password Policy Max Login Attempts
       not > 5'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_24:
@@ -1768,7 +1768,7 @@ rules:
     description: Check for weak Alibaba Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_ALI_24
-    pretty_name: 'CKV_ALI_24: Ensure RAM enforces MFA'
+    pretty_name: 'Ensure RAM enforces MFA'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_25:
     categories:
@@ -1778,7 +1778,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_25
-    pretty_name: 'CKV_ALI_25: Ensure RDS Instance SQL Collector Retention Period should
+    pretty_name: 'Ensure RDS Instance SQL Collector Retention Period should
       be greater than 180'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_26:
@@ -1788,7 +1788,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_26
-    pretty_name: 'CKV_ALI_26: Ensure Kubernetes installs plugin Terway or Flannel
+    pretty_name: 'Ensure Kubernetes installs plugin Terway or Flannel
       to support standard policies'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_27:
@@ -1800,7 +1800,7 @@ rules:
     description: Check that ensures best practices in Alibaba Cloud secrets management.
     group: cloud-weak-secrets-management
     name: CKV_ALI_27
-    pretty_name: 'CKV_ALI_27: Ensure KMS Key Rotation is enabled'
+    pretty_name: 'Ensure KMS Key Rotation is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_28:
     categories:
@@ -1811,7 +1811,7 @@ rules:
     description: Check that ensures best practices in Alibaba Cloud secrets management.
     group: cloud-weak-secrets-management
     name: CKV_ALI_28
-    pretty_name: 'CKV_ALI_28: Ensure KMS Keys are enabled'
+    pretty_name: 'Ensure KMS Keys are enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_29:
     categories:
@@ -1820,7 +1820,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_29
-    pretty_name: 'CKV_ALI_29: Alibaba ALB ACL does not restrict Access'
+    pretty_name: 'Alibaba ALB ACL does not restrict Access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_3:
     categories:
@@ -1829,7 +1829,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_3
-    pretty_name: 'CKV_ALI_3: Ensure no security groups allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security groups allow ingress from 0.0.0.0:0
       to port 3389'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_30:
@@ -1839,7 +1839,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_30
-    pretty_name: 'CKV_ALI_30: Ensure RDS instance auto upgrades for minor versions'
+    pretty_name: 'Ensure RDS instance auto upgrades for minor versions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_31:
     categories:
@@ -1848,7 +1848,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_31
-    pretty_name: 'CKV_ALI_31: Ensure K8s nodepools are set to auto repair'
+    pretty_name: 'Ensure K8s nodepools are set to auto repair'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_32:
     categories:
@@ -1857,7 +1857,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_32
-    pretty_name: 'CKV_ALI_32: Ensure launch template data disks are encrypted'
+    pretty_name: 'Ensure launch template data disks are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_33:
     categories:
@@ -1866,7 +1866,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_33
-    pretty_name: 'CKV_ALI_33: Alibaba Cloud Cypher Policy are secure'
+    pretty_name: 'Alibaba Cloud Cypher Policy are secure'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_35:
     categories:
@@ -1875,7 +1875,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_35
-    pretty_name: 'CKV_ALI_35: Ensure RDS instance has log_duration enabled'
+    pretty_name: 'Ensure RDS instance has log_duration enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_36:
     categories:
@@ -1884,7 +1884,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_36
-    pretty_name: 'CKV_ALI_36: Ensure RDS instance has log_disconnections enabled'
+    pretty_name: 'Ensure RDS instance has log_disconnections enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_37:
     categories:
@@ -1893,7 +1893,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_37
-    pretty_name: 'CKV_ALI_37: Ensure RDS instance has log_connections enabled'
+    pretty_name: 'Ensure RDS instance has log_connections enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_38:
     categories:
@@ -1902,7 +1902,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_38
-    pretty_name: 'CKV_ALI_38: Ensure log audit is enabled for RDS'
+    pretty_name: 'Ensure log audit is enabled for RDS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_4:
     categories:
@@ -1911,7 +1911,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_4
-    pretty_name: 'CKV_ALI_4: Ensure Action Trail Logging for all regions'
+    pretty_name: 'Ensure Action Trail Logging for all regions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_41:
     categories:
@@ -1920,7 +1920,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_41
-    pretty_name: 'CKV_ALI_41: Ensure MongoDB is deployed inside a VPC'
+    pretty_name: 'Ensure MongoDB is deployed inside a VPC'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_42:
     categories:
@@ -1929,7 +1929,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_42
-    pretty_name: 'CKV_ALI_42: Ensure Mongodb instance uses SSL'
+    pretty_name: 'Ensure Mongodb instance uses SSL'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_43:
     categories:
@@ -1938,7 +1938,7 @@ rules:
     description: Check for publicly accessible Alibaba Cloud resources.
     group: cloud-resources-public-access
     name: CKV_ALI_43
-    pretty_name: 'CKV_ALI_43: Ensure MongoDB instance is not public'
+    pretty_name: 'Ensure MongoDB instance is not public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_44:
     categories:
@@ -1947,7 +1947,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_44
-    pretty_name: 'CKV_ALI_44: Ensure MongoDB has Transparent Data Encryption Enabled'
+    pretty_name: 'Ensure MongoDB has Transparent Data Encryption Enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_5:
     categories:
@@ -1956,7 +1956,7 @@ rules:
     description: Check for misconfigurations in Alibaba Cloud resources.
     group: cloud-weak-configuration
     name: CKV_ALI_5
-    pretty_name: 'CKV_ALI_5: Ensure Action Trail Logging for all events'
+    pretty_name: 'Ensure Action Trail Logging for all events'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_6:
     categories:
@@ -1965,7 +1965,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_6
-    pretty_name: 'CKV_ALI_6: Ensure OSS bucket is encrypted with Customer Master Key'
+    pretty_name: 'Ensure OSS bucket is encrypted with Customer Master Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_7:
     categories:
@@ -1974,7 +1974,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_7
-    pretty_name: 'CKV_ALI_7: Ensure disk is encrypted'
+    pretty_name: 'Ensure disk is encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_8:
     categories:
@@ -1983,7 +1983,7 @@ rules:
     description: Check for unencrypted Alibaba Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_ALI_8
-    pretty_name: 'CKV_ALI_8: Ensure Disk is encrypted with Customer Master Key'
+    pretty_name: 'Ensure Disk is encrypted with Customer Master Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ALI_9:
     categories:
@@ -1992,7 +1992,7 @@ rules:
     description: Check for publicly accessible Alibaba Cloud resources.
     group: cloud-resources-public-access
     name: CKV_ALI_9
-    pretty_name: 'CKV_ALI_9: Ensure database instance is not public'
+    pretty_name: 'Ensure database instance is not public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ANSIBLE_1:
     categories:
@@ -2003,7 +2003,7 @@ rules:
     description: Check for weak Ansible configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_ANSIBLE_1
-    pretty_name: 'CKV_ANSIBLE_1: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with uri'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ANSIBLE_2:
@@ -2015,7 +2015,7 @@ rules:
     description: Check for weak Ansible configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_ANSIBLE_2
-    pretty_name: 'CKV_ANSIBLE_2: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with get_url'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ANSIBLE_3:
@@ -2027,7 +2027,7 @@ rules:
     description: Check for weak Ansible configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_ANSIBLE_3
-    pretty_name: 'CKV_ANSIBLE_3: Ensure that certificate validation isn''t disabled
+    pretty_name: 'Ensure that certificate validation isn''t disabled
       with yum'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ANSIBLE_4:
@@ -2039,7 +2039,7 @@ rules:
     description: Check for weak Ansible configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_ANSIBLE_4
-    pretty_name: 'CKV_ANSIBLE_4: Ensure that SSL validation isn''t disabled with yum'
+    pretty_name: 'Ensure that SSL validation isn''t disabled with yum'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ANSIBLE_5:
     categories:
@@ -2050,7 +2050,7 @@ rules:
     description: Check for weak Ansible configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_ANSIBLE_5
-    pretty_name: 'CKV_ANSIBLE_5: Ensure that packages with untrusted or missing signatures
+    pretty_name: 'Ensure that packages with untrusted or missing signatures
       are not used'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ANSIBLE_6:
@@ -2062,7 +2062,7 @@ rules:
     description: Check for misconfigurations in Ansible resources.
     group: cloud-weak-configuration
     name: CKV_ANSIBLE_6
-    pretty_name: 'CKV_ANSIBLE_6: Ensure that the force parameter is not used, as it
+    pretty_name: 'Ensure that the force parameter is not used, as it
       disables signature validation and allows packages to be downgraded which can
       leave the system in a broken or inconsistent state'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
@@ -2075,7 +2075,7 @@ rules:
     description: Check for misconfigurations in Argo resources.
     group: cloud-weak-configuration
     name: CKV_ARGO_1
-    pretty_name: 'CKV_ARGO_1: Ensure Workflow pods are not using the default ServiceAccount'
+    pretty_name: 'Ensure Workflow pods are not using the default ServiceAccount'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_ARGO_2:
     categories:
@@ -2086,7 +2086,7 @@ rules:
     description: Check for misconfigurations in Argo resources.
     group: cloud-weak-configuration
     name: CKV_ARGO_2
-    pretty_name: 'CKV_ARGO_2: Ensure Workflow pods are running as non-root user'
+    pretty_name: 'Ensure Workflow pods are running as non-root user'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_1:
     categories:
@@ -2097,7 +2097,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_1
-    pretty_name: 'CKV_AWS_1: Ensure IAM policies that allow full "*-*" administrative
+    pretty_name: 'Ensure IAM policies that allow full "*-*" administrative
       privileges are not created'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_10:
@@ -2109,7 +2109,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_10
-    pretty_name: 'CKV_AWS_10: Ensure IAM password policy requires minimum length of
+    pretty_name: 'Ensure IAM password policy requires minimum length of
       14 or greater'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_100:
@@ -2121,7 +2121,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_100
-    pretty_name: 'CKV_AWS_100: Ensure AWS EKS node group does not have implicit SSH
+    pretty_name: 'Ensure AWS EKS node group does not have implicit SSH
       access from 0.0.0.0/0'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_101:
@@ -2132,7 +2132,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_101
-    pretty_name: 'CKV_AWS_101: Ensure Neptune logging is enabled'
+    pretty_name: 'Ensure Neptune logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_102:
     categories:
@@ -2143,7 +2143,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_102
-    pretty_name: 'CKV_AWS_102: Ensure Neptune Cluster instance is not publicly available'
+    pretty_name: 'Ensure Neptune Cluster instance is not publicly available'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_103:
     categories:
@@ -2154,7 +2154,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_103
-    pretty_name: 'CKV_AWS_103: Ensure that load balancer is using at least TLS 1.2'
+    pretty_name: 'Ensure that load balancer is using at least TLS 1.2'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_104:
     categories:
@@ -2165,7 +2165,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_104
-    pretty_name: 'CKV_AWS_104: Ensure DocDB has audit logs enabled'
+    pretty_name: 'Ensure DocDB has audit logs enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_105:
     categories:
@@ -2176,7 +2176,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_105
-    pretty_name: 'CKV_AWS_105: Ensure Redshift uses SSL'
+    pretty_name: 'Ensure Redshift uses SSL'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_106:
     categories:
@@ -2187,7 +2187,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_106
-    pretty_name: 'CKV_AWS_106: Ensure EBS default encryption is enabled'
+    pretty_name: 'Ensure EBS default encryption is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_107:
     categories:
@@ -2198,7 +2198,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_107
-    pretty_name: 'CKV_AWS_107: Ensure IAM policies does not allow credentials exposure'
+    pretty_name: 'Ensure IAM policies does not allow credentials exposure'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_108:
     categories:
@@ -2208,7 +2208,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_108
-    pretty_name: 'CKV_AWS_108: Ensure IAM policies does not allow data exfiltration'
+    pretty_name: 'Ensure IAM policies does not allow data exfiltration'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_109:
     categories:
@@ -2219,7 +2219,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_109
-    pretty_name: 'CKV_AWS_109: Ensure IAM policies does not allow permissions management
+    pretty_name: 'Ensure IAM policies does not allow permissions management
       / resource exposure without constraints'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_11:
@@ -2230,7 +2230,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_11
-    pretty_name: 'CKV_AWS_11: Ensure IAM password policy requires at least one lowercase
+    pretty_name: 'Ensure IAM password policy requires at least one lowercase
       letter'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_110:
@@ -2242,7 +2242,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_110
-    pretty_name: 'CKV_AWS_110: Ensure IAM policies does not allow privilege escalation'
+    pretty_name: 'Ensure IAM policies does not allow privilege escalation'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_111:
     categories:
@@ -2253,7 +2253,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_111
-    pretty_name: 'CKV_AWS_111: Ensure IAM policies does not allow write access without
+    pretty_name: 'Ensure IAM policies does not allow write access without
       constraints'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_112:
@@ -2265,7 +2265,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_112
-    pretty_name: 'CKV_AWS_112: Ensure Session Manager data is encrypted in transit'
+    pretty_name: 'Ensure Session Manager data is encrypted in transit'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_113:
     categories:
@@ -2276,7 +2276,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_113
-    pretty_name: 'CKV_AWS_113: Ensure Session Manager logs are enabled and encrypted'
+    pretty_name: 'Ensure Session Manager logs are enabled and encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_114:
     categories:
@@ -2287,7 +2287,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_114
-    pretty_name: 'CKV_AWS_114: Ensure that EMR clusters with Kerberos have Kerberos
+    pretty_name: 'Ensure that EMR clusters with Kerberos have Kerberos
       Realm set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_115:
@@ -2299,7 +2299,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_115
-    pretty_name: 'CKV_AWS_115: Ensure that AWS Lambda function is configured for function-level
+    pretty_name: 'Ensure that AWS Lambda function is configured for function-level
       concurrent execution limit'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_116:
@@ -2310,7 +2310,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_116
-    pretty_name: 'CKV_AWS_116: Ensure that AWS Lambda function is configured for a
+    pretty_name: 'Ensure that AWS Lambda function is configured for a
       Dead Letter Queue(DLQ)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_117:
@@ -2321,7 +2321,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_117
-    pretty_name: 'CKV_AWS_117: Ensure that AWS Lambda function is configured inside
+    pretty_name: 'Ensure that AWS Lambda function is configured inside
       a VPC'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_118:
@@ -2332,7 +2332,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_118
-    pretty_name: 'CKV_AWS_118: Ensure that enhanced monitoring is enabled for Amazon
+    pretty_name: 'Ensure that enhanced monitoring is enabled for Amazon
       RDS instances'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_119:
@@ -2342,7 +2342,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_119
-    pretty_name: 'CKV_AWS_119: Ensure DynamoDB Tables are encrypted using a KMS Customer
+    pretty_name: 'Ensure DynamoDB Tables are encrypted using a KMS Customer
       Managed CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_12:
@@ -2352,7 +2352,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_12
-    pretty_name: 'CKV_AWS_12: Ensure IAM password policy requires at least one number'
+    pretty_name: 'Ensure IAM password policy requires at least one number'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_120:
     categories:
@@ -2362,7 +2362,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_120
-    pretty_name: 'CKV_AWS_120: Ensure API Gateway caching is enabled'
+    pretty_name: 'Ensure API Gateway caching is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_121:
     categories:
@@ -2373,7 +2373,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_121
-    pretty_name: 'CKV_AWS_121: Ensure AWS Config is enabled in all regions'
+    pretty_name: 'Ensure AWS Config is enabled in all regions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_122:
     categories:
@@ -2384,7 +2384,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_122
-    pretty_name: 'CKV_AWS_122: Ensure that direct internet access is disabled for
+    pretty_name: 'Ensure that direct internet access is disabled for
       an Amazon SageMaker Notebook Instance'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_123:
@@ -2396,7 +2396,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_123
-    pretty_name: 'CKV_AWS_123: Ensure that VPC Endpoint Service is configured for
+    pretty_name: 'Ensure that VPC Endpoint Service is configured for
       Manual Acceptance'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_124:
@@ -2406,7 +2406,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_124
-    pretty_name: 'CKV_AWS_124: Ensure that CloudFormation stacks are sending event
+    pretty_name: 'Ensure that CloudFormation stacks are sending event
       notifications to an SNS topic'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_126:
@@ -2417,7 +2417,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_126
-    pretty_name: 'CKV_AWS_126: Ensure that detailed monitoring is enabled for EC2
+    pretty_name: 'Ensure that detailed monitoring is enabled for EC2
       instances'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_127:
@@ -2429,7 +2429,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_127
-    pretty_name: 'CKV_AWS_127: Ensure that Elastic Load Balancer(s) uses SSL certificates
+    pretty_name: 'Ensure that Elastic Load Balancer(s) uses SSL certificates
       provided by AWS Certificate Manager'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_128:
@@ -2441,7 +2441,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_128
-    pretty_name: 'CKV_AWS_128: Ensure that an Amazon RDS Clusters have AWS Identity
+    pretty_name: 'Ensure that an Amazon RDS Clusters have AWS Identity
       and Access Management (IAM) authentication enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_129:
@@ -2453,7 +2453,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_129
-    pretty_name: 'CKV_AWS_129: Ensure that respective logs of Amazon Relational Database
+    pretty_name: 'Ensure that respective logs of Amazon Relational Database
       Service (Amazon RDS) are enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_13:
@@ -2465,7 +2465,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_13
-    pretty_name: 'CKV_AWS_13: Ensure IAM password policy prevents password reuse'
+    pretty_name: 'Ensure IAM password policy prevents password reuse'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_130:
     categories:
@@ -2476,7 +2476,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_130
-    pretty_name: 'CKV_AWS_130: Ensure VPC subnets do not assign public IP by default'
+    pretty_name: 'Ensure VPC subnets do not assign public IP by default'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_131:
     categories:
@@ -2487,7 +2487,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_131
-    pretty_name: 'CKV_AWS_131: Ensure that ALB drops HTTP headers'
+    pretty_name: 'Ensure that ALB drops HTTP headers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_133:
     categories:
@@ -2498,7 +2498,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_133
-    pretty_name: 'CKV_AWS_133: Ensure that RDS instances has backup policy'
+    pretty_name: 'Ensure that RDS instances has backup policy'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_134:
     categories:
@@ -2509,7 +2509,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_134
-    pretty_name: 'CKV_AWS_134: Ensure that Amazon ElastiCache Redis clusters have
+    pretty_name: 'Ensure that Amazon ElastiCache Redis clusters have
       automatic backup turned on'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_135:
@@ -2519,7 +2519,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_135
-    pretty_name: 'CKV_AWS_135: Ensure that EC2 is EBS optimized'
+    pretty_name: 'Ensure that EC2 is EBS optimized'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_136:
     categories:
@@ -2529,7 +2529,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_136
-    pretty_name: 'CKV_AWS_136: Ensure that ECR repositories are encrypted using KMS'
+    pretty_name: 'Ensure that ECR repositories are encrypted using KMS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_137:
     categories:
@@ -2540,7 +2540,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_137
-    pretty_name: 'CKV_AWS_137: Ensure that Elasticsearch is configured inside a VPC'
+    pretty_name: 'Ensure that Elasticsearch is configured inside a VPC'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_138:
     categories:
@@ -2550,7 +2550,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_138
-    pretty_name: 'CKV_AWS_138: Ensure that ELB is cross-zone-load-balancing enabled'
+    pretty_name: 'Ensure that ELB is cross-zone-load-balancing enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_139:
     categories:
@@ -2561,7 +2561,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_139
-    pretty_name: 'CKV_AWS_139: Ensure that RDS clusters have deletion protection enabled'
+    pretty_name: 'Ensure that RDS clusters have deletion protection enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_14:
     categories:
@@ -2571,7 +2571,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_14
-    pretty_name: 'CKV_AWS_14: Ensure IAM password policy requires at least one symbol'
+    pretty_name: 'Ensure IAM password policy requires at least one symbol'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_140:
     categories:
@@ -2582,7 +2582,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_140
-    pretty_name: 'CKV_AWS_140: Ensure that RDS global clusters are encrypted'
+    pretty_name: 'Ensure that RDS global clusters are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_141:
     categories:
@@ -2593,7 +2593,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_141
-    pretty_name: 'CKV_AWS_141: Ensured that redshift cluster allowing version upgrade
+    pretty_name: 'Ensured that redshift cluster allowing version upgrade
       by default'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_142:
@@ -2603,7 +2603,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_142
-    pretty_name: 'CKV_AWS_142: Ensure that Redshift cluster is encrypted by KMS'
+    pretty_name: 'Ensure that Redshift cluster is encrypted by KMS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_143:
     categories:
@@ -2613,7 +2613,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_143
-    pretty_name: 'CKV_AWS_143: Ensure that S3 bucket has lock configuration enabled
+    pretty_name: 'Ensure that S3 bucket has lock configuration enabled
       by default'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_144:
@@ -2624,7 +2624,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_144
-    pretty_name: 'CKV_AWS_144: Ensure that S3 bucket has cross-region replication
+    pretty_name: 'Ensure that S3 bucket has cross-region replication
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_145:
@@ -2634,7 +2634,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_145
-    pretty_name: 'CKV_AWS_145: Ensure that S3 buckets are encrypted with KMS by default'
+    pretty_name: 'Ensure that S3 buckets are encrypted with KMS by default'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_146:
     categories:
@@ -2645,7 +2645,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_146
-    pretty_name: 'CKV_AWS_146: Ensure that RDS database cluster snapshot is encrypted'
+    pretty_name: 'Ensure that RDS database cluster snapshot is encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_147:
     categories:
@@ -2656,7 +2656,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_147
-    pretty_name: 'CKV_AWS_147: Ensure that CodeBuild projects are encrypted'
+    pretty_name: 'Ensure that CodeBuild projects are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_148:
     categories:
@@ -2666,7 +2666,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_148
-    pretty_name: 'CKV_AWS_148: Ensure no default VPC is planned to be provisioned'
+    pretty_name: 'Ensure no default VPC is planned to be provisioned'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_149:
     categories:
@@ -2675,7 +2675,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_149
-    pretty_name: 'CKV_AWS_149: Ensure that Secrets Manager secret is encrypted using
+    pretty_name: 'Ensure that Secrets Manager secret is encrypted using
       KMS CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_15:
@@ -2686,7 +2686,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_15
-    pretty_name: 'CKV_AWS_15: Ensure IAM password policy requires at least one uppercase
+    pretty_name: 'Ensure IAM password policy requires at least one uppercase
       letter'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_150:
@@ -2698,7 +2698,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_150
-    pretty_name: 'CKV_AWS_150: Ensure that Load Balancer has deletion protection enabled'
+    pretty_name: 'Ensure that Load Balancer has deletion protection enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_152:
     categories:
@@ -2708,7 +2708,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_152
-    pretty_name: 'CKV_AWS_152: Ensure that Load Balancer (Network/Gateway) has cross-zone
+    pretty_name: 'Ensure that Load Balancer (Network/Gateway) has cross-zone
       load balancing enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_153:
@@ -2719,7 +2719,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_153
-    pretty_name: 'CKV_AWS_153: Autoscaling groups should supply tags to launch configurations'
+    pretty_name: 'Autoscaling groups should supply tags to launch configurations'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_154:
     categories:
@@ -2730,7 +2730,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_154
-    pretty_name: 'CKV_AWS_154: Ensure Redshift is not deployed outside of a VPC'
+    pretty_name: 'Ensure Redshift is not deployed outside of a VPC'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_155:
     categories:
@@ -2741,7 +2741,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_155
-    pretty_name: 'CKV_AWS_155: Ensure that Workspace user volumes are encrypted'
+    pretty_name: 'Ensure that Workspace user volumes are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_156:
     categories:
@@ -2752,7 +2752,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_156
-    pretty_name: 'CKV_AWS_156: Ensure that Workspace root volumes are encrypted'
+    pretty_name: 'Ensure that Workspace root volumes are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_157:
     categories:
@@ -2762,7 +2762,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_157
-    pretty_name: 'CKV_AWS_157: Ensure that RDS instances have Multi-AZ enabled'
+    pretty_name: 'Ensure that RDS instances have Multi-AZ enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_158:
     categories:
@@ -2771,7 +2771,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_158
-    pretty_name: 'CKV_AWS_158: Ensure that CloudWatch Log Group is encrypted by KMS'
+    pretty_name: 'Ensure that CloudWatch Log Group is encrypted by KMS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_159:
     categories:
@@ -2782,7 +2782,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_159
-    pretty_name: 'CKV_AWS_159: Ensure that Athena Workgroup is encrypted'
+    pretty_name: 'Ensure that Athena Workgroup is encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_16:
     categories:
@@ -2793,7 +2793,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_16
-    pretty_name: 'CKV_AWS_16: Ensure all data stored in the RDS is securely encrypted
+    pretty_name: 'Ensure all data stored in the RDS is securely encrypted
       at rest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_160:
@@ -2803,7 +2803,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_160
-    pretty_name: 'CKV_AWS_160: Ensure that Timestream database is encrypted with KMS
+    pretty_name: 'Ensure that Timestream database is encrypted with KMS
       CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_161:
@@ -2815,7 +2815,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_161
-    pretty_name: 'CKV_AWS_161: Ensure RDS database has IAM authentication enabled'
+    pretty_name: 'Ensure RDS database has IAM authentication enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_162:
     categories:
@@ -2826,7 +2826,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_162
-    pretty_name: 'CKV_AWS_162: Ensure RDS cluster has IAM authentication enabled'
+    pretty_name: 'Ensure RDS cluster has IAM authentication enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_163:
     categories:
@@ -2837,7 +2837,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_163
-    pretty_name: 'CKV_AWS_163: Ensure ECR image scanning on push is enabled'
+    pretty_name: 'Ensure ECR image scanning on push is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_164:
     categories:
@@ -2848,7 +2848,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_164
-    pretty_name: 'CKV_AWS_164: Ensure Transfer Server is not exposed publicly.'
+    pretty_name: 'Ensure Transfer Server is not exposed publicly.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_165:
     categories:
@@ -2859,7 +2859,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_165
-    pretty_name: 'CKV_AWS_165: Ensure Dynamodb point in time recovery (backup) is
+    pretty_name: 'Ensure Dynamodb point in time recovery (backup) is
       enabled for global tables'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_166:
@@ -2869,7 +2869,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_166
-    pretty_name: 'CKV_AWS_166: Ensure Backup Vault is encrypted at rest using KMS
+    pretty_name: 'Ensure Backup Vault is encrypted at rest using KMS
       CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_167:
@@ -2881,7 +2881,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_167
-    pretty_name: 'CKV_AWS_167: Ensure Glacier Vault access policy is not public by
+    pretty_name: 'Ensure Glacier Vault access policy is not public by
       only allowing specific services or principals to access it'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_168:
@@ -2893,7 +2893,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_168
-    pretty_name: 'CKV_AWS_168: Ensure SQS queue policy is not public by only allowing
+    pretty_name: 'Ensure SQS queue policy is not public by only allowing
       specific services or principals to access it'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_169:
@@ -2905,7 +2905,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_169
-    pretty_name: 'CKV_AWS_169: Ensure SNS topic policy is not public by only allowing
+    pretty_name: 'Ensure SNS topic policy is not public by only allowing
       specific services or principals to access it'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_17:
@@ -2917,7 +2917,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_17
-    pretty_name: 'CKV_AWS_17: Ensure all data stored in RDS is not publicly accessible'
+    pretty_name: 'Ensure all data stored in RDS is not publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_170:
     categories:
@@ -2928,7 +2928,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_170
-    pretty_name: 'CKV_AWS_170: Ensure QLDB ledger permissions mode is set to STANDARD'
+    pretty_name: 'Ensure QLDB ledger permissions mode is set to STANDARD'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_171:
     categories:
@@ -2939,7 +2939,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_171
-    pretty_name: 'CKV_AWS_171: Ensure Cluster security configuration encryption is
+    pretty_name: 'Ensure Cluster security configuration encryption is
       using SSE-KMS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_172:
@@ -2951,7 +2951,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_172
-    pretty_name: 'CKV_AWS_172: Ensure QLDB ledger has deletion protection enabled'
+    pretty_name: 'Ensure QLDB ledger has deletion protection enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_173:
     categories:
@@ -2961,7 +2961,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_173
-    pretty_name: 'CKV_AWS_173: Check encryption settings for Lambda environmental
+    pretty_name: 'Check encryption settings for Lambda environmental
       variable'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_174:
@@ -2973,7 +2973,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_174
-    pretty_name: 'CKV_AWS_174: Verify CloudFront Distribution Viewer Certificate is
+    pretty_name: 'Verify CloudFront Distribution Viewer Certificate is
       using TLS v1.2'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_175:
@@ -2983,7 +2983,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_175
-    pretty_name: 'CKV_AWS_175: Ensure WAF has associated rules'
+    pretty_name: 'Ensure WAF has associated rules'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_176:
     categories:
@@ -2992,7 +2992,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_176
-    pretty_name: 'CKV_AWS_176: Ensure Logging is enabled for WAF  Web Access Control
+    pretty_name: 'Ensure Logging is enabled for WAF  Web Access Control
       Lists'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_177:
@@ -3002,7 +3002,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_177
-    pretty_name: 'CKV_AWS_177: Ensure Kinesis Video Stream is encrypted by KMS using
+    pretty_name: 'Ensure Kinesis Video Stream is encrypted by KMS using
       a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_178:
@@ -3012,7 +3012,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_178
-    pretty_name: 'CKV_AWS_178: Ensure fx ontap file system is encrypted by KMS using
+    pretty_name: 'Ensure fx ontap file system is encrypted by KMS using
       a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_179:
@@ -3022,7 +3022,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_179
-    pretty_name: 'CKV_AWS_179: Ensure FSX Windows filesystem is encrypted by KMS using
+    pretty_name: 'Ensure FSX Windows filesystem is encrypted by KMS using
       a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_18:
@@ -3034,7 +3034,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_18
-    pretty_name: 'CKV_AWS_18: Ensure the S3 bucket has access logging enabled'
+    pretty_name: 'Ensure the S3 bucket has access logging enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_180:
     categories:
@@ -3043,7 +3043,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_180
-    pretty_name: 'CKV_AWS_180: Ensure Image Builder component is encrypted by KMS
+    pretty_name: 'Ensure Image Builder component is encrypted by KMS
       using a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_181:
@@ -3053,7 +3053,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_181
-    pretty_name: 'CKV_AWS_181: Ensure S3 Object Copy is encrypted by KMS using a customer
+    pretty_name: 'Ensure S3 Object Copy is encrypted by KMS using a customer
       managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_182:
@@ -3063,7 +3063,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_182
-    pretty_name: 'CKV_AWS_182: Ensure Doc DB is encrypted by KMS using a customer
+    pretty_name: 'Ensure Doc DB is encrypted by KMS using a customer
       managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_183:
@@ -3073,7 +3073,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_183
-    pretty_name: 'CKV_AWS_183: Ensure EBS Snapshot Copy is encrypted by KMS using
+    pretty_name: 'Ensure EBS Snapshot Copy is encrypted by KMS using
       a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_184:
@@ -3083,7 +3083,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_184
-    pretty_name: 'CKV_AWS_184: Ensure resource is encrypted by KMS using a customer
+    pretty_name: 'Ensure resource is encrypted by KMS using a customer
       managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_185:
@@ -3093,7 +3093,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_185
-    pretty_name: 'CKV_AWS_185: Ensure Kinesis Stream is encrypted by KMS using a customer
+    pretty_name: 'Ensure Kinesis Stream is encrypted by KMS using a customer
       managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_186:
@@ -3103,7 +3103,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_186
-    pretty_name: 'CKV_AWS_186: Ensure S3 bucket Object is encrypted by KMS using a
+    pretty_name: 'Ensure S3 bucket Object is encrypted by KMS using a
       customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_187:
@@ -3113,7 +3113,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_187
-    pretty_name: 'CKV_AWS_187: Ensure Sagemaker domain is encrypted by KMS using a
+    pretty_name: 'Ensure Sagemaker domain is encrypted by KMS using a
       customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_188:
@@ -3123,7 +3123,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_188
-    pretty_name: 'CKV_AWS_188: Ensure RedShift Cluster is encrypted by KMS using a
+    pretty_name: 'Ensure RedShift Cluster is encrypted by KMS using a
       customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_189:
@@ -3133,7 +3133,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_189
-    pretty_name: 'CKV_AWS_189: Ensure EBS Volume is encrypted by KMS using a customer
+    pretty_name: 'Ensure EBS Volume is encrypted by KMS using a customer
       managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_19:
@@ -3145,7 +3145,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_19
-    pretty_name: 'CKV_AWS_19: Ensure all data stored in the S3 bucket is securely
+    pretty_name: 'Ensure all data stored in the S3 bucket is securely
       encrypted at rest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_190:
@@ -3155,7 +3155,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_190
-    pretty_name: 'CKV_AWS_190: Ensure lustre file systems is encrypted by KMS using
+    pretty_name: 'Ensure lustre file systems is encrypted by KMS using
       a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_191:
@@ -3165,7 +3165,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_191
-    pretty_name: 'CKV_AWS_191: Ensure Elasticache replication group is encrypted by
+    pretty_name: 'Ensure Elasticache replication group is encrypted by
       KMS using a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_192:
@@ -3175,7 +3175,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_192
-    pretty_name: 'CKV_AWS_192: Ensure WAF prevents message lookup in Log4j2. See CVE-2021-44228
+    pretty_name: 'Ensure WAF prevents message lookup in Log4j2. See CVE-2021-44228
       aka log4jshell'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_193:
@@ -3187,7 +3187,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_193
-    pretty_name: 'CKV_AWS_193: Ensure AppSync has Logging enabled'
+    pretty_name: 'Ensure AppSync has Logging enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_194:
     categories:
@@ -3198,7 +3198,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_194
-    pretty_name: 'CKV_AWS_194: Ensure AppSync has Field-Level logs enabled'
+    pretty_name: 'Ensure AppSync has Field-Level logs enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_195:
     categories:
@@ -3209,7 +3209,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_195
-    pretty_name: 'CKV_AWS_195: Ensure Glue component has a security configuration
+    pretty_name: 'Ensure Glue component has a security configuration
       associated'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_196:
@@ -3221,7 +3221,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_196
-    pretty_name: 'CKV_AWS_196: Ensure no aws_elasticache_security_group resources
+    pretty_name: 'Ensure no aws_elasticache_security_group resources
       exist'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_197:
@@ -3233,7 +3233,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_197
-    pretty_name: 'CKV_AWS_197: Ensure MQ Broker Audit logging is enabled'
+    pretty_name: 'Ensure MQ Broker Audit logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_198:
     categories:
@@ -3244,7 +3244,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_198
-    pretty_name: 'CKV_AWS_198: Ensure no aws_db_security_group resources exist'
+    pretty_name: 'Ensure no aws_db_security_group resources exist'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_199:
     categories:
@@ -3253,7 +3253,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_199
-    pretty_name: 'CKV_AWS_199: Ensure Image Builder Distribution Configuration encrypts
+    pretty_name: 'Ensure Image Builder Distribution Configuration encrypts
       AMI''s using KMS - a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_2:
@@ -3265,7 +3265,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_2
-    pretty_name: 'CKV_AWS_2: Ensure ALB protocol is HTTPS'
+    pretty_name: 'Ensure ALB protocol is HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_20:
     categories:
@@ -3276,7 +3276,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_20
-    pretty_name: 'CKV_AWS_20: S3 Bucket has an ACL defined which allows public READ
+    pretty_name: 'S3 Bucket has an ACL defined which allows public READ
       access.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_200:
@@ -3286,7 +3286,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_200
-    pretty_name: 'CKV_AWS_200: Ensure that Image Recipe EBS Disk are encrypted with
+    pretty_name: 'Ensure that Image Recipe EBS Disk are encrypted with
       CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_201:
@@ -3296,7 +3296,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_201
-    pretty_name: 'CKV_AWS_201: Ensure MemoryDB is encrypted at rest using KMS CMKs'
+    pretty_name: 'Ensure MemoryDB is encrypted at rest using KMS CMKs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_202:
     categories:
@@ -3307,7 +3307,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_202
-    pretty_name: 'CKV_AWS_202: Ensure MemoryDB data is encrypted in transit'
+    pretty_name: 'Ensure MemoryDB data is encrypted in transit'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_203:
     categories:
@@ -3316,7 +3316,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_203
-    pretty_name: 'CKV_AWS_203: Ensure resource is encrypted by KMS using a customer
+    pretty_name: 'Ensure resource is encrypted by KMS using a customer
       managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_204:
@@ -3326,7 +3326,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_204
-    pretty_name: 'CKV_AWS_204: Ensure AMIs are encrypted using KMS CMKs'
+    pretty_name: 'Ensure AMIs are encrypted using KMS CMKs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_205:
     categories:
@@ -3337,7 +3337,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_205
-    pretty_name: 'CKV_AWS_205: Ensure to Limit AMI launch Permissions'
+    pretty_name: 'Ensure to Limit AMI launch Permissions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_206:
     categories:
@@ -3348,7 +3348,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_206
-    pretty_name: 'CKV_AWS_206: Ensure API Gateway Domain uses a modern security Policy'
+    pretty_name: 'Ensure API Gateway Domain uses a modern security Policy'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_207:
     categories:
@@ -3359,7 +3359,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_207
-    pretty_name: 'CKV_AWS_207: Ensure MQ Broker minor version updates are enabled'
+    pretty_name: 'Ensure MQ Broker minor version updates are enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_208:
     categories:
@@ -3370,7 +3370,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_208
-    pretty_name: 'CKV_AWS_208: Ensure MQBroker version is current'
+    pretty_name: 'Ensure MQBroker version is current'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_209:
     categories:
@@ -3379,7 +3379,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_209
-    pretty_name: 'CKV_AWS_209: Ensure MQ broker encrypted by KMS using a customer
+    pretty_name: 'Ensure MQ broker encrypted by KMS using a customer
       managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_21:
@@ -3390,7 +3390,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_21
-    pretty_name: 'CKV_AWS_21: Ensure all data stored in the S3 bucket have versioning
+    pretty_name: 'Ensure all data stored in the S3 bucket have versioning
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_210:
@@ -3402,7 +3402,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_210
-    pretty_name: 'CKV_AWS_210: Batch job does not define a privileged container'
+    pretty_name: 'Batch job does not define a privileged container'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_211:
     categories:
@@ -3413,7 +3413,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_211
-    pretty_name: 'CKV_AWS_211: Ensure RDS uses a modern CaCert'
+    pretty_name: 'Ensure RDS uses a modern CaCert'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_212:
     categories:
@@ -3422,7 +3422,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_212
-    pretty_name: 'CKV_AWS_212: Ensure EBS Volume is encrypted by KMS using a customer
+    pretty_name: 'Ensure EBS Volume is encrypted by KMS using a customer
       managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_213:
@@ -3434,7 +3434,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_213
-    pretty_name: 'CKV_AWS_213: Ensure ELB Policy uses only secure protocols'
+    pretty_name: 'Ensure ELB Policy uses only secure protocols'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_214:
     categories:
@@ -3445,7 +3445,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_214
-    pretty_name: 'CKV_AWS_214: Ensure Appsync API Cache is encrypted at rest'
+    pretty_name: 'Ensure Appsync API Cache is encrypted at rest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_215:
     categories:
@@ -3456,7 +3456,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_215
-    pretty_name: 'CKV_AWS_215: Ensure Appsync API Cache is encrypted in transit'
+    pretty_name: 'Ensure Appsync API Cache is encrypted in transit'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_216:
     categories:
@@ -3465,7 +3465,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_216
-    pretty_name: 'CKV_AWS_216: Ensure Cloudfront distribution is enabled'
+    pretty_name: 'Ensure Cloudfront distribution is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_217:
     categories:
@@ -3476,7 +3476,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_217
-    pretty_name: 'CKV_AWS_217: Ensure Create before destroy for API deployments'
+    pretty_name: 'Ensure Create before destroy for API deployments'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_218:
     categories:
@@ -3487,7 +3487,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_218
-    pretty_name: 'CKV_AWS_218: Ensure that Cloudsearch is using latest TLS'
+    pretty_name: 'Ensure that Cloudsearch is using latest TLS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_219:
     categories:
@@ -3496,7 +3496,7 @@ rules:
     description: Check for weak AWS configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_AWS_219
-    pretty_name: 'CKV_AWS_219: Ensure Code Pipeline Artifact store is using a KMS
+    pretty_name: 'Ensure Code Pipeline Artifact store is using a KMS
       CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_22:
@@ -3506,7 +3506,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_22
-    pretty_name: 'CKV_AWS_22: Ensure SageMaker Notebook is encrypted at rest using
+    pretty_name: 'Ensure SageMaker Notebook is encrypted at rest using
       KMS CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_220:
@@ -3518,7 +3518,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_220
-    pretty_name: 'CKV_AWS_220: Ensure that Cloudsearch is using https'
+    pretty_name: 'Ensure that Cloudsearch is using https'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_221:
     categories:
@@ -3527,7 +3527,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_221
-    pretty_name: 'CKV_AWS_221: Ensure Code artifact Domain is encrypted by KMS using
+    pretty_name: 'Ensure Code artifact Domain is encrypted by KMS using
       a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_222:
@@ -3539,7 +3539,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_222
-    pretty_name: 'CKV_AWS_222: Ensure DMS instance gets all minor upgrade automatically'
+    pretty_name: 'Ensure DMS instance gets all minor upgrade automatically'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_223:
     categories:
@@ -3550,7 +3550,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_223
-    pretty_name: 'CKV_AWS_223: Ensure ECS Cluster enables logging of ECS Exec'
+    pretty_name: 'Ensure ECS Cluster enables logging of ECS Exec'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_224:
     categories:
@@ -3559,7 +3559,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_224
-    pretty_name: 'CKV_AWS_224: Ensure Cluster logging with CMK'
+    pretty_name: 'Ensure Cluster logging with CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_225:
     categories:
@@ -3570,7 +3570,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_225
-    pretty_name: 'CKV_AWS_225: Ensure API Gateway method setting caching is enabled'
+    pretty_name: 'Ensure API Gateway method setting caching is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_226:
     categories:
@@ -3581,7 +3581,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_226
-    pretty_name: 'CKV_AWS_226: Ensure DB instance gets all minor upgrades automatically'
+    pretty_name: 'Ensure DB instance gets all minor upgrades automatically'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_227:
     categories:
@@ -3592,7 +3592,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_227
-    pretty_name: 'CKV_AWS_227: Ensure KMS key is enabled'
+    pretty_name: 'Ensure KMS key is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_228:
     categories:
@@ -3603,7 +3603,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_228
-    pretty_name: 'CKV_AWS_228: Verify Elasticsearch domain is using an up to date
+    pretty_name: 'Verify Elasticsearch domain is using an up to date
       TLS policy'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_229:
@@ -3615,7 +3615,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_229
-    pretty_name: 'CKV_AWS_229: Ensure no NACL allow ingress from 0.0.0.0:0 to port
+    pretty_name: 'Ensure no NACL allow ingress from 0.0.0.0:0 to port
       21'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_23:
@@ -3627,7 +3627,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_23
-    pretty_name: 'CKV_AWS_23: Ensure every security groups rule has a description'
+    pretty_name: 'Ensure every security groups rule has a description'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_230:
     categories:
@@ -3638,7 +3638,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_230
-    pretty_name: 'CKV_AWS_230: Ensure no NACL allow ingress from 0.0.0.0:0 to port
+    pretty_name: 'Ensure no NACL allow ingress from 0.0.0.0:0 to port
       20'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_231:
@@ -3650,7 +3650,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_231
-    pretty_name: 'CKV_AWS_231: Ensure no NACL allow ingress from 0.0.0.0:0 to port
+    pretty_name: 'Ensure no NACL allow ingress from 0.0.0.0:0 to port
       3389'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_232:
@@ -3662,7 +3662,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_232
-    pretty_name: 'CKV_AWS_232: Ensure no NACL allow ingress from 0.0.0.0:0 to port
+    pretty_name: 'Ensure no NACL allow ingress from 0.0.0.0:0 to port
       22'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_233:
@@ -3674,7 +3674,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_233
-    pretty_name: 'CKV_AWS_233: Ensure Create before destroy for ACM certificates'
+    pretty_name: 'Ensure Create before destroy for ACM certificates'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_234:
     categories:
@@ -3684,7 +3684,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_234
-    pretty_name: 'CKV_AWS_234: Verify logging preference for ACM certificates'
+    pretty_name: 'Verify logging preference for ACM certificates'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_235:
     categories:
@@ -3695,7 +3695,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_235
-    pretty_name: 'CKV_AWS_235: Ensure that copied AMIs are encrypted'
+    pretty_name: 'Ensure that copied AMIs are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_236:
     categories:
@@ -3704,7 +3704,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_236
-    pretty_name: 'CKV_AWS_236: Ensure AMI copying uses a CMK'
+    pretty_name: 'Ensure AMI copying uses a CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_237:
     categories:
@@ -3715,7 +3715,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_237
-    pretty_name: 'CKV_AWS_237: Ensure Create before destroy for API GATEWAY'
+    pretty_name: 'Ensure Create before destroy for API GATEWAY'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_238:
     categories:
@@ -3724,7 +3724,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_238
-    pretty_name: 'CKV_AWS_238: Ensure that Guard Duty detector is enabled'
+    pretty_name: 'Ensure that Guard Duty detector is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_239:
     categories:
@@ -3735,7 +3735,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_239
-    pretty_name: 'CKV_AWS_239: Ensure DAX cluster endpoint is using TLS'
+    pretty_name: 'Ensure DAX cluster endpoint is using TLS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_24:
     categories:
@@ -3746,7 +3746,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_24
-    pretty_name: 'CKV_AWS_24: Ensure no security groups allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security groups allow ingress from 0.0.0.0:0
       to port 22'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_240:
@@ -3758,7 +3758,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_240
-    pretty_name: 'CKV_AWS_240: Ensure Kinesis Firehose delivery stream is encrypted'
+    pretty_name: 'Ensure Kinesis Firehose delivery stream is encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_241:
     categories:
@@ -3767,7 +3767,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_241
-    pretty_name: 'CKV_AWS_241: Ensure that Kinesis Firehose Delivery Streams are encrypted
+    pretty_name: 'Ensure that Kinesis Firehose Delivery Streams are encrypted
       with CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_242:
@@ -3779,7 +3779,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_242
-    pretty_name: 'CKV_AWS_242: Ensure MWAA environment has scheduler logs enabled'
+    pretty_name: 'Ensure MWAA environment has scheduler logs enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_243:
     categories:
@@ -3790,7 +3790,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_243
-    pretty_name: 'CKV_AWS_243: Ensure MWAA environment has worker logs enabled'
+    pretty_name: 'Ensure MWAA environment has worker logs enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_244:
     categories:
@@ -3801,7 +3801,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_244
-    pretty_name: 'CKV_AWS_244: Ensure MWAA environment has webserver logs enabled'
+    pretty_name: 'Ensure MWAA environment has webserver logs enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_245:
     categories:
@@ -3810,7 +3810,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_245
-    pretty_name: 'CKV_AWS_245: Ensure replicated backups are encrypted at rest using
+    pretty_name: 'Ensure replicated backups are encrypted at rest using
       KMS CMKs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_246:
@@ -3820,7 +3820,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_246
-    pretty_name: 'CKV_AWS_246: Ensure RDS Cluster activity streams are encrypted using
+    pretty_name: 'Ensure RDS Cluster activity streams are encrypted using
       KMS CMKs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_247:
@@ -3830,7 +3830,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_247
-    pretty_name: 'CKV_AWS_247: Ensure all data stored in the Elasticsearch is encrypted
+    pretty_name: 'Ensure all data stored in the Elasticsearch is encrypted
       with a CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_248:
@@ -3842,7 +3842,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_248
-    pretty_name: 'CKV_AWS_248: Ensure that Elasticsearch is not using the default
+    pretty_name: 'Ensure that Elasticsearch is not using the default
       Security Group'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_249:
@@ -3853,7 +3853,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_249
-    pretty_name: 'CKV_AWS_249: Ensure that the Execution Role ARN and the Task Role
+    pretty_name: 'Ensure that the Execution Role ARN and the Task Role
       ARN are different in ECS Task definitions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_25:
@@ -3865,7 +3865,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_25
-    pretty_name: 'CKV_AWS_25: Ensure no security groups allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security groups allow ingress from 0.0.0.0:0
       to port 3389'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_250:
@@ -3877,7 +3877,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_250
-    pretty_name: 'CKV_AWS_250: Ensure that RDS PostgreSQL instances use a non vulnerable
+    pretty_name: 'Ensure that RDS PostgreSQL instances use a non vulnerable
       version with the log_fdw extension'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_251:
@@ -3889,7 +3889,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_251
-    pretty_name: 'CKV_AWS_251: Ensure CloudTrail logging is enabled'
+    pretty_name: 'Ensure CloudTrail logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_252:
     categories:
@@ -3898,7 +3898,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_252
-    pretty_name: 'CKV_AWS_252: Ensure CloudTrail defines an SNS Topic'
+    pretty_name: 'Ensure CloudTrail defines an SNS Topic'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_253:
     categories:
@@ -3909,7 +3909,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_253
-    pretty_name: 'CKV_AWS_253: Ensure DLM cross region events are encrypted'
+    pretty_name: 'Ensure DLM cross region events are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_254:
     categories:
@@ -3918,7 +3918,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_254
-    pretty_name: 'CKV_AWS_254: Ensure DLM cross region events are encrypted with Customer
+    pretty_name: 'Ensure DLM cross region events are encrypted with Customer
       Managed Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_255:
@@ -3930,7 +3930,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_255
-    pretty_name: 'CKV_AWS_255: Ensure DLM cross region schedules are encrypted'
+    pretty_name: 'Ensure DLM cross region schedules are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_256:
     categories:
@@ -3939,7 +3939,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_256
-    pretty_name: 'CKV_AWS_256: Ensure DLM cross region schedules are encrypted using
+    pretty_name: 'Ensure DLM cross region schedules are encrypted using
       a Customer Managed Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_257:
@@ -3950,7 +3950,7 @@ rules:
     description: Check for weak AWS configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_AWS_257
-    pretty_name: 'CKV_AWS_257: Ensure codecommit branch changes have at least 2 approvals'
+    pretty_name: 'Ensure codecommit branch changes have at least 2 approvals'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_258:
     categories:
@@ -3961,7 +3961,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_258
-    pretty_name: 'CKV_AWS_258: Ensure that Lambda function URLs AuthType is not None'
+    pretty_name: 'Ensure that Lambda function URLs AuthType is not None'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_259:
     categories:
@@ -3972,7 +3972,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_259
-    pretty_name: 'CKV_AWS_259: Ensure CloudFront response header policy enforces Strict
+    pretty_name: 'Ensure CloudFront response header policy enforces Strict
       Transport Security'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_26:
@@ -3984,7 +3984,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_26
-    pretty_name: 'CKV_AWS_26: Ensure all data stored in the SNS topic is encrypted'
+    pretty_name: 'Ensure all data stored in the SNS topic is encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_260:
     categories:
@@ -3995,7 +3995,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_260
-    pretty_name: 'CKV_AWS_260: Ensure no security groups allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security groups allow ingress from 0.0.0.0:0
       to port 80'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_261:
@@ -4006,7 +4006,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_261
-    pretty_name: 'CKV_AWS_261: Ensure HTTP HTTPS Target group defines Healthcheck'
+    pretty_name: 'Ensure HTTP HTTPS Target group defines Healthcheck'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_262:
     categories:
@@ -4015,7 +4015,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_262
-    pretty_name: 'CKV_AWS_262: Ensure Kendra index Server side encryption uses CMK'
+    pretty_name: 'Ensure Kendra index Server side encryption uses CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_263:
     categories:
@@ -4024,7 +4024,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_263
-    pretty_name: 'CKV_AWS_263: Ensure App Flow flow uses CMK'
+    pretty_name: 'Ensure App Flow flow uses CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_264:
     categories:
@@ -4033,7 +4033,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_264
-    pretty_name: 'CKV_AWS_264: Ensure App Flow connector profile uses CMK'
+    pretty_name: 'Ensure App Flow connector profile uses CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_265:
     categories:
@@ -4042,7 +4042,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_265
-    pretty_name: 'CKV_AWS_265: Ensure Keyspaces Table uses CMK'
+    pretty_name: 'Ensure Keyspaces Table uses CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_266:
     categories:
@@ -4051,7 +4051,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_266
-    pretty_name: 'CKV_AWS_266: Ensure App Flow connector profile uses CMK'
+    pretty_name: 'Ensure App Flow connector profile uses CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_267:
     categories:
@@ -4060,7 +4060,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_267
-    pretty_name: 'CKV_AWS_267: Ensure that Comprehend Entity Recognizer''s model is
+    pretty_name: 'Ensure that Comprehend Entity Recognizer''s model is
       encrypted by KMS using a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_268:
@@ -4070,7 +4070,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_268
-    pretty_name: 'CKV_AWS_268: Ensure that Comprehend Entity Recognizer''s volume
+    pretty_name: 'Ensure that Comprehend Entity Recognizer''s volume
       is encrypted by KMS using a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_269:
@@ -4080,7 +4080,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_269
-    pretty_name: 'CKV_AWS_269: Ensure Connect Instance Kinesis Video Stream Storage
+    pretty_name: 'Ensure Connect Instance Kinesis Video Stream Storage
       Config uses CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_27:
@@ -4092,7 +4092,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_27
-    pretty_name: 'CKV_AWS_27: Ensure all data stored in the SQS queue is encrypted'
+    pretty_name: 'Ensure all data stored in the SQS queue is encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_270:
     categories:
@@ -4101,7 +4101,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_270
-    pretty_name: 'CKV_AWS_270: Ensure Connect Instance S3 Storage Config uses CMK'
+    pretty_name: 'Ensure Connect Instance S3 Storage Config uses CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_271:
     categories:
@@ -4110,7 +4110,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_271
-    pretty_name: 'CKV_AWS_271: Ensure DynamoDB table replica KMS encryption uses CMK'
+    pretty_name: 'Ensure DynamoDB table replica KMS encryption uses CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_272:
     categories:
@@ -4121,7 +4121,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_272
-    pretty_name: 'CKV_AWS_272: Ensure AWS Lambda function is configured to validate
+    pretty_name: 'Ensure AWS Lambda function is configured to validate
       code-signing'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_273:
@@ -4132,7 +4132,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_273
-    pretty_name: 'CKV_AWS_273: Ensure access is controlled through SSO and not AWS
+    pretty_name: 'Ensure access is controlled through SSO and not AWS
       IAM defined users'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_274:
@@ -4143,7 +4143,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_274
-    pretty_name: 'CKV_AWS_274: Disallow IAM roles, users, and groups from using the
+    pretty_name: 'Disallow IAM roles, users, and groups from using the
       AWS AdministratorAccess policy'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_275:
@@ -4154,7 +4154,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_275
-    pretty_name: 'CKV_AWS_275: Disallow policies from using the AWS AdministratorAccess
+    pretty_name: 'Disallow policies from using the AWS AdministratorAccess
       policy'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_276:
@@ -4164,7 +4164,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_276
-    pretty_name: 'CKV_AWS_276: Ensure Data Trace is not enabled in API Gateway Method
+    pretty_name: 'Ensure Data Trace is not enabled in API Gateway Method
       Settings'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_277:
@@ -4176,7 +4176,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_277
-    pretty_name: 'CKV_AWS_277: Ensure no security groups allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security groups allow ingress from 0.0.0.0:0
       to port -1'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_278:
@@ -4188,7 +4188,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_278
-    pretty_name: 'CKV_AWS_278: Ensure MemoryDB snapshot is encrypted by KMS using
+    pretty_name: 'Ensure MemoryDB snapshot is encrypted by KMS using
       a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_279:
@@ -4200,7 +4200,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_279
-    pretty_name: 'CKV_AWS_279: Ensure Neptune snapshot is securely encrypted'
+    pretty_name: 'Ensure Neptune snapshot is securely encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_28:
     categories:
@@ -4211,7 +4211,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_28
-    pretty_name: 'CKV_AWS_28: Ensure Dynamodb point in time recovery (backup) is enabled'
+    pretty_name: 'Ensure Dynamodb point in time recovery (backup) is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_280:
     categories:
@@ -4222,7 +4222,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_280
-    pretty_name: 'CKV_AWS_280: Ensure Neptune snapshot is encrypted by KMS using a
+    pretty_name: 'Ensure Neptune snapshot is encrypted by KMS using a
       customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_281:
@@ -4234,7 +4234,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_281
-    pretty_name: 'CKV_AWS_281: Ensure RedShift snapshot copy is encrypted by KMS using
+    pretty_name: 'Ensure RedShift snapshot copy is encrypted by KMS using
       a customer managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_282:
@@ -4246,7 +4246,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_282
-    pretty_name: 'CKV_AWS_282: Ensure that Redshift Serverless namespace is encrypted
+    pretty_name: 'Ensure that Redshift Serverless namespace is encrypted
       by KMS using a customer managed key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_283:
@@ -4258,7 +4258,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_283
-    pretty_name: 'CKV_AWS_283: Ensure no IAM policies documents allow ALL or any AWS
+    pretty_name: 'Ensure no IAM policies documents allow ALL or any AWS
       principal permissions to the resource'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_284:
@@ -4270,7 +4270,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_284
-    pretty_name: 'CKV_AWS_284: Ensure State Machine has X-Ray tracing enabled'
+    pretty_name: 'Ensure State Machine has X-Ray tracing enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_285:
     categories:
@@ -4281,7 +4281,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_285
-    pretty_name: 'CKV_AWS_285: Ensure State Machine has execution history logging
+    pretty_name: 'Ensure State Machine has execution history logging
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_286:
@@ -4293,7 +4293,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_286
-    pretty_name: 'CKV_AWS_286: Ensure IAM policies does not allow privilege escalation'
+    pretty_name: 'Ensure IAM policies does not allow privilege escalation'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_287:
     categories:
@@ -4304,7 +4304,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_287
-    pretty_name: 'CKV_AWS_287: Ensure IAM policies does not allow credentials exposure'
+    pretty_name: 'Ensure IAM policies does not allow credentials exposure'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_288:
     categories:
@@ -4315,7 +4315,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_288
-    pretty_name: 'CKV_AWS_288: Ensure IAM policies does not allow data exfiltration'
+    pretty_name: 'Ensure IAM policies does not allow data exfiltration'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_289:
     categories:
@@ -4326,7 +4326,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_289
-    pretty_name: 'CKV_AWS_289: Ensure IAM policies does not allow permissions management
+    pretty_name: 'Ensure IAM policies does not allow permissions management
       / resource exposure without constraints'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_29:
@@ -4338,7 +4338,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_29
-    pretty_name: 'CKV_AWS_29: Ensure all data stored in the Elasticache Replication
+    pretty_name: 'Ensure all data stored in the Elasticache Replication
       Group is securely encrypted at rest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_290:
@@ -4350,7 +4350,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_290
-    pretty_name: 'CKV_AWS_290: Ensure IAM policies does not allow write access without
+    pretty_name: 'Ensure IAM policies does not allow write access without
       constraints'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_291:
@@ -4362,7 +4362,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_291
-    pretty_name: 'CKV_AWS_291: Ensure MSK nodes are private'
+    pretty_name: 'Ensure MSK nodes are private'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_292:
     categories:
@@ -4373,7 +4373,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_292
-    pretty_name: 'CKV_AWS_292: Ensure DocDB Global Cluster is encrypted at rest (default
+    pretty_name: 'Ensure DocDB Global Cluster is encrypted at rest (default
       is unencrypted)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_293:
@@ -4385,7 +4385,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_293
-    pretty_name: 'CKV_AWS_293: Ensure that AWS database instances have deletion protection
+    pretty_name: 'Ensure that AWS database instances have deletion protection
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_294:
@@ -4397,7 +4397,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_294
-    pretty_name: 'CKV_AWS_294: Ensure Cloud Trail Event Data Store uses CMK'
+    pretty_name: 'Ensure Cloud Trail Event Data Store uses CMK'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_295:
     categories:
@@ -4408,7 +4408,7 @@ rules:
     description: stored-secrets
     group: stored-secrets
     name: CKV_AWS_295
-    pretty_name: 'CKV_AWS_295: Ensure DataSync Location Object Storage doesn''t expose
+    pretty_name: 'Ensure DataSync Location Object Storage doesn''t expose
       secrets'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_296:
@@ -4420,7 +4420,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_296
-    pretty_name: 'CKV_AWS_296: Ensure DMS endpoint uses Customer Managed Key (CMK)'
+    pretty_name: 'Ensure DMS endpoint uses Customer Managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_297:
     categories:
@@ -4431,7 +4431,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_297
-    pretty_name: 'CKV_AWS_297: Ensure EventBridge Scheduler Schedule uses Customer
+    pretty_name: 'Ensure EventBridge Scheduler Schedule uses Customer
       Managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_298:
@@ -4443,7 +4443,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_298
-    pretty_name: 'CKV_AWS_298: Ensure DMS S3 uses Customer Managed Key (CMK)'
+    pretty_name: 'Ensure DMS S3 uses Customer Managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_299:
     categories:
@@ -4454,7 +4454,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_299
-    pretty_name: 'CKV_AWS_299: Ensure DMS S3 defines in-transit encryption'
+    pretty_name: 'Ensure DMS S3 defines in-transit encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_3:
     categories:
@@ -4465,7 +4465,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_3
-    pretty_name: 'CKV_AWS_3: Ensure all data stored in the EBS is securely encrypted'
+    pretty_name: 'Ensure all data stored in the EBS is securely encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_30:
     categories:
@@ -4476,7 +4476,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_30
-    pretty_name: 'CKV_AWS_30: Ensure all data stored in the Elasticache Replication
+    pretty_name: 'Ensure all data stored in the Elasticache Replication
       Group is securely encrypted at transit'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_300:
@@ -4488,7 +4488,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_300
-    pretty_name: 'CKV_AWS_300: Ensure S3 lifecycle configuration sets period for aborting
+    pretty_name: 'Ensure S3 lifecycle configuration sets period for aborting
       failed uploads'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_301:
@@ -4500,7 +4500,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_301
-    pretty_name: 'CKV_AWS_301: Ensure that AWS Lambda function is not publicly accessible'
+    pretty_name: 'Ensure that AWS Lambda function is not publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_302:
     categories:
@@ -4511,7 +4511,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_302
-    pretty_name: 'CKV_AWS_302: Ensure DB Snapshots are not Public'
+    pretty_name: 'Ensure DB Snapshots are not Public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_303:
     categories:
@@ -4522,7 +4522,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_303
-    pretty_name: 'CKV_AWS_303: Ensure SSM documents are not Public'
+    pretty_name: 'Ensure SSM documents are not Public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_304:
     categories:
@@ -4533,7 +4533,7 @@ rules:
     description: Check that ensures best practices in AWS secrets management.
     group: cloud-weak-secrets-management
     name: CKV_AWS_304
-    pretty_name: 'CKV_AWS_304: Ensure Secrets Manager secrets should be rotated within
+    pretty_name: 'Ensure Secrets Manager secrets should be rotated within
       90 days'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_305:
@@ -4545,7 +4545,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_305
-    pretty_name: 'CKV_AWS_305: Ensure Cloudfront distribution has a default root object
+    pretty_name: 'Ensure Cloudfront distribution has a default root object
       configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_306:
@@ -4557,7 +4557,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_306
-    pretty_name: 'CKV_AWS_306: Ensure SageMaker notebook instances should be launched
+    pretty_name: 'Ensure SageMaker notebook instances should be launched
       into a custom VPC'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_307:
@@ -4569,7 +4569,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_307
-    pretty_name: 'CKV_AWS_307: Ensure SageMaker Users should not have root access
+    pretty_name: 'Ensure SageMaker Users should not have root access
       to SageMaker notebook instances'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_308:
@@ -4581,7 +4581,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_308
-    pretty_name: 'CKV_AWS_308: Ensure API Gateway method setting caching is set to
+    pretty_name: 'Ensure API Gateway method setting caching is set to
       encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_309:
@@ -4593,7 +4593,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_309
-    pretty_name: 'CKV_AWS_309: Ensure API GatewayV2 routes specify an authorization
+    pretty_name: 'Ensure API GatewayV2 routes specify an authorization
       type'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_31:
@@ -4605,7 +4605,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_31
-    pretty_name: 'CKV_AWS_31: Ensure all data stored in the Elasticache Replication
+    pretty_name: 'Ensure all data stored in the Elasticache Replication
       Group is securely encrypted at transit and has auth token'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_310:
@@ -4617,7 +4617,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_310
-    pretty_name: 'CKV_AWS_310: Ensure CloudFront distributions should have origin
+    pretty_name: 'Ensure CloudFront distributions should have origin
       failover configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_311:
@@ -4629,7 +4629,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_311
-    pretty_name: 'CKV_AWS_311: Ensure that CodeBuild S3 logs are encrypted'
+    pretty_name: 'Ensure that CodeBuild S3 logs are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_312:
     categories:
@@ -4640,7 +4640,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_312
-    pretty_name: 'CKV_AWS_312: Ensure Elastic Beanstalk environments have enhanced
+    pretty_name: 'Ensure Elastic Beanstalk environments have enhanced
       health reporting enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_313:
@@ -4652,7 +4652,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_313
-    pretty_name: 'CKV_AWS_313: Ensure RDS cluster configured to copy tags to snapshots'
+    pretty_name: 'Ensure RDS cluster configured to copy tags to snapshots'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_314:
     categories:
@@ -4663,7 +4663,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_314
-    pretty_name: 'CKV_AWS_314: Ensure CodeBuild project environments have a logging
+    pretty_name: 'Ensure CodeBuild project environments have a logging
       configuration'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_315:
@@ -4675,7 +4675,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_315
-    pretty_name: 'CKV_AWS_315: Ensure EC2 Auto Scaling groups use EC2 launch templates'
+    pretty_name: 'Ensure EC2 Auto Scaling groups use EC2 launch templates'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_316:
     categories:
@@ -4686,7 +4686,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_316
-    pretty_name: 'CKV_AWS_316: Ensure CodeBuild project environments do not have privileged
+    pretty_name: 'Ensure CodeBuild project environments do not have privileged
       mode enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_317:
@@ -4698,7 +4698,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_317
-    pretty_name: 'CKV_AWS_317: Ensure Elasticsearch Domain Audit Logging is enabled'
+    pretty_name: 'Ensure Elasticsearch Domain Audit Logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_318:
     categories:
@@ -4709,7 +4709,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_318
-    pretty_name: 'CKV_AWS_318: Ensure Elasticsearch domains are configured with at
+    pretty_name: 'Ensure Elasticsearch domains are configured with at
       least three dedicated master nodes for HA'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_319:
@@ -4721,7 +4721,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_319
-    pretty_name: 'CKV_AWS_319: Ensure that CloudWatch alarm actions are enabled'
+    pretty_name: 'Ensure that CloudWatch alarm actions are enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_32:
     categories:
@@ -4732,7 +4732,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_32
-    pretty_name: 'CKV_AWS_32: Ensure ECR policy is not set to public'
+    pretty_name: 'Ensure ECR policy is not set to public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_320:
     categories:
@@ -4743,7 +4743,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_320
-    pretty_name: 'CKV_AWS_320: Ensure Redshift clusters do not use the default database
+    pretty_name: 'Ensure Redshift clusters do not use the default database
       name'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_321:
@@ -4755,7 +4755,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_321
-    pretty_name: 'CKV_AWS_321: Ensure Redshift clusters use enhanced VPC routing'
+    pretty_name: 'Ensure Redshift clusters use enhanced VPC routing'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_322:
     categories:
@@ -4766,7 +4766,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_322
-    pretty_name: 'CKV_AWS_322: Ensure ElastiCache for Redis cache clusters have auto
+    pretty_name: 'Ensure ElastiCache for Redis cache clusters have auto
       minor version upgrades enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_323:
@@ -4778,7 +4778,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_323
-    pretty_name: 'CKV_AWS_323: Ensure ElastiCache clusters do not use the default
+    pretty_name: 'Ensure ElastiCache clusters do not use the default
       subnet group'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_324:
@@ -4790,7 +4790,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_324
-    pretty_name: 'CKV_AWS_324: Ensure that RDS Cluster log capture is enabled'
+    pretty_name: 'Ensure that RDS Cluster log capture is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_325:
     categories:
@@ -4801,7 +4801,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_325
-    pretty_name: 'CKV_AWS_325: Ensure that RDS Cluster audit logging is enabled for
+    pretty_name: 'Ensure that RDS Cluster audit logging is enabled for
       MySQL engine'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_326:
@@ -4813,7 +4813,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_326
-    pretty_name: 'CKV_AWS_326: Ensure that RDS Aurora Clusters have backtracking enabled'
+    pretty_name: 'Ensure that RDS Aurora Clusters have backtracking enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_327:
     categories:
@@ -4824,7 +4824,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_327
-    pretty_name: 'CKV_AWS_327: Ensure RDS Clusters are encrypted using KMS CMKs'
+    pretty_name: 'Ensure RDS Clusters are encrypted using KMS CMKs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_328:
     categories:
@@ -4835,7 +4835,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_328
-    pretty_name: 'CKV_AWS_328: Ensure that ALB is configured with defensive or strictest
+    pretty_name: 'Ensure that ALB is configured with defensive or strictest
       desync mitigation mode'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_329:
@@ -4847,7 +4847,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_329
-    pretty_name: 'CKV_AWS_329: EFS access points should enforce a root directory'
+    pretty_name: 'EFS access points should enforce a root directory'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_33:
     categories:
@@ -4858,7 +4858,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_33
-    pretty_name: 'CKV_AWS_33: Ensure KMS key policy does not contain wildcard (*)
+    pretty_name: 'Ensure KMS key policy does not contain wildcard (*)
       principal'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_330:
@@ -4870,7 +4870,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_330
-    pretty_name: 'CKV_AWS_330: EFS access points should enforce a user identity'
+    pretty_name: 'EFS access points should enforce a user identity'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_331:
     categories:
@@ -4881,7 +4881,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_331
-    pretty_name: 'CKV_AWS_331: Ensure Transit Gateways do not automatically accept
+    pretty_name: 'Ensure Transit Gateways do not automatically accept
       VPC attachment requests'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_332:
@@ -4893,7 +4893,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_332
-    pretty_name: 'CKV_AWS_332: Ensure ECS Fargate services run on the latest Fargate
+    pretty_name: 'Ensure ECS Fargate services run on the latest Fargate
       platform version'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_333:
@@ -4905,7 +4905,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_333
-    pretty_name: 'CKV_AWS_333: Ensure ECS services do not have public IP addresses
+    pretty_name: 'Ensure ECS services do not have public IP addresses
       assigned to them automatically'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_334:
@@ -4917,7 +4917,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_334
-    pretty_name: 'CKV_AWS_334: Ensure ECS containers should run as non-privileged'
+    pretty_name: 'Ensure ECS containers should run as non-privileged'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_34:
     categories:
@@ -4928,7 +4928,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_34
-    pretty_name: 'CKV_AWS_34: Ensure cloudfront distribution ViewerProtocolPolicy
+    pretty_name: 'Ensure cloudfront distribution ViewerProtocolPolicy
       is set to HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_35:
@@ -4938,7 +4938,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_35
-    pretty_name: 'CKV_AWS_35: Ensure CloudTrail logs are encrypted at rest using KMS
+    pretty_name: 'Ensure CloudTrail logs are encrypted at rest using KMS
       CMKs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_36:
@@ -4950,7 +4950,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_36
-    pretty_name: 'CKV_AWS_36: Ensure CloudTrail log file validation is enabled'
+    pretty_name: 'Ensure CloudTrail log file validation is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_37:
     categories:
@@ -4961,7 +4961,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_37
-    pretty_name: 'CKV_AWS_37: Ensure Amazon EKS control plane logging enabled for
+    pretty_name: 'Ensure Amazon EKS control plane logging enabled for
       all log types'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_38:
@@ -4972,7 +4972,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_38
-    pretty_name: 'CKV_AWS_38: Ensure Amazon EKS public endpoint not accessible to
+    pretty_name: 'Ensure Amazon EKS public endpoint not accessible to
       0.0.0.0/0'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_39:
@@ -4983,7 +4983,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_39
-    pretty_name: 'CKV_AWS_39: Ensure Amazon EKS public endpoint disabled'
+    pretty_name: 'Ensure Amazon EKS public endpoint disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_40:
     categories:
@@ -4994,7 +4994,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_40
-    pretty_name: 'CKV_AWS_40: Ensure IAM policies are attached only to groups or roles'
+    pretty_name: 'Ensure IAM policies are attached only to groups or roles'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_41:
     categories:
@@ -5005,7 +5005,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_AWS_41
-    pretty_name: 'CKV_AWS_41: Ensure no hard coded AWS access key and secret key exists
+    pretty_name: 'Ensure no hard coded AWS access key and secret key exists
       in provider'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_42:
@@ -5017,7 +5017,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_42
-    pretty_name: 'CKV_AWS_42: Ensure EFS is securely encrypted'
+    pretty_name: 'Ensure EFS is securely encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_43:
     categories:
@@ -5028,7 +5028,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_43
-    pretty_name: 'CKV_AWS_43: Ensure Kinesis Stream is securely encrypted'
+    pretty_name: 'Ensure Kinesis Stream is securely encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_44:
     categories:
@@ -5039,7 +5039,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_44
-    pretty_name: 'CKV_AWS_44: Ensure Neptune storage is securely encrypted'
+    pretty_name: 'Ensure Neptune storage is securely encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_45:
     categories:
@@ -5050,7 +5050,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_AWS_45
-    pretty_name: 'CKV_AWS_45: Ensure no hard-coded secrets exist in lambda environment'
+    pretty_name: 'Ensure no hard-coded secrets exist in lambda environment'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_46:
     categories:
@@ -5061,7 +5061,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_AWS_46
-    pretty_name: 'CKV_AWS_46: Ensure no hard-coded secrets exist in EC2 user data'
+    pretty_name: 'Ensure no hard-coded secrets exist in EC2 user data'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_47:
     categories:
@@ -5072,7 +5072,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_47
-    pretty_name: 'CKV_AWS_47: Ensure DAX is encrypted at rest (default is unencrypted)'
+    pretty_name: 'Ensure DAX is encrypted at rest (default is unencrypted)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_48:
     categories:
@@ -5083,7 +5083,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_48
-    pretty_name: 'CKV_AWS_48: Ensure MQ Broker logging is enabled'
+    pretty_name: 'Ensure MQ Broker logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_49:
     categories:
@@ -5094,7 +5094,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_49
-    pretty_name: 'CKV_AWS_49: Ensure no IAM policies documents allow "*" as a statement''s
+    pretty_name: 'Ensure no IAM policies documents allow "*" as a statement''s
       actions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_5:
@@ -5106,7 +5106,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_5
-    pretty_name: 'CKV_AWS_5: Ensure all data stored in the Elasticsearch is securely
+    pretty_name: 'Ensure all data stored in the Elasticsearch is securely
       encrypted at rest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_50:
@@ -5117,7 +5117,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_50
-    pretty_name: 'CKV_AWS_50: X-ray tracing is enabled for Lambda'
+    pretty_name: 'X-ray tracing is enabled for Lambda'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_51:
     categories:
@@ -5128,7 +5128,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_51
-    pretty_name: 'CKV_AWS_51: Ensure ECR Image Tags are immutable'
+    pretty_name: 'Ensure ECR Image Tags are immutable'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_53:
     categories:
@@ -5139,7 +5139,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_53
-    pretty_name: 'CKV_AWS_53: Ensure S3 bucket has block public ACLS enabled'
+    pretty_name: 'Ensure S3 bucket has block public ACLS enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_54:
     categories:
@@ -5150,7 +5150,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_54
-    pretty_name: 'CKV_AWS_54: Ensure S3 bucket has block public policy enabled'
+    pretty_name: 'Ensure S3 bucket has block public policy enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_55:
     categories:
@@ -5161,7 +5161,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_55
-    pretty_name: 'CKV_AWS_55: Ensure S3 bucket has ignore public ACLs enabled'
+    pretty_name: 'Ensure S3 bucket has ignore public ACLs enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_56:
     categories:
@@ -5172,7 +5172,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_56
-    pretty_name: 'CKV_AWS_56: Ensure S3 bucket has ''restrict_public_bucket'' enabled'
+    pretty_name: 'Ensure S3 bucket has ''restrict_public_bucket'' enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_57:
     categories:
@@ -5183,7 +5183,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_57
-    pretty_name: 'CKV_AWS_57: S3 Bucket has an ACL defined which allows public WRITE
+    pretty_name: 'S3 Bucket has an ACL defined which allows public WRITE
       access.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_58:
@@ -5195,7 +5195,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_58
-    pretty_name: 'CKV_AWS_58: Ensure EKS Cluster has Secrets Encryption Enabled'
+    pretty_name: 'Ensure EKS Cluster has Secrets Encryption Enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_59:
     categories:
@@ -5206,7 +5206,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_59
-    pretty_name: 'CKV_AWS_59: Ensure there is no open access to back-end resources
+    pretty_name: 'Ensure there is no open access to back-end resources
       through API'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_6:
@@ -5218,7 +5218,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_6
-    pretty_name: 'CKV_AWS_6: Ensure all Elasticsearch has node-to-node encryption
+    pretty_name: 'Ensure all Elasticsearch has node-to-node encryption
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_60:
@@ -5230,7 +5230,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_60
-    pretty_name: 'CKV_AWS_60: Ensure IAM role allows only specific services or principals
+    pretty_name: 'Ensure IAM role allows only specific services or principals
       to assume it'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_61:
@@ -5242,7 +5242,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_61
-    pretty_name: 'CKV_AWS_61: Ensure AWS IAM policy does not allow assume role permission
+    pretty_name: 'Ensure AWS IAM policy does not allow assume role permission
       across all services'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_62:
@@ -5254,7 +5254,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_62
-    pretty_name: 'CKV_AWS_62: Ensure IAM policies that allow full "*-*" administrative
+    pretty_name: 'Ensure IAM policies that allow full "*-*" administrative
       privileges are not created'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_63:
@@ -5266,7 +5266,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_63
-    pretty_name: 'CKV_AWS_63: Ensure no IAM policies documents allow "*" as a statement''s
+    pretty_name: 'Ensure no IAM policies documents allow "*" as a statement''s
       actions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_64:
@@ -5278,7 +5278,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_64
-    pretty_name: 'CKV_AWS_64: Ensure all data stored in the Redshift cluster is securely
+    pretty_name: 'Ensure all data stored in the Redshift cluster is securely
       encrypted at rest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_65:
@@ -5289,7 +5289,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_65
-    pretty_name: 'CKV_AWS_65: Ensure container insights are enabled on ECS cluster'
+    pretty_name: 'Ensure container insights are enabled on ECS cluster'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_66:
     categories:
@@ -5300,7 +5300,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_66
-    pretty_name: 'CKV_AWS_66: Ensure that CloudWatch Log Group specifies retention
+    pretty_name: 'Ensure that CloudWatch Log Group specifies retention
       days'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_67:
@@ -5312,7 +5312,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_67
-    pretty_name: 'CKV_AWS_67: Ensure CloudTrail is enabled in all Regions'
+    pretty_name: 'Ensure CloudTrail is enabled in all Regions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_68:
     categories:
@@ -5321,7 +5321,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_68
-    pretty_name: 'CKV_AWS_68: CloudFront Distribution should have WAF enabled'
+    pretty_name: 'CloudFront Distribution should have WAF enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_69:
     categories:
@@ -5332,7 +5332,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_69
-    pretty_name: 'CKV_AWS_69: Ensure MQ Broker is not publicly exposed'
+    pretty_name: 'Ensure MQ Broker is not publicly exposed'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_7:
     categories:
@@ -5343,7 +5343,7 @@ rules:
     description: Check that ensures best practices in AWS secrets management.
     group: cloud-weak-secrets-management
     name: CKV_AWS_7
-    pretty_name: 'CKV_AWS_7: Ensure rotation for customer created CMKs is enabled'
+    pretty_name: 'Ensure rotation for customer created CMKs is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_70:
     categories:
@@ -5354,7 +5354,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_70
-    pretty_name: 'CKV_AWS_70: Ensure S3 bucket does not allow an action with any Principal'
+    pretty_name: 'Ensure S3 bucket does not allow an action with any Principal'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_71:
     categories:
@@ -5364,7 +5364,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_71
-    pretty_name: 'CKV_AWS_71: Ensure Redshift Cluster logging is enabled'
+    pretty_name: 'Ensure Redshift Cluster logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_72:
     categories:
@@ -5375,7 +5375,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_72
-    pretty_name: 'CKV_AWS_72: Ensure SQS policy does not allow ALL (*) actions.'
+    pretty_name: 'Ensure SQS policy does not allow ALL (*) actions.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_73:
     categories:
@@ -5385,7 +5385,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_73
-    pretty_name: 'CKV_AWS_73: Ensure API Gateway has X-Ray Tracing enabled'
+    pretty_name: 'Ensure API Gateway has X-Ray Tracing enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_74:
     categories:
@@ -5396,7 +5396,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_74
-    pretty_name: 'CKV_AWS_74: Ensure DocDB is encrypted at rest (default is unencrypted)'
+    pretty_name: 'Ensure DocDB is encrypted at rest (default is unencrypted)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_75:
     categories:
@@ -5405,7 +5405,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_75
-    pretty_name: 'CKV_AWS_75: Ensure Global Accelerator accelerator has flow logs
+    pretty_name: 'Ensure Global Accelerator accelerator has flow logs
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_76:
@@ -5417,7 +5417,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_76
-    pretty_name: 'CKV_AWS_76: Ensure API Gateway has Access Logging enabled'
+    pretty_name: 'Ensure API Gateway has Access Logging enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_77:
     categories:
@@ -5428,7 +5428,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_77
-    pretty_name: 'CKV_AWS_77: Ensure Athena Database is encrypted at rest (default
+    pretty_name: 'Ensure Athena Database is encrypted at rest (default
       is unencrypted)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_78:
@@ -5440,7 +5440,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_78
-    pretty_name: 'CKV_AWS_78: Ensure that CodeBuild Project encryption is not disabled'
+    pretty_name: 'Ensure that CodeBuild Project encryption is not disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_79:
     categories:
@@ -5451,7 +5451,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_79
-    pretty_name: 'CKV_AWS_79: Ensure Instance Metadata Service Version 1 is not enabled'
+    pretty_name: 'Ensure Instance Metadata Service Version 1 is not enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_8:
     categories:
@@ -5462,7 +5462,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_8
-    pretty_name: 'CKV_AWS_8: Ensure all data stored in the Launch configuration or
+    pretty_name: 'Ensure all data stored in the Launch configuration or
       instance Elastic Blocks Store is securely encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_80:
@@ -5474,7 +5474,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_80
-    pretty_name: 'CKV_AWS_80: Ensure MSK Cluster logging is enabled'
+    pretty_name: 'Ensure MSK Cluster logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_81:
     categories:
@@ -5485,7 +5485,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_81
-    pretty_name: 'CKV_AWS_81: Ensure MSK Cluster encryption in rest and transit is
+    pretty_name: 'Ensure MSK Cluster encryption in rest and transit is
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_82:
@@ -5497,7 +5497,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_82
-    pretty_name: 'CKV_AWS_82: Ensure Athena Workgroup should enforce configuration
+    pretty_name: 'Ensure Athena Workgroup should enforce configuration
       to prevent client disabling encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_83:
@@ -5509,7 +5509,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_83
-    pretty_name: 'CKV_AWS_83: Ensure Elasticsearch Domain enforces HTTPS'
+    pretty_name: 'Ensure Elasticsearch Domain enforces HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_84:
     categories:
@@ -5519,7 +5519,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_84
-    pretty_name: 'CKV_AWS_84: Ensure Elasticsearch Domain Logging is enabled'
+    pretty_name: 'Ensure Elasticsearch Domain Logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_85:
     categories:
@@ -5529,7 +5529,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_85
-    pretty_name: 'CKV_AWS_85: Ensure DocDB Logging is enabled'
+    pretty_name: 'Ensure DocDB Logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_86:
     categories:
@@ -5540,7 +5540,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_86
-    pretty_name: 'CKV_AWS_86: Ensure Cloudfront distribution has Access Logging enabled'
+    pretty_name: 'Ensure Cloudfront distribution has Access Logging enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_87:
     categories:
@@ -5551,7 +5551,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_87
-    pretty_name: 'CKV_AWS_87: Redshift cluster should not be publicly accessible'
+    pretty_name: 'Redshift cluster should not be publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_88:
     categories:
@@ -5562,7 +5562,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_88
-    pretty_name: 'CKV_AWS_88: EC2 instance should not have public IP.'
+    pretty_name: 'EC2 instance should not have public IP.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_89:
     categories:
@@ -5573,7 +5573,7 @@ rules:
     description: Check for publicly accessible AWS resources.
     group: cloud-resources-public-access
     name: CKV_AWS_89
-    pretty_name: 'CKV_AWS_89: DMS replication instance should not be publicly accessible'
+    pretty_name: 'DMS replication instance should not be publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_9:
     categories:
@@ -5582,7 +5582,7 @@ rules:
     description: Check for weak AWS permissions.
     group: cloud-insecure-iam
     name: CKV_AWS_9
-    pretty_name: 'CKV_AWS_9: Ensure IAM password policy expires passwords within 90
+    pretty_name: 'Ensure IAM password policy expires passwords within 90
       days or less'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_90:
@@ -5594,7 +5594,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_90
-    pretty_name: 'CKV_AWS_90: Ensure DocDB TLS is not disabled'
+    pretty_name: 'Ensure DocDB TLS is not disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_91:
     categories:
@@ -5605,7 +5605,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_91
-    pretty_name: 'CKV_AWS_91: Ensure the ELBv2 (Application/Network) has access logging
+    pretty_name: 'Ensure the ELBv2 (Application/Network) has access logging
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_92:
@@ -5617,7 +5617,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_92
-    pretty_name: 'CKV_AWS_92: Ensure the ELB has access logging enabled'
+    pretty_name: 'Ensure the ELB has access logging enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_93:
     categories:
@@ -5628,7 +5628,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_93
-    pretty_name: 'CKV_AWS_93: Ensure S3 bucket policy does not lockout all but root
+    pretty_name: 'Ensure S3 bucket policy does not lockout all but root
       user. (Prevent lockouts needing root account fixes)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_94:
@@ -5640,7 +5640,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_94
-    pretty_name: 'CKV_AWS_94: Ensure Glue Data Catalog Encryption is enabled'
+    pretty_name: 'Ensure Glue Data Catalog Encryption is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_95:
     categories:
@@ -5651,7 +5651,7 @@ rules:
     description: Check for misconfigurations in AWS resources.
     group: cloud-weak-configuration
     name: CKV_AWS_95
-    pretty_name: 'CKV_AWS_95: Ensure API Gateway V2 has Access Logging enabled'
+    pretty_name: 'Ensure API Gateway V2 has Access Logging enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_96:
     categories:
@@ -5662,7 +5662,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_96
-    pretty_name: 'CKV_AWS_96: Ensure all data stored in Aurora is securely encrypted
+    pretty_name: 'Ensure all data stored in Aurora is securely encrypted
       at rest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_97:
@@ -5674,7 +5674,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_97
-    pretty_name: 'CKV_AWS_97: Ensure Encryption in transit is enabled for EFS volumes
+    pretty_name: 'Ensure Encryption in transit is enabled for EFS volumes
       in ECS Task definitions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_98:
@@ -5686,7 +5686,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_98
-    pretty_name: 'CKV_AWS_98: Ensure all data stored in the Sagemaker Endpoint is
+    pretty_name: 'Ensure all data stored in the Sagemaker Endpoint is
       securely encrypted at rest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AWS_99:
@@ -5698,7 +5698,7 @@ rules:
     description: Check for unencrypted AWS resources.
     group: cloud-unencrypted-resources
     name: CKV_AWS_99
-    pretty_name: 'CKV_AWS_99: Ensure Glue Security Configuration Encryption is enabled'
+    pretty_name: 'Ensure Glue Security Configuration Encryption is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZUREPIPELINES_1:
     categories:
@@ -5709,7 +5709,7 @@ rules:
     description: Check for weak Azure Pipelines configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_AZUREPIPELINES_1
-    pretty_name: 'CKV_AZUREPIPELINES_1: Ensure container job uses a non latest version
+    pretty_name: 'Ensure container job uses a non latest version
       tag'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZUREPIPELINES_2:
@@ -5720,7 +5720,7 @@ rules:
     description: Check for weak Azure Pipelines configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_AZUREPIPELINES_2
-    pretty_name: 'CKV_AZUREPIPELINES_2: Ensure container job uses a version digest'
+    pretty_name: 'Ensure container job uses a version digest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZUREPIPELINES_3:
     categories:
@@ -5731,7 +5731,7 @@ rules:
     description: Check for weak Azure Pipelines configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_AZUREPIPELINES_3
-    pretty_name: 'CKV_AZUREPIPELINES_3: Ensure set variable is not marked as a secret'
+    pretty_name: 'Ensure set variable is not marked as a secret'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_1:
     categories:
@@ -5742,7 +5742,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_1
-    pretty_name: 'CKV_AZURE_1: Ensure Azure Instance does not use basic authentication(Use
+    pretty_name: 'Ensure Azure Instance does not use basic authentication(Use
       SSH Key Instead)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_10:
@@ -5754,7 +5754,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_10
-    pretty_name: 'CKV_AZURE_10: Ensure that SSH access is restricted from the internet'
+    pretty_name: 'Ensure that SSH access is restricted from the internet'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_100:
     categories:
@@ -5763,7 +5763,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_100
-    pretty_name: 'CKV_AZURE_100: Ensure that Cosmos DB accounts have customer-managed
+    pretty_name: 'Ensure that Cosmos DB accounts have customer-managed
       keys to encrypt data at rest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_101:
@@ -5775,7 +5775,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_101
-    pretty_name: 'CKV_AZURE_101: Ensure that Azure Cosmos DB disables public network
+    pretty_name: 'Ensure that Azure Cosmos DB disables public network
       access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_102:
@@ -5786,7 +5786,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_102
-    pretty_name: 'CKV_AZURE_102: Ensure that PostgreSQL server enables geo-redundant
+    pretty_name: 'Ensure that PostgreSQL server enables geo-redundant
       backups'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_103:
@@ -5797,7 +5797,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_103
-    pretty_name: 'CKV_AZURE_103: Ensure that Azure Data Factory uses Git repository
+    pretty_name: 'Ensure that Azure Data Factory uses Git repository
       for source control'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_104:
@@ -5809,7 +5809,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_104
-    pretty_name: 'CKV_AZURE_104: Ensure that Azure Data factory public network access
+    pretty_name: 'Ensure that Azure Data factory public network access
       is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_105:
@@ -5821,7 +5821,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_105
-    pretty_name: 'CKV_AZURE_105: Ensure that Data Lake Store accounts enables encryption'
+    pretty_name: 'Ensure that Data Lake Store accounts enables encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_106:
     categories:
@@ -5832,7 +5832,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_106
-    pretty_name: 'CKV_AZURE_106: Ensure that Azure Event Grid Domain public network
+    pretty_name: 'Ensure that Azure Event Grid Domain public network
       access is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_107:
@@ -5843,7 +5843,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_107
-    pretty_name: 'CKV_AZURE_107: Ensure that API management services use virtual networks'
+    pretty_name: 'Ensure that API management services use virtual networks'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_108:
     categories:
@@ -5852,7 +5852,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_108
-    pretty_name: 'CKV_AZURE_108: Ensure that Azure IoT Hub disables public network
+    pretty_name: 'Ensure that Azure IoT Hub disables public network
       access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_109:
@@ -5864,7 +5864,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_109
-    pretty_name: 'CKV_AZURE_109: Ensure that key vault allows firewall rules settings'
+    pretty_name: 'Ensure that key vault allows firewall rules settings'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_11:
     categories:
@@ -5875,7 +5875,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_11
-    pretty_name: 'CKV_AZURE_11: Ensure no SQL Databases allow ingress from 0.0.0.0/0
+    pretty_name: 'Ensure no SQL Databases allow ingress from 0.0.0.0/0
       (ANY IP)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_110:
@@ -5887,7 +5887,7 @@ rules:
     description: Check that ensures best practices in Azure secrets management.
     group: cloud-weak-secrets-management
     name: CKV_AZURE_110
-    pretty_name: 'CKV_AZURE_110: Ensure that key vault enables purge protection'
+    pretty_name: 'Ensure that key vault enables purge protection'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_111:
     categories:
@@ -5898,7 +5898,7 @@ rules:
     description: Check that ensures best practices in Azure secrets management.
     group: cloud-weak-secrets-management
     name: CKV_AZURE_111
-    pretty_name: 'CKV_AZURE_111: Ensure that key vault enables soft delete'
+    pretty_name: 'Ensure that key vault enables soft delete'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_112:
     categories:
@@ -5908,7 +5908,7 @@ rules:
     description: Check that ensures best practices in Azure secrets management.
     group: cloud-weak-secrets-management
     name: CKV_AZURE_112
-    pretty_name: 'CKV_AZURE_112: Ensure that key vault key is backed by HSM'
+    pretty_name: 'Ensure that key vault key is backed by HSM'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_113:
     categories:
@@ -5919,7 +5919,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_113
-    pretty_name: 'CKV_AZURE_113: Ensure that SQL server disables public network access'
+    pretty_name: 'Ensure that SQL server disables public network access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_114:
     categories:
@@ -5929,7 +5929,7 @@ rules:
     description: Check that ensures best practices in Azure secrets management.
     group: cloud-weak-secrets-management
     name: CKV_AZURE_114
-    pretty_name: 'CKV_AZURE_114: Ensure that key vault secrets have "content_type"
+    pretty_name: 'Ensure that key vault secrets have "content_type"
       set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_115:
@@ -5941,7 +5941,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_115
-    pretty_name: 'CKV_AZURE_115: Ensure that AKS enables private clusters'
+    pretty_name: 'Ensure that AKS enables private clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_116:
     categories:
@@ -5952,7 +5952,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_116
-    pretty_name: 'CKV_AZURE_116: Ensure that AKS uses Azure Policies Add-on'
+    pretty_name: 'Ensure that AKS uses Azure Policies Add-on'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_117:
     categories:
@@ -5963,7 +5963,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_117
-    pretty_name: 'CKV_AZURE_117: Ensure that AKS uses disk encryption set'
+    pretty_name: 'Ensure that AKS uses disk encryption set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_118:
     categories:
@@ -5974,7 +5974,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_118
-    pretty_name: 'CKV_AZURE_118: Ensure that Network Interfaces disable IP forwarding'
+    pretty_name: 'Ensure that Network Interfaces disable IP forwarding'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_119:
     categories:
@@ -5985,7 +5985,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_119
-    pretty_name: 'CKV_AZURE_119: Ensure that Network Interfaces don''t use public
+    pretty_name: 'Ensure that Network Interfaces don''t use public
       IPs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_12:
@@ -5995,7 +5995,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_12
-    pretty_name: 'CKV_AZURE_12: Ensure that Network Security Group Flow Log retention
+    pretty_name: 'Ensure that Network Security Group Flow Log retention
       period is ''greater than 90 days'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_120:
@@ -6005,7 +6005,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_120
-    pretty_name: 'CKV_AZURE_120: Ensure that Application Gateway enables WAF'
+    pretty_name: 'Ensure that Application Gateway enables WAF'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_121:
     categories:
@@ -6014,7 +6014,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_121
-    pretty_name: 'CKV_AZURE_121: Ensure that Azure Front Door enables WAF'
+    pretty_name: 'Ensure that Azure Front Door enables WAF'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_122:
     categories:
@@ -6023,7 +6023,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_122
-    pretty_name: 'CKV_AZURE_122: Ensure that Application Gateway uses WAF in "Detection"
+    pretty_name: 'Ensure that Application Gateway uses WAF in "Detection"
       or "Prevention" modes'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_123:
@@ -6033,7 +6033,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_123
-    pretty_name: 'CKV_AZURE_123: Ensure that Azure Front Door uses WAF in "Detection"
+    pretty_name: 'Ensure that Azure Front Door uses WAF in "Detection"
       or "Prevention" modes'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_124:
@@ -6045,7 +6045,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_124
-    pretty_name: 'CKV_AZURE_124: Ensure that Azure Cognitive Search disables public
+    pretty_name: 'Ensure that Azure Cognitive Search disables public
       network access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_125:
@@ -6057,7 +6057,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_125
-    pretty_name: 'CKV_AZURE_125: Ensures that Service Fabric use three levels of protection
+    pretty_name: 'Ensures that Service Fabric use three levels of protection
       available'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_126:
@@ -6069,7 +6069,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_126
-    pretty_name: 'CKV_AZURE_126: Ensures that Active Directory is used for authentication
+    pretty_name: 'Ensures that Active Directory is used for authentication
       for Service Fabric'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_127:
@@ -6079,7 +6079,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_127
-    pretty_name: 'CKV_AZURE_127: Ensure that My SQL server enables Threat detection
+    pretty_name: 'Ensure that My SQL server enables Threat detection
       policy'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_128:
@@ -6089,7 +6089,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_128
-    pretty_name: 'CKV_AZURE_128: Ensure that PostgreSQL server enables Threat detection
+    pretty_name: 'Ensure that PostgreSQL server enables Threat detection
       policy'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_129:
@@ -6100,7 +6100,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_129
-    pretty_name: 'CKV_AZURE_129: Ensure that MariaDB server enables geo-redundant
+    pretty_name: 'Ensure that MariaDB server enables geo-redundant
       backups'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_13:
@@ -6112,7 +6112,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_13
-    pretty_name: 'CKV_AZURE_13: Ensure App Service Authentication is set on Azure
+    pretty_name: 'Ensure App Service Authentication is set on Azure
       App Service'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_130:
@@ -6124,7 +6124,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_130
-    pretty_name: 'CKV_AZURE_130: Ensure that PostgreSQL server enables infrastructure
+    pretty_name: 'Ensure that PostgreSQL server enables infrastructure
       encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_131:
@@ -6136,7 +6136,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_AZURE_131
-    pretty_name: 'CKV_AZURE_131: SecureString parameter should not have hardcoded
+    pretty_name: 'SecureString parameter should not have hardcoded
       default values'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_132:
@@ -6148,7 +6148,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_132
-    pretty_name: 'CKV_AZURE_132: Ensure cosmosdb does not allow privileged escalation
+    pretty_name: 'Ensure cosmosdb does not allow privileged escalation
       by restricting management plane changes'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_133:
@@ -6158,7 +6158,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_133
-    pretty_name: 'CKV_AZURE_133: Ensure Front Door WAF prevents message lookup in
+    pretty_name: 'Ensure Front Door WAF prevents message lookup in
       Log4j2. See CVE-2021-44228 aka log4jshell'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_134:
@@ -6170,7 +6170,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_134
-    pretty_name: 'CKV_AZURE_134: Ensure that Cognitive Services accounts disable public
+    pretty_name: 'Ensure that Cognitive Services accounts disable public
       network access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_135:
@@ -6180,7 +6180,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_135
-    pretty_name: 'CKV_AZURE_135: Ensure Application Gateway WAF prevents message lookup
+    pretty_name: 'Ensure Application Gateway WAF prevents message lookup
       in Log4j2. See CVE-2021-44228 aka log4jshell'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_136:
@@ -6191,7 +6191,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_136
-    pretty_name: 'CKV_AZURE_136: Ensure that PostgreSQL Flexible server enables geo-redundant
+    pretty_name: 'Ensure that PostgreSQL Flexible server enables geo-redundant
       backups'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_137:
@@ -6203,7 +6203,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_137
-    pretty_name: 'CKV_AZURE_137: Ensure ACR admin account is disabled'
+    pretty_name: 'Ensure ACR admin account is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_138:
     categories:
@@ -6213,7 +6213,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_138
-    pretty_name: 'CKV_AZURE_138: Ensures that ACR disables anonymous pulling of images'
+    pretty_name: 'Ensures that ACR disables anonymous pulling of images'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_139:
     categories:
@@ -6224,7 +6224,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_139
-    pretty_name: 'CKV_AZURE_139: Ensure ACR set to disable public networking'
+    pretty_name: 'Ensure ACR set to disable public networking'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_14:
     categories:
@@ -6235,7 +6235,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_14
-    pretty_name: 'CKV_AZURE_14: Ensure web app redirects all HTTP traffic to HTTPS
+    pretty_name: 'Ensure web app redirects all HTTP traffic to HTTPS
       in Azure App Service'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_140:
@@ -6247,7 +6247,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_140
-    pretty_name: 'CKV_AZURE_140: Ensure that Local Authentication is disabled on CosmosDB'
+    pretty_name: 'Ensure that Local Authentication is disabled on CosmosDB'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_141:
     categories:
@@ -6258,7 +6258,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_141
-    pretty_name: 'CKV_AZURE_141: Ensure AKS local admin account is disabled'
+    pretty_name: 'Ensure AKS local admin account is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_142:
     categories:
@@ -6269,7 +6269,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_142
-    pretty_name: 'CKV_AZURE_142: Ensure Machine Learning Compute Cluster Local Authentication
+    pretty_name: 'Ensure Machine Learning Compute Cluster Local Authentication
       is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_143:
@@ -6281,7 +6281,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_143
-    pretty_name: 'CKV_AZURE_143: Ensure AKS cluster nodes do not have public IP addresses'
+    pretty_name: 'Ensure AKS cluster nodes do not have public IP addresses'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_144:
     categories:
@@ -6292,7 +6292,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_144
-    pretty_name: 'CKV_AZURE_144: Ensure that Public Access is disabled for Machine
+    pretty_name: 'Ensure that Public Access is disabled for Machine
       Learning Workspace'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_145:
@@ -6304,7 +6304,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_145
-    pretty_name: 'CKV_AZURE_145: Ensure Function app is using the latest version of
+    pretty_name: 'Ensure Function app is using the latest version of
       TLS encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_146:
@@ -6315,7 +6315,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_146
-    pretty_name: 'CKV_AZURE_146: Ensure server parameter ''log_retention'' is set
+    pretty_name: 'Ensure server parameter ''log_retention'' is set
       to ''ON'' for PostgreSQL Database Server'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_147:
@@ -6327,7 +6327,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_147
-    pretty_name: 'CKV_AZURE_147: Ensure PostgreSQL is using the latest version of
+    pretty_name: 'Ensure PostgreSQL is using the latest version of
       TLS encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_148:
@@ -6339,7 +6339,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_148
-    pretty_name: 'CKV_AZURE_148: Ensure Redis Cache is using the latest version of
+    pretty_name: 'Ensure Redis Cache is using the latest version of
       TLS encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_149:
@@ -6351,7 +6351,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_149
-    pretty_name: 'CKV_AZURE_149: Ensure that Virtual machine does not enable password
+    pretty_name: 'Ensure that Virtual machine does not enable password
       authentication'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_15:
@@ -6363,7 +6363,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_15
-    pretty_name: 'CKV_AZURE_15: Ensure web app is using the latest version of TLS
+    pretty_name: 'Ensure web app is using the latest version of TLS
       encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_150:
@@ -6375,7 +6375,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_150
-    pretty_name: 'CKV_AZURE_150: Ensure Machine Learning Compute Cluster Minimum Nodes
+    pretty_name: 'Ensure Machine Learning Compute Cluster Minimum Nodes
       Set To 0'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_151:
@@ -6387,7 +6387,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_151
-    pretty_name: 'CKV_AZURE_151: Ensure Windows VM enables encryption'
+    pretty_name: 'Ensure Windows VM enables encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_152:
     categories:
@@ -6397,7 +6397,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_152
-    pretty_name: 'CKV_AZURE_152: Ensure Client Certificates are enforced for API management'
+    pretty_name: 'Ensure Client Certificates are enforced for API management'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_153:
     categories:
@@ -6408,7 +6408,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_153
-    pretty_name: 'CKV_AZURE_153: Ensure web app redirects all HTTP traffic to HTTPS
+    pretty_name: 'Ensure web app redirects all HTTP traffic to HTTPS
       in Azure App Service Slot'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_154:
@@ -6420,7 +6420,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_154
-    pretty_name: 'CKV_AZURE_154: Ensure the App service slot is using the latest version
+    pretty_name: 'Ensure the App service slot is using the latest version
       of TLS encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_155:
@@ -6432,7 +6432,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_155
-    pretty_name: 'CKV_AZURE_155: Ensure debugging is disabled for the App service
+    pretty_name: 'Ensure debugging is disabled for the App service
       slot'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_156:
@@ -6444,7 +6444,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_156
-    pretty_name: 'CKV_AZURE_156: Ensure default Auditing policy for a SQL Server is
+    pretty_name: 'Ensure default Auditing policy for a SQL Server is
       configured to capture and retain the activity logs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_157:
@@ -6455,7 +6455,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_157
-    pretty_name: 'CKV_AZURE_157: Ensure that Synapse workspace has data_exfiltration_protection_enabled'
+    pretty_name: 'Ensure that Synapse workspace has data_exfiltration_protection_enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_158:
     categories:
@@ -6466,7 +6466,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_158
-    pretty_name: 'CKV_AZURE_158: Ensure that databricks workspace has not public'
+    pretty_name: 'Ensure that databricks workspace has not public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_159:
     categories:
@@ -6477,7 +6477,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_159
-    pretty_name: 'CKV_AZURE_159: Ensure function app builtin logging is enabled'
+    pretty_name: 'Ensure function app builtin logging is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_16:
     categories:
@@ -6488,7 +6488,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_16
-    pretty_name: 'CKV_AZURE_16: Ensure that Register with Azure Active Directory is
+    pretty_name: 'Ensure that Register with Azure Active Directory is
       enabled on App Service'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_160:
@@ -6500,7 +6500,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_160
-    pretty_name: 'CKV_AZURE_160: Ensure that HTTP (port 80) access is restricted from
+    pretty_name: 'Ensure that HTTP (port 80) access is restricted from
       the internet'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_161:
@@ -6512,7 +6512,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_161
-    pretty_name: 'CKV_AZURE_161: Ensures Spring Cloud API Portal is enabled on for
+    pretty_name: 'Ensures Spring Cloud API Portal is enabled on for
       HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_162:
@@ -6524,7 +6524,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_162
-    pretty_name: 'CKV_AZURE_162: Ensures Spring Cloud API Portal Public Access Is
+    pretty_name: 'Ensures Spring Cloud API Portal Public Access Is
       Disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_163:
@@ -6536,7 +6536,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_163
-    pretty_name: 'CKV_AZURE_163: Enable vulnerability scanning for container images.'
+    pretty_name: 'Enable vulnerability scanning for container images.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_164:
     categories:
@@ -6547,7 +6547,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_164
-    pretty_name: 'CKV_AZURE_164: Ensures that ACR uses signed/trusted images'
+    pretty_name: 'Ensures that ACR uses signed/trusted images'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_165:
     categories:
@@ -6558,7 +6558,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_165
-    pretty_name: 'CKV_AZURE_165: Ensure geo-replicated container registries to match
+    pretty_name: 'Ensure geo-replicated container registries to match
       multi-region container deployments.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_166:
@@ -6570,7 +6570,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_166
-    pretty_name: 'CKV_AZURE_166: Ensure container image quarantine, scan, and mark
+    pretty_name: 'Ensure container image quarantine, scan, and mark
       images verified'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_167:
@@ -6582,7 +6582,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_167
-    pretty_name: 'CKV_AZURE_167: Ensure a retention policy is set to cleanup untagged
+    pretty_name: 'Ensure a retention policy is set to cleanup untagged
       manifests.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_168:
@@ -6594,7 +6594,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_168
-    pretty_name: 'CKV_AZURE_168: Ensure Azure Kubernetes Cluster (AKS) nodes should
+    pretty_name: 'Ensure Azure Kubernetes Cluster (AKS) nodes should
       use a minimum number of 50 pods.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_169:
@@ -6606,7 +6606,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_169
-    pretty_name: 'CKV_AZURE_169: Ensure Azure Kubernetes Cluster (AKS) nodes use scale
+    pretty_name: 'Ensure Azure Kubernetes Cluster (AKS) nodes use scale
       sets'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_17:
@@ -6617,7 +6617,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_17
-    pretty_name: 'CKV_AZURE_17: Ensure the web app has ''Client Certificates (Incoming
+    pretty_name: 'Ensure the web app has ''Client Certificates (Incoming
       client certificates)'' set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_170:
@@ -6629,7 +6629,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_170
-    pretty_name: 'CKV_AZURE_170: Ensure that AKS use the Paid Sku for its SLA'
+    pretty_name: 'Ensure that AKS use the Paid Sku for its SLA'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_171:
     categories:
@@ -6640,7 +6640,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_171
-    pretty_name: 'CKV_AZURE_171: Ensure AKS cluster upgrade channel is chosen'
+    pretty_name: 'Ensure AKS cluster upgrade channel is chosen'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_172:
     categories:
@@ -6651,7 +6651,7 @@ rules:
     description: Check that ensures best practices in Azure secrets management.
     group: cloud-weak-secrets-management
     name: CKV_AZURE_172
-    pretty_name: 'CKV_AZURE_172: Ensure autorotation of Secrets Store CSI Driver secrets
+    pretty_name: 'Ensure autorotation of Secrets Store CSI Driver secrets
       for AKS clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_173:
@@ -6663,7 +6663,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_173
-    pretty_name: 'CKV_AZURE_173: Ensure API management uses at least TLS 1.2'
+    pretty_name: 'Ensure API management uses at least TLS 1.2'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_174:
     categories:
@@ -6674,7 +6674,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_174
-    pretty_name: 'CKV_AZURE_174: Ensure API management public access is disabled'
+    pretty_name: 'Ensure API management public access is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_175:
     categories:
@@ -6685,7 +6685,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_175
-    pretty_name: 'CKV_AZURE_175: Ensure Web PubSub uses a SKU with an SLA'
+    pretty_name: 'Ensure Web PubSub uses a SKU with an SLA'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_176:
     categories:
@@ -6696,7 +6696,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_176
-    pretty_name: 'CKV_AZURE_176: Ensure Web PubSub uses managed identities to access
+    pretty_name: 'Ensure Web PubSub uses managed identities to access
       Azure resources'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_177:
@@ -6708,7 +6708,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_177
-    pretty_name: 'CKV_AZURE_177: Ensure Windows VM enables automatic updates'
+    pretty_name: 'Ensure Windows VM enables automatic updates'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_178:
     categories:
@@ -6719,7 +6719,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_178
-    pretty_name: 'CKV_AZURE_178: Ensure linux VM enables SSH with keys for secure
+    pretty_name: 'Ensure linux VM enables SSH with keys for secure
       communication'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_179:
@@ -6731,7 +6731,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_179
-    pretty_name: 'CKV_AZURE_179: Ensure VM agent is installed'
+    pretty_name: 'Ensure VM agent is installed'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_18:
     categories:
@@ -6742,7 +6742,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_18
-    pretty_name: 'CKV_AZURE_18: Ensure that ''HTTP Version'' is the latest if used
+    pretty_name: 'Ensure that ''HTTP Version'' is the latest if used
       to run the web app'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_180:
@@ -6754,7 +6754,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_180
-    pretty_name: 'CKV_AZURE_180: Ensure that data explorer uses Sku with an SLA'
+    pretty_name: 'Ensure that data explorer uses Sku with an SLA'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_181:
     categories:
@@ -6765,7 +6765,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_181
-    pretty_name: 'CKV_AZURE_181: Ensure that data explorer/Kusto uses managed identities
+    pretty_name: 'Ensure that data explorer/Kusto uses managed identities
       to access Azure resources securely.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_182:
@@ -6777,7 +6777,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_182
-    pretty_name: 'CKV_AZURE_182: Ensure that VNET has at least 2 connected DNS Endpoints'
+    pretty_name: 'Ensure that VNET has at least 2 connected DNS Endpoints'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_183:
     categories:
@@ -6788,7 +6788,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_183
-    pretty_name: 'CKV_AZURE_183: Ensure that VNET uses local DNS addresses'
+    pretty_name: 'Ensure that VNET uses local DNS addresses'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_184:
     categories:
@@ -6799,7 +6799,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_184
-    pretty_name: 'CKV_AZURE_184: Ensure ''local_auth_enabled'' is set to ''False'''
+    pretty_name: 'Ensure ''local_auth_enabled'' is set to ''False'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_185:
     categories:
@@ -6810,7 +6810,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_185
-    pretty_name: 'CKV_AZURE_185: Ensure ''Public Access'' is not Enabled for App configuration'
+    pretty_name: 'Ensure ''Public Access'' is not Enabled for App configuration'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_186:
     categories:
@@ -6821,7 +6821,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_186
-    pretty_name: 'CKV_AZURE_186: Ensure App configuration encryption block is set.'
+    pretty_name: 'Ensure App configuration encryption block is set.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_187:
     categories:
@@ -6832,7 +6832,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_187
-    pretty_name: 'CKV_AZURE_187: Ensure App configuration purge protection is enabled'
+    pretty_name: 'Ensure App configuration purge protection is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_188:
     categories:
@@ -6843,7 +6843,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_188
-    pretty_name: 'CKV_AZURE_188: Ensure App configuration Sku is standard'
+    pretty_name: 'Ensure App configuration Sku is standard'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_189:
     categories:
@@ -6854,7 +6854,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_189
-    pretty_name: 'CKV_AZURE_189: Ensure that Azure Key Vault disables public network
+    pretty_name: 'Ensure that Azure Key Vault disables public network
       access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_19:
@@ -6864,7 +6864,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_19
-    pretty_name: 'CKV_AZURE_19: Ensure that standard pricing tier is selected'
+    pretty_name: 'Ensure that standard pricing tier is selected'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_190:
     categories:
@@ -6875,7 +6875,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_190
-    pretty_name: 'CKV_AZURE_190: Ensure that Storage blobs restrict public access'
+    pretty_name: 'Ensure that Storage blobs restrict public access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_191:
     categories:
@@ -6886,7 +6886,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_191
-    pretty_name: 'CKV_AZURE_191: Ensure that Managed identity provider is enabled
+    pretty_name: 'Ensure that Managed identity provider is enabled
       for Azure Event Grid Topic'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_192:
@@ -6898,7 +6898,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_192
-    pretty_name: 'CKV_AZURE_192: Ensure that Azure Event Grid Topic local Authentication
+    pretty_name: 'Ensure that Azure Event Grid Topic local Authentication
       is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_193:
@@ -6910,7 +6910,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_193
-    pretty_name: 'CKV_AZURE_193: Ensure public network access is disabled for Azure
+    pretty_name: 'Ensure public network access is disabled for Azure
       Event Grid Topic'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_194:
@@ -6922,7 +6922,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_194
-    pretty_name: 'CKV_AZURE_194: Ensure that Managed identity provider is enabled
+    pretty_name: 'Ensure that Managed identity provider is enabled
       for Azure Event Grid Domain'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_195:
@@ -6934,7 +6934,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_195
-    pretty_name: 'CKV_AZURE_195: Ensure that Azure Event Grid Domain local Authentication
+    pretty_name: 'Ensure that Azure Event Grid Domain local Authentication
       is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_196:
@@ -6946,7 +6946,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_196
-    pretty_name: 'CKV_AZURE_196: Ensure that SignalR uses a Paid Sku for its SLA'
+    pretty_name: 'Ensure that SignalR uses a Paid Sku for its SLA'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_197:
     categories:
@@ -6957,7 +6957,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_197
-    pretty_name: 'CKV_AZURE_197: Ensure the Azure CDN disables the HTTP endpoint'
+    pretty_name: 'Ensure the Azure CDN disables the HTTP endpoint'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_198:
     categories:
@@ -6968,7 +6968,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_198
-    pretty_name: 'CKV_AZURE_198: Ensure the Azure CDN enables the HTTPS endpoint'
+    pretty_name: 'Ensure the Azure CDN enables the HTTPS endpoint'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_199:
     categories:
@@ -6979,7 +6979,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_199
-    pretty_name: 'CKV_AZURE_199: Ensure that Azure Service Bus uses double encryption'
+    pretty_name: 'Ensure that Azure Service Bus uses double encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_2:
     categories:
@@ -6990,7 +6990,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_2
-    pretty_name: 'CKV_AZURE_2: Ensure Azure managed disk has encryption enabled'
+    pretty_name: 'Ensure Azure managed disk has encryption enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_20:
     categories:
@@ -7001,7 +7001,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_20
-    pretty_name: 'CKV_AZURE_20: Ensure that security contact ''Phone number'' is set'
+    pretty_name: 'Ensure that security contact ''Phone number'' is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_200:
     categories:
@@ -7012,7 +7012,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_200
-    pretty_name: 'CKV_AZURE_200: Ensure the Azure CDN endpoint is using the latest
+    pretty_name: 'Ensure the Azure CDN endpoint is using the latest
       version of TLS encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_201:
@@ -7024,7 +7024,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_201
-    pretty_name: 'CKV_AZURE_201: Ensure that Azure Service Bus uses a customer-managed
+    pretty_name: 'Ensure that Azure Service Bus uses a customer-managed
       key to encrypt data'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_202:
@@ -7036,7 +7036,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_202
-    pretty_name: 'CKV_AZURE_202: Ensure that Managed identity provider is enabled
+    pretty_name: 'Ensure that Managed identity provider is enabled
       for Azure Service Bus'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_203:
@@ -7048,7 +7048,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_203
-    pretty_name: 'CKV_AZURE_203: Ensure Azure Service Bus Local Authentication is
+    pretty_name: 'Ensure Azure Service Bus Local Authentication is
       disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_204:
@@ -7060,7 +7060,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_204
-    pretty_name: 'CKV_AZURE_204: Ensure ''public network access enabled'' is set to
+    pretty_name: 'Ensure ''public network access enabled'' is set to
       ''False'' for Azure Service Bus'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_205:
@@ -7072,7 +7072,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_205
-    pretty_name: 'CKV_AZURE_205: Ensure Azure Service Bus is using the latest version
+    pretty_name: 'Ensure Azure Service Bus is using the latest version
       of TLS encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_206:
@@ -7084,7 +7084,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_206
-    pretty_name: 'CKV_AZURE_206: Ensure that Storage Accounts use replication'
+    pretty_name: 'Ensure that Storage Accounts use replication'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_207:
     categories:
@@ -7095,7 +7095,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_207
-    pretty_name: 'CKV_AZURE_207: Ensure Azure Cognitive Search service uses managed
+    pretty_name: 'Ensure Azure Cognitive Search service uses managed
       identities to access Azure resources'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_208:
@@ -7107,7 +7107,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_208
-    pretty_name: 'CKV_AZURE_208: Ensure that Azure Cognitive Search maintains SLA
+    pretty_name: 'Ensure that Azure Cognitive Search maintains SLA
       for index updates'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_209:
@@ -7119,7 +7119,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_209
-    pretty_name: 'CKV_AZURE_209: Ensure that Azure Cognitive Search maintains SLA
+    pretty_name: 'Ensure that Azure Cognitive Search maintains SLA
       for search index queries'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_21:
@@ -7131,7 +7131,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_21
-    pretty_name: 'CKV_AZURE_21: Ensure that ''Send email notification for high severity
+    pretty_name: 'Ensure that ''Send email notification for high severity
       alerts'' is set to ''On'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_210:
@@ -7143,7 +7143,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_210
-    pretty_name: 'CKV_AZURE_210: Ensure Azure Cognitive Search service allowed IPS
+    pretty_name: 'Ensure Azure Cognitive Search service allowed IPS
       does not give public Access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_211:
@@ -7155,7 +7155,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_211
-    pretty_name: 'CKV_AZURE_211: Ensure App Service plan suitable for production use'
+    pretty_name: 'Ensure App Service plan suitable for production use'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_212:
     categories:
@@ -7166,7 +7166,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_212
-    pretty_name: 'CKV_AZURE_212: Ensure App Service has a minimum number of instances
+    pretty_name: 'Ensure App Service has a minimum number of instances
       for failover'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_213:
@@ -7178,7 +7178,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_213
-    pretty_name: 'CKV_AZURE_213: Ensure that App Service configures health check'
+    pretty_name: 'Ensure that App Service configures health check'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_214:
     categories:
@@ -7189,7 +7189,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_214
-    pretty_name: 'CKV_AZURE_214: Ensure App Service is set to be always on'
+    pretty_name: 'Ensure App Service is set to be always on'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_22:
     categories:
@@ -7200,7 +7200,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_22
-    pretty_name: 'CKV_AZURE_22: Ensure that ''Send email notification for high severity
+    pretty_name: 'Ensure that ''Send email notification for high severity
       alerts'' is set to ''On'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_23:
@@ -7212,7 +7212,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_23
-    pretty_name: 'CKV_AZURE_23: Ensure that ''Auditing'' is set to ''On'' for SQL
+    pretty_name: 'Ensure that ''Auditing'' is set to ''On'' for SQL
       servers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_24:
@@ -7223,7 +7223,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_24
-    pretty_name: 'CKV_AZURE_24: Ensure that ''Auditing'' Retention is ''greater than
+    pretty_name: 'Ensure that ''Auditing'' Retention is ''greater than
       90 days'' for SQL servers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_25:
@@ -7233,7 +7233,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_25
-    pretty_name: 'CKV_AZURE_25: Ensure that ''Threat Detection types'' is set to ''All'''
+    pretty_name: 'Ensure that ''Threat Detection types'' is set to ''All'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_26:
     categories:
@@ -7244,7 +7244,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_26
-    pretty_name: 'CKV_AZURE_26: Ensure that ''Send Alerts To'' is enabled for MSSQL
+    pretty_name: 'Ensure that ''Send Alerts To'' is enabled for MSSQL
       servers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_27:
@@ -7256,7 +7256,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_27
-    pretty_name: 'CKV_AZURE_27: Ensure that ''Email service and co-administrators''
+    pretty_name: 'Ensure that ''Email service and co-administrators''
       is ''Enabled'' for MSSQL servers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_28:
@@ -7268,7 +7268,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_28
-    pretty_name: 'CKV_AZURE_28: Ensure ''Enforce SSL connection'' is set to ''ENABLED''
+    pretty_name: 'Ensure ''Enforce SSL connection'' is set to ''ENABLED''
       for MySQL Database Server'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_29:
@@ -7279,7 +7279,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_29
-    pretty_name: 'CKV_AZURE_29: Ensure ''Enforce SSL connection'' is set to ''ENABLED''
+    pretty_name: 'Ensure ''Enforce SSL connection'' is set to ''ENABLED''
       for PostgreSQL Database Server'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_3:
@@ -7291,7 +7291,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_3
-    pretty_name: 'CKV_AZURE_3: Ensure that ''Secure transfer required'' is set to
+    pretty_name: 'Ensure that ''Secure transfer required'' is set to
       ''Enabled'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_30:
@@ -7302,7 +7302,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_30
-    pretty_name: 'CKV_AZURE_30: Ensure server parameter ''log_checkpoints'' is set
+    pretty_name: 'Ensure server parameter ''log_checkpoints'' is set
       to ''ON'' for PostgreSQL Database Server'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_31:
@@ -7312,7 +7312,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_31
-    pretty_name: 'CKV_AZURE_31: Ensure configuration ''log_connections'' is set to
+    pretty_name: 'Ensure configuration ''log_connections'' is set to
       ''ON'' for PostgreSQL Database Server'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_32:
@@ -7322,7 +7322,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_32
-    pretty_name: 'CKV_AZURE_32: Ensure server parameter ''connection_throttling''
+    pretty_name: 'Ensure server parameter ''connection_throttling''
       is set to ''ON'' for PostgreSQL Database Server'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_33:
@@ -7333,7 +7333,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_33
-    pretty_name: 'CKV_AZURE_33: Ensure Storage logging is enabled for Queue service
+    pretty_name: 'Ensure Storage logging is enabled for Queue service
       for read, write and delete requests'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_34:
@@ -7345,7 +7345,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_34
-    pretty_name: 'CKV_AZURE_34: Ensure that ''Public access level'' is set to Private
+    pretty_name: 'Ensure that ''Public access level'' is set to Private
       for blob containers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_35:
@@ -7357,7 +7357,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_35
-    pretty_name: 'CKV_AZURE_35: Ensure default network access rule for Storage Accounts
+    pretty_name: 'Ensure default network access rule for Storage Accounts
       is set to deny'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_36:
@@ -7369,7 +7369,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_36
-    pretty_name: 'CKV_AZURE_36: Ensure ''Trusted Microsoft Services'' is enabled for
+    pretty_name: 'Ensure ''Trusted Microsoft Services'' is enabled for
       Storage Account access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_37:
@@ -7380,7 +7380,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_37
-    pretty_name: 'CKV_AZURE_37: Ensure that Activity Log Retention is set 365 days
+    pretty_name: 'Ensure that Activity Log Retention is set 365 days
       or greater'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_38:
@@ -7391,7 +7391,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_38
-    pretty_name: 'CKV_AZURE_38: Ensure audit profile captures all the activities'
+    pretty_name: 'Ensure audit profile captures all the activities'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_39:
     categories:
@@ -7402,7 +7402,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_39
-    pretty_name: 'CKV_AZURE_39: Ensure that no custom subscription owner roles are
+    pretty_name: 'Ensure that no custom subscription owner roles are
       created'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_4:
@@ -7414,7 +7414,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_4
-    pretty_name: 'CKV_AZURE_4: Ensure AKS logging to Azure Monitoring is Configured'
+    pretty_name: 'Ensure AKS logging to Azure Monitoring is Configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_40:
     categories:
@@ -7424,7 +7424,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_40
-    pretty_name: 'CKV_AZURE_40: Ensure that the expiration date is set on all keys'
+    pretty_name: 'Ensure that the expiration date is set on all keys'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_41:
     categories:
@@ -7434,7 +7434,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_41
-    pretty_name: 'CKV_AZURE_41: Ensure that the expiration date is set on all secrets'
+    pretty_name: 'Ensure that the expiration date is set on all secrets'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_42:
     categories:
@@ -7445,7 +7445,7 @@ rules:
     description: Check that ensures best practices in Azure secrets management.
     group: cloud-weak-secrets-management
     name: CKV_AZURE_42
-    pretty_name: 'CKV_AZURE_42: Ensure the key vault is recoverable'
+    pretty_name: 'Ensure the key vault is recoverable'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_43:
     categories:
@@ -7454,7 +7454,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_43
-    pretty_name: 'CKV_AZURE_43: Ensure Storage Accounts adhere to the naming rules'
+    pretty_name: 'Ensure Storage Accounts adhere to the naming rules'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_44:
     categories:
@@ -7465,7 +7465,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_44
-    pretty_name: 'CKV_AZURE_44: Ensure Storage Account is using the latest version
+    pretty_name: 'Ensure Storage Account is using the latest version
       of TLS encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_45:
@@ -7477,7 +7477,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_45
-    pretty_name: 'CKV_AZURE_45: Ensure that no sensitive credentials are exposed in
+    pretty_name: 'Ensure that no sensitive credentials are exposed in
       VM custom_data'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_47:
@@ -7488,7 +7488,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_47
-    pretty_name: 'CKV_AZURE_47: Ensure ''Enforce SSL connection'' is set to ''ENABLED''
+    pretty_name: 'Ensure ''Enforce SSL connection'' is set to ''ENABLED''
       for MariaDB servers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_48:
@@ -7500,7 +7500,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_48
-    pretty_name: 'CKV_AZURE_48: Ensure ''public network access enabled'' is set to
+    pretty_name: 'Ensure ''public network access enabled'' is set to
       ''False'' for MariaDB servers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_49:
@@ -7512,7 +7512,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_49
-    pretty_name: 'CKV_AZURE_49: Ensure Azure linux scale set does not use basic authentication(Use
+    pretty_name: 'Ensure Azure linux scale set does not use basic authentication(Use
       SSH Key Instead)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_5:
@@ -7524,7 +7524,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_5
-    pretty_name: 'CKV_AZURE_5: Ensure RBAC is enabled on AKS clusters'
+    pretty_name: 'Ensure RBAC is enabled on AKS clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_50:
     categories:
@@ -7535,7 +7535,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_50
-    pretty_name: 'CKV_AZURE_50: Ensure Virtual Machine Extensions are not Installed'
+    pretty_name: 'Ensure Virtual Machine Extensions are not Installed'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_52:
     categories:
@@ -7545,7 +7545,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_52
-    pretty_name: 'CKV_AZURE_52: Ensure MSSQL is using the latest version of TLS encryption'
+    pretty_name: 'Ensure MSSQL is using the latest version of TLS encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_53:
     categories:
@@ -7556,7 +7556,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_53
-    pretty_name: 'CKV_AZURE_53: Ensure ''public network access enabled'' is set to
+    pretty_name: 'Ensure ''public network access enabled'' is set to
       ''False'' for mySQL servers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_54:
@@ -7567,7 +7567,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_54
-    pretty_name: 'CKV_AZURE_54: Ensure MySQL is using the latest version of TLS encryption'
+    pretty_name: 'Ensure MySQL is using the latest version of TLS encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_55:
     categories:
@@ -7577,7 +7577,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_55
-    pretty_name: 'CKV_AZURE_55: Ensure that Azure Defender is set to On for Servers'
+    pretty_name: 'Ensure that Azure Defender is set to On for Servers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_56:
     categories:
@@ -7588,7 +7588,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_56
-    pretty_name: 'CKV_AZURE_56: Ensure that function apps enables Authentication'
+    pretty_name: 'Ensure that function apps enables Authentication'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_57:
     categories:
@@ -7599,7 +7599,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_57
-    pretty_name: 'CKV_AZURE_57: Ensure that CORS disallows every resource to access
+    pretty_name: 'Ensure that CORS disallows every resource to access
       app services'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_58:
@@ -7610,7 +7610,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_58
-    pretty_name: 'CKV_AZURE_58: Ensure that Azure Synapse workspaces enables managed
+    pretty_name: 'Ensure that Azure Synapse workspaces enables managed
       virtual networks'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_59:
@@ -7622,7 +7622,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_59
-    pretty_name: 'CKV_AZURE_59: Ensure that Storage accounts disallow public access'
+    pretty_name: 'Ensure that Storage accounts disallow public access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_6:
     categories:
@@ -7632,7 +7632,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_6
-    pretty_name: 'CKV_AZURE_6: Ensure AKS has an API Server Authorized IP Ranges enabled'
+    pretty_name: 'Ensure AKS has an API Server Authorized IP Ranges enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_60:
     categories:
@@ -7643,7 +7643,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_60
-    pretty_name: 'CKV_AZURE_60: Ensure that storage account enables secure transfer'
+    pretty_name: 'Ensure that storage account enables secure transfer'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_61:
     categories:
@@ -7653,7 +7653,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_61
-    pretty_name: 'CKV_AZURE_61: Ensure that Azure Defender is set to On for App Service'
+    pretty_name: 'Ensure that Azure Defender is set to On for App Service'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_62:
     categories:
@@ -7662,7 +7662,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_62
-    pretty_name: 'CKV_AZURE_62: Ensure function apps are not accessible from all regions'
+    pretty_name: 'Ensure function apps are not accessible from all regions'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_63:
     categories:
@@ -7673,7 +7673,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_63
-    pretty_name: 'CKV_AZURE_63: Ensure that App service enables HTTP logging'
+    pretty_name: 'Ensure that App service enables HTTP logging'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_64:
     categories:
@@ -7684,7 +7684,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_64
-    pretty_name: 'CKV_AZURE_64: Ensure that Azure File Sync disables public network
+    pretty_name: 'Ensure that Azure File Sync disables public network
       access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_65:
@@ -7696,7 +7696,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_65
-    pretty_name: 'CKV_AZURE_65: Ensure that App service enables detailed error messages'
+    pretty_name: 'Ensure that App service enables detailed error messages'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_66:
     categories:
@@ -7706,7 +7706,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_66
-    pretty_name: 'CKV_AZURE_66: Ensure that App service enables failed request tracing'
+    pretty_name: 'Ensure that App service enables failed request tracing'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_67:
     categories:
@@ -7715,7 +7715,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_67
-    pretty_name: 'CKV_AZURE_67: Ensure that ''HTTP Version'' is the latest, if used
+    pretty_name: 'Ensure that ''HTTP Version'' is the latest, if used
       to run the Function app'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_68:
@@ -7727,7 +7727,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_68
-    pretty_name: 'CKV_AZURE_68: Ensure that PostgreSQL server disables public network
+    pretty_name: 'Ensure that PostgreSQL server disables public network
       access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_69:
@@ -7738,7 +7738,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_69
-    pretty_name: 'CKV_AZURE_69: Ensure that Azure Defender is set to On for Azure
+    pretty_name: 'Ensure that Azure Defender is set to On for Azure
       SQL database servers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_7:
@@ -7749,7 +7749,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_7
-    pretty_name: 'CKV_AZURE_7: Ensure AKS cluster has Network Policy configured'
+    pretty_name: 'Ensure AKS cluster has Network Policy configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_70:
     categories:
@@ -7760,7 +7760,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_70
-    pretty_name: 'CKV_AZURE_70: Ensure that Function apps is only accessible over
+    pretty_name: 'Ensure that Function apps is only accessible over
       HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_71:
@@ -7772,7 +7772,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_71
-    pretty_name: 'CKV_AZURE_71: Ensure that Managed identity provider is enabled for
+    pretty_name: 'Ensure that Managed identity provider is enabled for
       app services'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_72:
@@ -7784,7 +7784,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_72
-    pretty_name: 'CKV_AZURE_72: Ensure that remote debugging is not enabled for app
+    pretty_name: 'Ensure that remote debugging is not enabled for app
       services'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_73:
@@ -7796,7 +7796,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_73
-    pretty_name: 'CKV_AZURE_73: Ensure that Automation account variables are encrypted'
+    pretty_name: 'Ensure that Automation account variables are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_74:
     categories:
@@ -7807,7 +7807,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_74
-    pretty_name: 'CKV_AZURE_74: Ensure that Azure Data Explorer uses disk encryption'
+    pretty_name: 'Ensure that Azure Data Explorer uses disk encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_75:
     categories:
@@ -7816,7 +7816,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_75
-    pretty_name: 'CKV_AZURE_75: Ensure that Azure Data Explorer uses double encryption'
+    pretty_name: 'Ensure that Azure Data Explorer uses double encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_76:
     categories:
@@ -7825,7 +7825,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_76
-    pretty_name: 'CKV_AZURE_76: Ensure that Azure Batch account uses key vault to
+    pretty_name: 'Ensure that Azure Batch account uses key vault to
       encrypt data'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_77:
@@ -7837,7 +7837,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_77
-    pretty_name: 'CKV_AZURE_77: Ensure that UDP Services are restricted from the Internet '
+    pretty_name: 'Ensure that UDP Services are restricted from the Internet '
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_78:
     categories:
@@ -7848,7 +7848,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_78
-    pretty_name: 'CKV_AZURE_78: Ensure FTP deployments are disabled'
+    pretty_name: 'Ensure FTP deployments are disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_79:
     categories:
@@ -7858,7 +7858,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_79
-    pretty_name: 'CKV_AZURE_79: Ensure that Azure Defender is set to On for SQL servers
+    pretty_name: 'Ensure that Azure Defender is set to On for SQL servers
       on machines'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_8:
@@ -7870,7 +7870,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_8
-    pretty_name: 'CKV_AZURE_8: Ensure Kubernetes Dashboard is disabled'
+    pretty_name: 'Ensure Kubernetes Dashboard is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_80:
     categories:
@@ -7881,7 +7881,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_80
-    pretty_name: 'CKV_AZURE_80: Ensure that ''Net Framework'' version is the latest,
+    pretty_name: 'Ensure that ''Net Framework'' version is the latest,
       if used as a part of the web app'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_81:
@@ -7893,7 +7893,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_81
-    pretty_name: 'CKV_AZURE_81: Ensure that ''PHP version'' is the latest, if used
+    pretty_name: 'Ensure that ''PHP version'' is the latest, if used
       to run the web app'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_82:
@@ -7905,7 +7905,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_82
-    pretty_name: 'CKV_AZURE_82: Ensure that ''Python version'' is the latest, if used
+    pretty_name: 'Ensure that ''Python version'' is the latest, if used
       to run the web app'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_83:
@@ -7917,7 +7917,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_83
-    pretty_name: 'CKV_AZURE_83: Ensure that ''Java version'' is the latest, if used
+    pretty_name: 'Ensure that ''Java version'' is the latest, if used
       to run the web app'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_84:
@@ -7928,7 +7928,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_84
-    pretty_name: 'CKV_AZURE_84: Ensure that Azure Defender is set to On for Storage'
+    pretty_name: 'Ensure that Azure Defender is set to On for Storage'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_85:
     categories:
@@ -7938,7 +7938,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_85
-    pretty_name: 'CKV_AZURE_85: Ensure that Azure Defender is set to On for Kubernetes'
+    pretty_name: 'Ensure that Azure Defender is set to On for Kubernetes'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_86:
     categories:
@@ -7948,7 +7948,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_86
-    pretty_name: 'CKV_AZURE_86: Ensure that Azure Defender is set to On for Container
+    pretty_name: 'Ensure that Azure Defender is set to On for Container
       Registries'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_87:
@@ -7959,7 +7959,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_87
-    pretty_name: 'CKV_AZURE_87: Ensure that Azure Defender is set to On for Key Vault'
+    pretty_name: 'Ensure that Azure Defender is set to On for Key Vault'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_88:
     categories:
@@ -7968,7 +7968,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_88
-    pretty_name: 'CKV_AZURE_88: Ensure that app services use Azure Files'
+    pretty_name: 'Ensure that app services use Azure Files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_89:
     categories:
@@ -7979,7 +7979,7 @@ rules:
     description: Check for publicly accessible Azure resources.
     group: cloud-resources-public-access
     name: CKV_AZURE_89
-    pretty_name: 'CKV_AZURE_89: Ensure that Azure Cache for Redis disables public
+    pretty_name: 'Ensure that Azure Cache for Redis disables public
       network access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_9:
@@ -7991,7 +7991,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_9
-    pretty_name: 'CKV_AZURE_9: Ensure that RDP access is restricted from the internet'
+    pretty_name: 'Ensure that RDP access is restricted from the internet'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_91:
     categories:
@@ -8001,7 +8001,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_91
-    pretty_name: 'CKV_AZURE_91: Ensure that only SSL are enabled for Cache for Redis'
+    pretty_name: 'Ensure that only SSL are enabled for Cache for Redis'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_92:
     categories:
@@ -8012,7 +8012,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_92
-    pretty_name: 'CKV_AZURE_92: Ensure that Virtual Machines use managed disks'
+    pretty_name: 'Ensure that Virtual Machines use managed disks'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_93:
     categories:
@@ -8021,7 +8021,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_93
-    pretty_name: 'CKV_AZURE_93: Ensure that managed disks use a specific set of disk
+    pretty_name: 'Ensure that managed disks use a specific set of disk
       encryption sets for the customer-managed key encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_94:
@@ -8032,7 +8032,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_94
-    pretty_name: 'CKV_AZURE_94: Ensure that My SQL server enables geo-redundant backups'
+    pretty_name: 'Ensure that My SQL server enables geo-redundant backups'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_95:
     categories:
@@ -8043,7 +8043,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_95
-    pretty_name: 'CKV_AZURE_95: Ensure that automatic OS image patching is enabled
+    pretty_name: 'Ensure that automatic OS image patching is enabled
       for Virtual Machine Scale Sets'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_96:
@@ -8054,7 +8054,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_96
-    pretty_name: 'CKV_AZURE_96: Ensure that MySQL server enables infrastructure encryption'
+    pretty_name: 'Ensure that MySQL server enables infrastructure encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_97:
     categories:
@@ -8065,7 +8065,7 @@ rules:
     description: Check for unencrypted Azure resources.
     group: cloud-unencrypted-resources
     name: CKV_AZURE_97
-    pretty_name: 'CKV_AZURE_97: Ensure that Virtual machine scale sets have encryption
+    pretty_name: 'Ensure that Virtual machine scale sets have encryption
       at host enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_98:
@@ -8077,7 +8077,7 @@ rules:
     description: Check for misconfigurations in Azure resources.
     group: cloud-weak-configuration
     name: CKV_AZURE_98
-    pretty_name: 'CKV_AZURE_98: Ensure that Azure Container group is deployed into
+    pretty_name: 'Ensure that Azure Container group is deployed into
       virtual network'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_AZURE_99:
@@ -8089,7 +8089,7 @@ rules:
     description: Check for weak Azure permissions.
     group: cloud-insecure-iam
     name: CKV_AZURE_99
-    pretty_name: 'CKV_AZURE_99: Ensure Cosmos DB accounts have restricted access'
+    pretty_name: 'Ensure Cosmos DB accounts have restricted access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_BCW_1:
     categories:
@@ -8100,7 +8100,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_BCW_1
-    pretty_name: 'CKV_BCW_1: Ensure no hard coded API token exist in the provider'
+    pretty_name: 'Ensure no hard coded API token exist in the provider'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_BITBUCKETPIPELINES_1:
     categories:
@@ -8110,7 +8110,7 @@ rules:
     description: Check for weak Bitbucket Pipelines configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_BITBUCKETPIPELINES_1
-    pretty_name: 'CKV_BITBUCKETPIPELINES_1: Ensure the pipeline image uses a non latest
+    pretty_name: 'Ensure the pipeline image uses a non latest
       version tag'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_BITBUCKET_1:
@@ -8120,7 +8120,7 @@ rules:
     description: Check for weak Bitbucket configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_BITBUCKET_1
-    pretty_name: 'CKV_BITBUCKET_1: Merge requests should require at least 2 approvals'
+    pretty_name: 'Merge requests should require at least 2 approvals'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_CIRCLECIPIPELINES_1:
     categories:
@@ -8130,7 +8130,7 @@ rules:
     description: Check for weak CircleCI configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_CIRCLECIPIPELINES_1
-    pretty_name: 'CKV_CIRCLECIPIPELINES_1: Ensure the pipeline image uses a non latest
+    pretty_name: 'Ensure the pipeline image uses a non latest
       version tag'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_CIRCLECIPIPELINES_2:
@@ -8141,7 +8141,7 @@ rules:
     description: Check for weak CircleCI configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_CIRCLECIPIPELINES_2
-    pretty_name: 'CKV_CIRCLECIPIPELINES_2: Ensure the pipeline image version is referenced
+    pretty_name: 'Ensure the pipeline image version is referenced
       via hash not arbitrary tag.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_CIRCLECIPIPELINES_3:
@@ -8152,7 +8152,7 @@ rules:
     description: Check for weak CircleCI configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_CIRCLECIPIPELINES_3
-    pretty_name: 'CKV_CIRCLECIPIPELINES_3: Ensure mutable development orbs are not
+    pretty_name: 'Ensure mutable development orbs are not
       used.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_CIRCLECIPIPELINES_4:
@@ -8164,7 +8164,7 @@ rules:
     description: Check for weak CircleCI configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_CIRCLECIPIPELINES_4
-    pretty_name: 'CKV_CIRCLECIPIPELINES_4: Ensure unversioned volatile orbs are not
+    pretty_name: 'Ensure unversioned volatile orbs are not
       used.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_CIRCLECIPIPELINES_5:
@@ -8176,7 +8176,7 @@ rules:
     description: Check for weak CircleCI configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_CIRCLECIPIPELINES_5
-    pretty_name: 'CKV_CIRCLECIPIPELINES_5: Suspicious use of netcat with IP address'
+    pretty_name: 'Suspicious use of netcat with IP address'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_CIRCLECIPIPELINES_6:
     categories:
@@ -8187,7 +8187,7 @@ rules:
     description: Check for weak CircleCI configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_CIRCLECIPIPELINES_6
-    pretty_name: 'CKV_CIRCLECIPIPELINES_6: Ensure run commands are not vulnerable
+    pretty_name: 'Ensure run commands are not vulnerable
       to shell injection'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_CIRCLECIPIPELINES_7:
@@ -8199,7 +8199,7 @@ rules:
     description: Check for weak CircleCI configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_CIRCLECIPIPELINES_7
-    pretty_name: 'CKV_CIRCLECIPIPELINES_7: Suspicious use of curl in run task'
+    pretty_name: 'Suspicious use of curl in run task'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DIO_1:
     categories:
@@ -8209,7 +8209,7 @@ rules:
     description: Check for misconfigurations in Digital Ocean resources.
     group: cloud-weak-configuration
     name: CKV_DIO_1
-    pretty_name: 'CKV_DIO_1: Ensure the Spaces bucket has versioning enabled'
+    pretty_name: 'Ensure the Spaces bucket has versioning enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DIO_2:
     categories:
@@ -8220,7 +8220,7 @@ rules:
     description: Check for misconfigurations in Digital Ocean resources.
     group: cloud-weak-configuration
     name: CKV_DIO_2
-    pretty_name: 'CKV_DIO_2: Ensure the droplet specifies an SSH key'
+    pretty_name: 'Ensure the droplet specifies an SSH key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DIO_3:
     categories:
@@ -8231,7 +8231,7 @@ rules:
     description: Check for publicly accessible Digital Ocean resources.
     group: cloud-resources-public-access
     name: CKV_DIO_3
-    pretty_name: 'CKV_DIO_3: Ensure the Spaces bucket is private'
+    pretty_name: 'Ensure the Spaces bucket is private'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DIO_4:
     categories:
@@ -8242,7 +8242,7 @@ rules:
     description: Check for misconfigurations in Digital Ocean resources.
     group: cloud-weak-configuration
     name: CKV_DIO_4
-    pretty_name: 'CKV_DIO_4: Ensure the firewall ingress is not wide open'
+    pretty_name: 'Ensure the firewall ingress is not wide open'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_1:
     categories:
@@ -8253,7 +8253,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_1
-    pretty_name: 'CKV_DOCKER_1: Ensure port 22 is not exposed'
+    pretty_name: 'Ensure port 22 is not exposed'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_10:
     categories:
@@ -8264,7 +8264,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_10
-    pretty_name: 'CKV_DOCKER_10: Ensure that WORKDIR values are absolute paths'
+    pretty_name: 'Ensure that WORKDIR values are absolute paths'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_11:
     categories:
@@ -8275,7 +8275,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_11
-    pretty_name: 'CKV_DOCKER_11: Ensure From Alias are unique for multistage builds.'
+    pretty_name: 'Ensure From Alias are unique for multistage builds.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_2:
     categories:
@@ -8284,7 +8284,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_2
-    pretty_name: 'CKV_DOCKER_2: Ensure that HEALTHCHECK instructions have been added
+    pretty_name: 'Ensure that HEALTHCHECK instructions have been added
       to container images'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_3:
@@ -8294,7 +8294,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_3
-    pretty_name: 'CKV_DOCKER_3: Ensure that a user for the container has been created'
+    pretty_name: 'Ensure that a user for the container has been created'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_4:
     categories:
@@ -8303,7 +8303,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_4
-    pretty_name: 'CKV_DOCKER_4: Ensure that COPY is used instead of ADD in Dockerfiles'
+    pretty_name: 'Ensure that COPY is used instead of ADD in Dockerfiles'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_5:
     categories:
@@ -8314,7 +8314,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_5
-    pretty_name: 'CKV_DOCKER_5: Ensure update instructions are not use alone in the
+    pretty_name: 'Ensure update instructions are not use alone in the
       Dockerfile'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_6:
@@ -8324,7 +8324,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_6
-    pretty_name: 'CKV_DOCKER_6: Ensure that LABEL maintainer is used instead of MAINTAINER
+    pretty_name: 'Ensure that LABEL maintainer is used instead of MAINTAINER
       (deprecated)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_7:
@@ -8336,7 +8336,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_7
-    pretty_name: 'CKV_DOCKER_7: Ensure the base image uses a non latest version tag'
+    pretty_name: 'Ensure the base image uses a non latest version tag'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_8:
     categories:
@@ -8346,7 +8346,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_8
-    pretty_name: 'CKV_DOCKER_8: Ensure the last USER is not root'
+    pretty_name: 'Ensure the last USER is not root'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_DOCKER_9:
     categories:
@@ -8355,7 +8355,7 @@ rules:
     description: Check for misconfigurations in Docker resources.
     group: cloud-weak-configuration
     name: CKV_DOCKER_9
-    pretty_name: 'CKV_DOCKER_9: Ensure that APT isn''t used'
+    pretty_name: 'Ensure that APT isn''t used'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_1:
     categories:
@@ -8366,7 +8366,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_1
-    pretty_name: 'CKV_GCP_1: Ensure Stackdriver Logging is set to Enabled on Kubernetes
+    pretty_name: 'Ensure Stackdriver Logging is set to Enabled on Kubernetes
       Engine Clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_10:
@@ -8378,7 +8378,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_10
-    pretty_name: 'CKV_GCP_10: Ensure ''Automatic node upgrade'' is enabled for Kubernetes
+    pretty_name: 'Ensure ''Automatic node upgrade'' is enabled for Kubernetes
       Clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_100:
@@ -8390,7 +8390,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_100
-    pretty_name: 'CKV_GCP_100: Ensure that BigQuery Tables are not anonymously or
+    pretty_name: 'Ensure that BigQuery Tables are not anonymously or
       publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_101:
@@ -8402,7 +8402,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_101
-    pretty_name: 'CKV_GCP_101: Ensure that Artifact Registry repositories are not
+    pretty_name: 'Ensure that Artifact Registry repositories are not
       anonymously or publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_102:
@@ -8414,7 +8414,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_102
-    pretty_name: 'CKV_GCP_102: Ensure that GCP Cloud Run services are not anonymously
+    pretty_name: 'Ensure that GCP Cloud Run services are not anonymously
       or publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_103:
@@ -8426,7 +8426,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_103
-    pretty_name: 'CKV_GCP_103: Ensure Dataproc Clusters do not have public IPs'
+    pretty_name: 'Ensure Dataproc Clusters do not have public IPs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_104:
     categories:
@@ -8437,7 +8437,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_104
-    pretty_name: 'CKV_GCP_104: Ensure Datafusion has stack driver logging enabled'
+    pretty_name: 'Ensure Datafusion has stack driver logging enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_105:
     categories:
@@ -8448,7 +8448,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_105
-    pretty_name: 'CKV_GCP_105: Ensure Datafusion has stack driver monitoring enabled'
+    pretty_name: 'Ensure Datafusion has stack driver monitoring enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_106:
     categories:
@@ -8459,7 +8459,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_106
-    pretty_name: 'CKV_GCP_106: Ensure Google compute firewall ingress does not allow
+    pretty_name: 'Ensure Google compute firewall ingress does not allow
       unrestricted http port 80 access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_107:
@@ -8469,7 +8469,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_107
-    pretty_name: 'CKV_GCP_107: Cloud functions should not be public'
+    pretty_name: 'Cloud functions should not be public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_108:
     categories:
@@ -8480,7 +8480,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_108
-    pretty_name: 'CKV_GCP_108: Ensure hostnames are logged for GCP PostgreSQL databases'
+    pretty_name: 'Ensure hostnames are logged for GCP PostgreSQL databases'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_109:
     categories:
@@ -8491,7 +8491,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_109
-    pretty_name: 'CKV_GCP_109: Ensure the GCP PostgreSQL database log levels are set
+    pretty_name: 'Ensure the GCP PostgreSQL database log levels are set
       to ERROR or lower'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_11:
@@ -8503,7 +8503,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_11
-    pretty_name: 'CKV_GCP_11: Ensure that Cloud SQL database Instances are not open
+    pretty_name: 'Ensure that Cloud SQL database Instances are not open
       to the world'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_110:
@@ -8514,7 +8514,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_110
-    pretty_name: 'CKV_GCP_110: Ensure pgAudit is enabled for your GCP PostgreSQL database'
+    pretty_name: 'Ensure pgAudit is enabled for your GCP PostgreSQL database'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_111:
     categories:
@@ -8523,7 +8523,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_111
-    pretty_name: 'CKV_GCP_111: Ensure GCP PostgreSQL logs SQL statements'
+    pretty_name: 'Ensure GCP PostgreSQL logs SQL statements'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_112:
     categories:
@@ -8534,7 +8534,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_112
-    pretty_name: 'CKV_GCP_112: Esnure KMS policy should not allow public access'
+    pretty_name: 'Esnure KMS policy should not allow public access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_113:
     categories:
@@ -8545,7 +8545,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_113
-    pretty_name: 'CKV_GCP_113: Ensure IAM policy should not define public access'
+    pretty_name: 'Ensure IAM policy should not define public access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_114:
     categories:
@@ -8556,7 +8556,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_114
-    pretty_name: 'CKV_GCP_114: Ensure public access prevention is enforced on Cloud
+    pretty_name: 'Ensure public access prevention is enforced on Cloud
       Storage bucket'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_115:
@@ -8568,7 +8568,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_115
-    pretty_name: 'CKV_GCP_115: Ensure basic roles are not used at organization level.'
+    pretty_name: 'Ensure basic roles are not used at organization level.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_116:
     categories:
@@ -8579,7 +8579,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_116
-    pretty_name: 'CKV_GCP_116: Ensure basic roles are not used at folder level.'
+    pretty_name: 'Ensure basic roles are not used at folder level.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_117:
     categories:
@@ -8590,7 +8590,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_117
-    pretty_name: 'CKV_GCP_117: Ensure basic roles are not used at project level.'
+    pretty_name: 'Ensure basic roles are not used at project level.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_12:
     categories:
@@ -8599,7 +8599,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_12
-    pretty_name: 'CKV_GCP_12: Ensure Network Policy is enabled on Kubernetes Engine
+    pretty_name: 'Ensure Network Policy is enabled on Kubernetes Engine
       Clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_13:
@@ -8611,7 +8611,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_13
-    pretty_name: 'CKV_GCP_13: Ensure client certificate authentication to Kubernetes
+    pretty_name: 'Ensure client certificate authentication to Kubernetes
       Engine Clusters is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_14:
@@ -8623,7 +8623,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_14
-    pretty_name: 'CKV_GCP_14: Ensure all Cloud SQL database instance have backup configuration
+    pretty_name: 'Ensure all Cloud SQL database instance have backup configuration
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_15:
@@ -8635,7 +8635,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_15
-    pretty_name: 'CKV_GCP_15: Ensure that BigQuery datasets are not anonymously or
+    pretty_name: 'Ensure that BigQuery datasets are not anonymously or
       publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_16:
@@ -8645,7 +8645,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_16
-    pretty_name: 'CKV_GCP_16: Ensure that DNSSEC is enabled for Cloud DNS'
+    pretty_name: 'Ensure that DNSSEC is enabled for Cloud DNS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_17:
     categories:
@@ -8656,7 +8656,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_17
-    pretty_name: 'CKV_GCP_17: Ensure that RSASHA1 is not used for the zone-signing
+    pretty_name: 'Ensure that RSASHA1 is not used for the zone-signing
       and key-signing keys in Cloud DNS DNSSEC'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_18:
@@ -8667,7 +8667,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_18
-    pretty_name: 'CKV_GCP_18: Ensure GKE Control Plane is not public'
+    pretty_name: 'Ensure GKE Control Plane is not public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_19:
     categories:
@@ -8678,7 +8678,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_19
-    pretty_name: 'CKV_GCP_19: Ensure GKE basic auth is disabled'
+    pretty_name: 'Ensure GKE basic auth is disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_2:
     categories:
@@ -8689,7 +8689,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_2
-    pretty_name: 'CKV_GCP_2: Ensure Google compute firewall ingress does not allow
+    pretty_name: 'Ensure Google compute firewall ingress does not allow
       unrestricted ssh access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_20:
@@ -8700,7 +8700,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_20
-    pretty_name: 'CKV_GCP_20: Ensure master authorized networks is set to enabled
+    pretty_name: 'Ensure master authorized networks is set to enabled
       in GKE clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_21:
@@ -8710,7 +8710,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_21
-    pretty_name: 'CKV_GCP_21: Ensure Kubernetes Clusters are configured with Labels'
+    pretty_name: 'Ensure Kubernetes Clusters are configured with Labels'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_22:
     categories:
@@ -8721,7 +8721,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_22
-    pretty_name: 'CKV_GCP_22: Ensure Container-Optimized OS (cos) is used for Kubernetes
+    pretty_name: 'Ensure Container-Optimized OS (cos) is used for Kubernetes
       Engine Clusters Node image'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_23:
@@ -8731,7 +8731,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_23
-    pretty_name: 'CKV_GCP_23: Ensure Kubernetes Cluster is created with Alias IP ranges
+    pretty_name: 'Ensure Kubernetes Cluster is created with Alias IP ranges
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_24:
@@ -8741,7 +8741,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_24
-    pretty_name: 'CKV_GCP_24: Ensure PodSecurityPolicy controller is enabled on the
+    pretty_name: 'Ensure PodSecurityPolicy controller is enabled on the
       Kubernetes Engine Clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_25:
@@ -8751,7 +8751,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_25
-    pretty_name: 'CKV_GCP_25: Ensure Kubernetes Cluster is created with Private cluster
+    pretty_name: 'Ensure Kubernetes Cluster is created with Private cluster
       enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_26:
@@ -8761,7 +8761,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_26
-    pretty_name: 'CKV_GCP_26: Ensure that VPC Flow Logs is enabled for every subnet
+    pretty_name: 'Ensure that VPC Flow Logs is enabled for every subnet
       in a VPC Network'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_27:
@@ -8772,7 +8772,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_27
-    pretty_name: 'CKV_GCP_27: Ensure that the default network does not exist in a
+    pretty_name: 'Ensure that the default network does not exist in a
       project'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_28:
@@ -8784,7 +8784,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_28
-    pretty_name: 'CKV_GCP_28: Ensure that Cloud Storage bucket is not anonymously
+    pretty_name: 'Ensure that Cloud Storage bucket is not anonymously
       or publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_29:
@@ -8796,7 +8796,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_29
-    pretty_name: 'CKV_GCP_29: Ensure that Cloud Storage buckets have uniform bucket-level
+    pretty_name: 'Ensure that Cloud Storage buckets have uniform bucket-level
       access enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_3:
@@ -8808,7 +8808,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_3
-    pretty_name: 'CKV_GCP_3: Ensure Google compute firewall ingress does not allow
+    pretty_name: 'Ensure Google compute firewall ingress does not allow
       unrestricted rdp access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_30:
@@ -8820,7 +8820,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_30
-    pretty_name: 'CKV_GCP_30: Ensure that instances are not configured to use the
+    pretty_name: 'Ensure that instances are not configured to use the
       default service account'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_31:
@@ -8832,7 +8832,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_31
-    pretty_name: 'CKV_GCP_31: Ensure that instances are not configured to use the
+    pretty_name: 'Ensure that instances are not configured to use the
       default service account with full access to all Cloud APIs'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_32:
@@ -8844,7 +8844,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_32
-    pretty_name: 'CKV_GCP_32: Ensure ''Block Project-wide SSH keys'' is enabled for
+    pretty_name: 'Ensure ''Block Project-wide SSH keys'' is enabled for
       VM instances'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_33:
@@ -8856,7 +8856,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_33
-    pretty_name: 'CKV_GCP_33: Ensure oslogin is enabled for a Project'
+    pretty_name: 'Ensure oslogin is enabled for a Project'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_34:
     categories:
@@ -8867,7 +8867,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_34
-    pretty_name: 'CKV_GCP_34: Ensure that no instance in the project overrides the
+    pretty_name: 'Ensure that no instance in the project overrides the
       project setting for enabling OSLogin'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_35:
@@ -8879,7 +8879,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_35
-    pretty_name: 'CKV_GCP_35: Ensure ''Enable connecting to serial ports'' is not
+    pretty_name: 'Ensure ''Enable connecting to serial ports'' is not
       enabled for VM Instance'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_36:
@@ -8891,7 +8891,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_36
-    pretty_name: 'CKV_GCP_36: Ensure that IP forwarding is not enabled on Instances'
+    pretty_name: 'Ensure that IP forwarding is not enabled on Instances'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_37:
     categories:
@@ -8900,7 +8900,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_37
-    pretty_name: 'CKV_GCP_37: Ensure VM disks for critical VMs are encrypted with
+    pretty_name: 'Ensure VM disks for critical VMs are encrypted with
       Customer Supplied Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_38:
@@ -8910,7 +8910,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_38
-    pretty_name: 'CKV_GCP_38: Ensure VM disks for critical VMs are encrypted with
+    pretty_name: 'Ensure VM disks for critical VMs are encrypted with
       Customer Supplied Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_39:
@@ -8921,7 +8921,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_39
-    pretty_name: 'CKV_GCP_39: Ensure Compute instances are launched with Shielded
+    pretty_name: 'Ensure Compute instances are launched with Shielded
       VM enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_4:
@@ -8933,7 +8933,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_4
-    pretty_name: 'CKV_GCP_4: Ensure no HTTPS or SSL proxy load balancers permit SSL
+    pretty_name: 'Ensure no HTTPS or SSL proxy load balancers permit SSL
       policies with weak cipher suites'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_40:
@@ -8945,7 +8945,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_40
-    pretty_name: 'CKV_GCP_40: Ensure that Compute instances do not have public IP
+    pretty_name: 'Ensure that Compute instances do not have public IP
       addresses'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_41:
@@ -8957,7 +8957,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_41
-    pretty_name: 'CKV_GCP_41: Ensure that IAM users are not assigned the Service Account
+    pretty_name: 'Ensure that IAM users are not assigned the Service Account
       User or Service Account Token Creator roles at project level'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_42:
@@ -8969,7 +8969,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_42
-    pretty_name: 'CKV_GCP_42: Ensure that Service Account has no Admin privileges'
+    pretty_name: 'Ensure that Service Account has no Admin privileges'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_43:
     categories:
@@ -8979,7 +8979,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_43
-    pretty_name: 'CKV_GCP_43: Ensure KMS encryption keys are rotated within a period
+    pretty_name: 'Ensure KMS encryption keys are rotated within a period
       of 90 days'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_44:
@@ -8991,7 +8991,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_44
-    pretty_name: 'CKV_GCP_44: Ensure no roles that enable to impersonate and manage
+    pretty_name: 'Ensure no roles that enable to impersonate and manage
       all service accounts are used at a folder level'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_45:
@@ -9003,7 +9003,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_45
-    pretty_name: 'CKV_GCP_45: Ensure no roles that enable to impersonate and manage
+    pretty_name: 'Ensure no roles that enable to impersonate and manage
       all service accounts are used at an organization level'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_46:
@@ -9015,7 +9015,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_46
-    pretty_name: 'CKV_GCP_46: Ensure Default Service account is not used at a project
+    pretty_name: 'Ensure Default Service account is not used at a project
       level'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_47:
@@ -9027,7 +9027,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_47
-    pretty_name: 'CKV_GCP_47: Ensure default service account is not used at an organization
+    pretty_name: 'Ensure default service account is not used at an organization
       level'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_48:
@@ -9039,7 +9039,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_48
-    pretty_name: 'CKV_GCP_48: Ensure Default Service account is not used at a folder
+    pretty_name: 'Ensure Default Service account is not used at a folder
       level'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_49:
@@ -9051,7 +9051,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_49
-    pretty_name: 'CKV_GCP_49: Ensure roles do not impersonate or manage Service Accounts
+    pretty_name: 'Ensure roles do not impersonate or manage Service Accounts
       used at project level'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_50:
@@ -9063,7 +9063,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_50
-    pretty_name: 'CKV_GCP_50: Ensure MySQL database ''local_infile'' flag is set to
+    pretty_name: 'Ensure MySQL database ''local_infile'' flag is set to
       ''off'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_51:
@@ -9075,7 +9075,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_51
-    pretty_name: 'CKV_GCP_51: Ensure PostgreSQL database ''log_checkpoints'' flag
+    pretty_name: 'Ensure PostgreSQL database ''log_checkpoints'' flag
       is set to ''on'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_52:
@@ -9087,7 +9087,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_52
-    pretty_name: 'CKV_GCP_52: Ensure PostgreSQL database ''log_connections'' flag
+    pretty_name: 'Ensure PostgreSQL database ''log_connections'' flag
       is set to ''on'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_53:
@@ -9098,7 +9098,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_53
-    pretty_name: 'CKV_GCP_53: Ensure PostgreSQL database ''log_disconnections'' flag
+    pretty_name: 'Ensure PostgreSQL database ''log_disconnections'' flag
       is set to ''on'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_54:
@@ -9109,7 +9109,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_54
-    pretty_name: 'CKV_GCP_54: Ensure PostgreSQL database ''log_lock_waits'' flag is
+    pretty_name: 'Ensure PostgreSQL database ''log_lock_waits'' flag is
       set to ''on'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_55:
@@ -9119,7 +9119,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_55
-    pretty_name: 'CKV_GCP_55: Ensure PostgreSQL database ''log_min_messages'' flag
+    pretty_name: 'Ensure PostgreSQL database ''log_min_messages'' flag
       is set to a valid value'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_56:
@@ -9130,7 +9130,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_56
-    pretty_name: 'CKV_GCP_56: Ensure PostgreSQL database ''log_temp_files flag is
+    pretty_name: 'Ensure PostgreSQL database ''log_temp_files flag is
       set to ''0'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_57:
@@ -9140,7 +9140,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_57
-    pretty_name: 'CKV_GCP_57: Ensure PostgreSQL database ''log_min_duration_statement''
+    pretty_name: 'Ensure PostgreSQL database ''log_min_duration_statement''
       flag is set to ''-1'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_58:
@@ -9152,7 +9152,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_58
-    pretty_name: 'CKV_GCP_58: Ensure SQL database ''cross db ownership chaining''
+    pretty_name: 'Ensure SQL database ''cross db ownership chaining''
       flag is set to ''off'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_59:
@@ -9164,7 +9164,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_59
-    pretty_name: 'CKV_GCP_59: Ensure SQL database ''contained database authentication''
+    pretty_name: 'Ensure SQL database ''contained database authentication''
       flag is set to ''off'''
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_6:
@@ -9176,7 +9176,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_6
-    pretty_name: 'CKV_GCP_6: Ensure all Cloud SQL database instance requires all incoming
+    pretty_name: 'Ensure all Cloud SQL database instance requires all incoming
       connections to use SSL'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_60:
@@ -9188,7 +9188,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_60
-    pretty_name: 'CKV_GCP_60: Ensure Cloud SQL database does not have public IP'
+    pretty_name: 'Ensure Cloud SQL database does not have public IP'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_61:
     categories:
@@ -9197,7 +9197,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_61
-    pretty_name: 'CKV_GCP_61: Enable VPC Flow Logs and Intranode Visibility'
+    pretty_name: 'Enable VPC Flow Logs and Intranode Visibility'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_62:
     categories:
@@ -9207,7 +9207,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_62
-    pretty_name: 'CKV_GCP_62: Bucket should log access'
+    pretty_name: 'Bucket should log access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_63:
     categories:
@@ -9218,7 +9218,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_63
-    pretty_name: 'CKV_GCP_63: Bucket should not log to itself'
+    pretty_name: 'Bucket should not log to itself'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_64:
     categories:
@@ -9227,7 +9227,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_64
-    pretty_name: 'CKV_GCP_64: Ensure clusters are created with Private Nodes'
+    pretty_name: 'Ensure clusters are created with Private Nodes'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_65:
     categories:
@@ -9238,7 +9238,7 @@ rules:
     description: Check for weak Google Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_GCP_65
-    pretty_name: 'CKV_GCP_65: Manage Kubernetes RBAC users with Google Groups for
+    pretty_name: 'Manage Kubernetes RBAC users with Google Groups for
       GKE'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_66:
@@ -9249,7 +9249,7 @@ rules:
     description: Check for weak Google Cloud configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_GCP_66
-    pretty_name: 'CKV_GCP_66: Ensure use of Binary Authorization'
+    pretty_name: 'Ensure use of Binary Authorization'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_67:
     categories:
@@ -9260,7 +9260,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_67
-    pretty_name: 'CKV_GCP_67: Ensure legacy Compute Engine instance metadata APIs
+    pretty_name: 'Ensure legacy Compute Engine instance metadata APIs
       are Disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_68:
@@ -9271,7 +9271,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_68
-    pretty_name: 'CKV_GCP_68: Ensure Secure Boot for Shielded GKE Nodes is Enabled'
+    pretty_name: 'Ensure Secure Boot for Shielded GKE Nodes is Enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_69:
     categories:
@@ -9282,7 +9282,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_69
-    pretty_name: 'CKV_GCP_69: Ensure the GKE Metadata Server is Enabled'
+    pretty_name: 'Ensure the GKE Metadata Server is Enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_7:
     categories:
@@ -9293,7 +9293,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_7
-    pretty_name: 'CKV_GCP_7: Ensure Legacy Authorization is set to Disabled on Kubernetes
+    pretty_name: 'Ensure Legacy Authorization is set to Disabled on Kubernetes
       Engine Clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_70:
@@ -9305,7 +9305,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_70
-    pretty_name: 'CKV_GCP_70: Ensure the GKE Release Channel is set'
+    pretty_name: 'Ensure the GKE Release Channel is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_71:
     categories:
@@ -9315,7 +9315,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_71
-    pretty_name: 'CKV_GCP_71: Ensure Shielded GKE Nodes are Enabled'
+    pretty_name: 'Ensure Shielded GKE Nodes are Enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_72:
     categories:
@@ -9325,7 +9325,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_72
-    pretty_name: 'CKV_GCP_72: Ensure Integrity Monitoring for Shielded GKE Nodes is
+    pretty_name: 'Ensure Integrity Monitoring for Shielded GKE Nodes is
       Enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_73:
@@ -9337,7 +9337,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_73
-    pretty_name: 'CKV_GCP_73: Ensure Cloud Armor prevents message lookup in Log4j2.
+    pretty_name: 'Ensure Cloud Armor prevents message lookup in Log4j2.
       See CVE-2021-44228 aka log4jshell'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_74:
@@ -9349,7 +9349,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_74
-    pretty_name: 'CKV_GCP_74: Ensure that private_ip_google_access is enabled for
+    pretty_name: 'Ensure that private_ip_google_access is enabled for
       Subnet'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_75:
@@ -9361,7 +9361,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_75
-    pretty_name: 'CKV_GCP_75: Ensure Google compute firewall ingress does not allow
+    pretty_name: 'Ensure Google compute firewall ingress does not allow
       unrestricted FTP access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_76:
@@ -9373,7 +9373,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_76
-    pretty_name: 'CKV_GCP_76: Ensure that Private google access is enabled for IPV6'
+    pretty_name: 'Ensure that Private google access is enabled for IPV6'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_77:
     categories:
@@ -9384,7 +9384,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_77
-    pretty_name: 'CKV_GCP_77: Ensure Google compute firewall ingress does not allow
+    pretty_name: 'Ensure Google compute firewall ingress does not allow
       on ftp port'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_78:
@@ -9394,7 +9394,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_78
-    pretty_name: 'CKV_GCP_78: Ensure Cloud storage has versioning enabled'
+    pretty_name: 'Ensure Cloud storage has versioning enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_79:
     categories:
@@ -9405,7 +9405,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_79
-    pretty_name: 'CKV_GCP_79: Ensure SQL database is using latest Major version'
+    pretty_name: 'Ensure SQL database is using latest Major version'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_8:
     categories:
@@ -9416,7 +9416,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_8
-    pretty_name: 'CKV_GCP_8: Ensure Stackdriver Monitoring is set to Enabled on Kubernetes
+    pretty_name: 'Ensure Stackdriver Monitoring is set to Enabled on Kubernetes
       Engine Clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_80:
@@ -9426,7 +9426,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_80
-    pretty_name: 'CKV_GCP_80: Ensure Big Query Tables are encrypted with Customer
+    pretty_name: 'Ensure Big Query Tables are encrypted with Customer
       Supplied Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_81:
@@ -9436,7 +9436,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_81
-    pretty_name: 'CKV_GCP_81: Ensure Big Query Tables are encrypted with Customer
+    pretty_name: 'Ensure Big Query Tables are encrypted with Customer
       Supplied Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_82:
@@ -9448,7 +9448,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_82
-    pretty_name: 'CKV_GCP_82: Ensure KMS keys are protected from deletion'
+    pretty_name: 'Ensure KMS keys are protected from deletion'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_83:
     categories:
@@ -9457,7 +9457,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_83
-    pretty_name: 'CKV_GCP_83: Ensure PubSub Topics are encrypted with Customer Supplied
+    pretty_name: 'Ensure PubSub Topics are encrypted with Customer Supplied
       Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_84:
@@ -9467,7 +9467,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_84
-    pretty_name: 'CKV_GCP_84: Ensure Artifact Registry Repositories are encrypted
+    pretty_name: 'Ensure Artifact Registry Repositories are encrypted
       with Customer Supplied Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_85:
@@ -9477,7 +9477,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_85
-    pretty_name: 'CKV_GCP_85: Ensure Big Table Instances are encrypted with Customer
+    pretty_name: 'Ensure Big Table Instances are encrypted with Customer
       Supplied Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_86:
@@ -9489,7 +9489,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_86
-    pretty_name: 'CKV_GCP_86: Ensure Cloud build workers are private'
+    pretty_name: 'Ensure Cloud build workers are private'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_87:
     categories:
@@ -9500,7 +9500,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_87
-    pretty_name: 'CKV_GCP_87: Ensure Data fusion instances are private'
+    pretty_name: 'Ensure Data fusion instances are private'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_88:
     categories:
@@ -9511,7 +9511,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_88
-    pretty_name: 'CKV_GCP_88: Ensure Google compute firewall ingress does not allow
+    pretty_name: 'Ensure Google compute firewall ingress does not allow
       unrestricted mysql access'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_89:
@@ -9523,7 +9523,7 @@ rules:
     description: Check that ensures best practices in Google Cloud secrets management.
     group: cloud-weak-secrets-management
     name: CKV_GCP_89
-    pretty_name: 'CKV_GCP_89: Ensure Vertex AI instances are private'
+    pretty_name: 'Ensure Vertex AI instances are private'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_9:
     categories:
@@ -9532,7 +9532,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_9
-    pretty_name: 'CKV_GCP_9: Ensure ''Automatic node repair'' is enabled for Kubernetes
+    pretty_name: 'Ensure ''Automatic node repair'' is enabled for Kubernetes
       Clusters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_90:
@@ -9542,7 +9542,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_90
-    pretty_name: 'CKV_GCP_90: Ensure data flow jobs are encrypted with Customer Supplied
+    pretty_name: 'Ensure data flow jobs are encrypted with Customer Supplied
       Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_91:
@@ -9552,7 +9552,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_91
-    pretty_name: 'CKV_GCP_91: Ensure Dataproc cluster is encrypted with Customer Supplied
+    pretty_name: 'Ensure Dataproc cluster is encrypted with Customer Supplied
       Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_92:
@@ -9562,7 +9562,7 @@ rules:
     description: Check that ensures best practices in Google Cloud secrets management.
     group: cloud-weak-secrets-management
     name: CKV_GCP_92
-    pretty_name: 'CKV_GCP_92: Ensure Vertex AI datasets uses a CMK (Customer Manager
+    pretty_name: 'Ensure Vertex AI datasets uses a CMK (Customer Manager
       Key)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_93:
@@ -9572,7 +9572,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_93
-    pretty_name: 'CKV_GCP_93: Ensure Spanner Database is encrypted with Customer Supplied
+    pretty_name: 'Ensure Spanner Database is encrypted with Customer Supplied
       Encryption Keys (CSEK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_94:
@@ -9584,7 +9584,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_94
-    pretty_name: 'CKV_GCP_94: Ensure Dataflow jobs are private'
+    pretty_name: 'Ensure Dataflow jobs are private'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_95:
     categories:
@@ -9595,7 +9595,7 @@ rules:
     description: Check for misconfigurations in Google Cloud resources.
     group: cloud-weak-configuration
     name: CKV_GCP_95
-    pretty_name: 'CKV_GCP_95: Ensure Memorystore for Redis has AUTH enabled'
+    pretty_name: 'Ensure Memorystore for Redis has AUTH enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_96:
     categories:
@@ -9604,7 +9604,7 @@ rules:
     description: Check that ensures best practices in Google Cloud secrets management.
     group: cloud-weak-secrets-management
     name: CKV_GCP_96
-    pretty_name: 'CKV_GCP_96: Ensure Vertex AI Metadata Store uses a CMK (Customer
+    pretty_name: 'Ensure Vertex AI Metadata Store uses a CMK (Customer
       Manager Key)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_97:
@@ -9614,7 +9614,7 @@ rules:
     description: Check for unencrypted Google Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_GCP_97
-    pretty_name: 'CKV_GCP_97: Ensure Memorystore for Redis uses intransit encryption'
+    pretty_name: 'Ensure Memorystore for Redis uses intransit encryption'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_98:
     categories:
@@ -9625,7 +9625,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_98
-    pretty_name: 'CKV_GCP_98: Ensure that Dataproc clusters are not anonymously or
+    pretty_name: 'Ensure that Dataproc clusters are not anonymously or
       publicly accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GCP_99:
@@ -9637,7 +9637,7 @@ rules:
     description: Check for publicly accessible Google Cloud resources.
     group: cloud-resources-public-access
     name: CKV_GCP_99
-    pretty_name: 'CKV_GCP_99: Ensure that Pub/Sub Topics are not anonymously or publicly
+    pretty_name: 'Ensure that Pub/Sub Topics are not anonymously or publicly
       accessible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GHA_1:
@@ -9649,7 +9649,7 @@ rules:
     description: Check for weak GitHub Action configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_GHA_1
-    pretty_name: 'CKV_GHA_1: Ensure ACTIONS_ALLOW_UNSECURE_COMMANDS isn''t true on
+    pretty_name: 'Ensure ACTIONS_ALLOW_UNSECURE_COMMANDS isn''t true on
       environment variables'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GHA_2:
@@ -9661,7 +9661,7 @@ rules:
     description: Check for weak GitHub Action configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_GHA_2
-    pretty_name: 'CKV_GHA_2: Ensure run commands are not vulnerable to shell injection'
+    pretty_name: 'Ensure run commands are not vulnerable to shell injection'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GHA_3:
     categories:
@@ -9672,7 +9672,7 @@ rules:
     description: Check for weak GitHub Action configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_GHA_3
-    pretty_name: 'CKV_GHA_3: Suspicious use of curl with secrets'
+    pretty_name: 'Suspicious use of curl with secrets'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GHA_4:
     categories:
@@ -9683,7 +9683,7 @@ rules:
     description: Check for weak GitHub Action configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_GHA_4
-    pretty_name: 'CKV_GHA_4: Suspicious use of netcat with IP address'
+    pretty_name: 'Suspicious use of netcat with IP address'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GHA_5:
     categories:
@@ -9692,7 +9692,7 @@ rules:
     description: Check for weak GitHub Action configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_GHA_5
-    pretty_name: 'CKV_GHA_5: Found artifact build without evidence of cosign sign
+    pretty_name: 'Found artifact build without evidence of cosign sign
       execution in pipeline'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GHA_6:
@@ -9702,7 +9702,7 @@ rules:
     description: Check for weak GitHub Action configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_GHA_6
-    pretty_name: 'CKV_GHA_6: Found artifact build without evidence of cosign sbom
+    pretty_name: 'Found artifact build without evidence of cosign sbom
       attestation in pipeline'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GHA_7:
@@ -9712,7 +9712,7 @@ rules:
     description: Check for weak GitHub Action configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_GHA_7
-    pretty_name: 'CKV_GHA_7: The build output cannot be affected by user parameters
+    pretty_name: 'The build output cannot be affected by user parameters
       other than the build entry point and the top-level source location. GitHub Actions
       workflow_dispatch inputs MUST be empty. '
     ref: https://www.checkov.io/5.Policy%20Index/all.html
@@ -9725,7 +9725,7 @@ rules:
     description: Check for misconfigurations in GitHub resources.
     group: cloud-weak-configuration
     name: CKV_GITHUB_1
-    pretty_name: 'CKV_GITHUB_1: Ensure GitHub organization security settings require
+    pretty_name: 'Ensure GitHub organization security settings require
       2FA'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITHUB_10:
@@ -9737,7 +9737,7 @@ rules:
     description: Check for weak GitHub configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_GITHUB_10
-    pretty_name: 'CKV_GITHUB_10: Ensure branch protection rules are enforced on administrators'
+    pretty_name: 'Ensure branch protection rules are enforced on administrators'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITHUB_2:
     categories:
@@ -9746,7 +9746,7 @@ rules:
     description: Check for misconfigurations in GitHub resources.
     group: cloud-weak-configuration
     name: CKV_GITHUB_2
-    pretty_name: 'CKV_GITHUB_2: Ensure GitHub organization security settings require
+    pretty_name: 'Ensure GitHub organization security settings require
       SSO'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITHUB_3:
@@ -9756,7 +9756,7 @@ rules:
     description: Check for misconfigurations in GitHub resources.
     group: cloud-weak-configuration
     name: CKV_GITHUB_3
-    pretty_name: 'CKV_GITHUB_3: Ensure GitHub organization security settings has IP
+    pretty_name: 'Ensure GitHub organization security settings has IP
       allow list enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITHUB_4:
@@ -9767,7 +9767,7 @@ rules:
     description: Check for weak GitHub configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GITHUB_4
-    pretty_name: 'CKV_GITHUB_4: Ensure GitHub branch protection rules requires signed
+    pretty_name: 'Ensure GitHub branch protection rules requires signed
       commits'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITHUB_5:
@@ -9779,7 +9779,7 @@ rules:
     description: Check for weak GitHub configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GITHUB_5
-    pretty_name: 'CKV_GITHUB_5: Ensure GitHub branch protection rules does not allow
+    pretty_name: 'Ensure GitHub branch protection rules does not allow
       force pushes'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITHUB_6:
@@ -9791,7 +9791,7 @@ rules:
     description: Check for unencrypted GitHub resources.
     group: cloud-unencrypted-resources
     name: CKV_GITHUB_6
-    pretty_name: 'CKV_GITHUB_6: Ensure GitHub organization webhooks are using HTTPS'
+    pretty_name: 'Ensure GitHub organization webhooks are using HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITHUB_7:
     categories:
@@ -9802,7 +9802,7 @@ rules:
     description: Check for unencrypted GitHub resources.
     group: cloud-unencrypted-resources
     name: CKV_GITHUB_7
-    pretty_name: 'CKV_GITHUB_7: Ensure GitHub repository webhooks are using HTTPS'
+    pretty_name: 'Ensure GitHub repository webhooks are using HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITHUB_8:
     categories:
@@ -9812,7 +9812,7 @@ rules:
     description: Check for weak GitHub configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GITHUB_8
-    pretty_name: 'CKV_GITHUB_8: Ensure GitHub branch protection rules requires linear
+    pretty_name: 'Ensure GitHub branch protection rules requires linear
       history'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITHUB_9:
@@ -9822,7 +9822,7 @@ rules:
     description: Check for weak GitHub configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GITHUB_9
-    pretty_name: 'CKV_GITHUB_9: Ensure 2 admins are set for each repository'
+    pretty_name: 'Ensure 2 admins are set for each repository'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITLABCI_1:
     categories:
@@ -9833,7 +9833,7 @@ rules:
     description: Check for weak GitLab CI configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_GITLABCI_1
-    pretty_name: 'CKV_GITLABCI_1: Suspicious use of curl with CI environment variables
+    pretty_name: 'Suspicious use of curl with CI environment variables
       in script'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITLABCI_2:
@@ -9845,7 +9845,7 @@ rules:
     description: Check for misconfigurations in GitLab CI resources.
     group: cloud-weak-configuration
     name: CKV_GITLABCI_2
-    pretty_name: 'CKV_GITLABCI_2: Avoid creating rules that generate double pipelines'
+    pretty_name: 'Avoid creating rules that generate double pipelines'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITLABCI_3:
     categories:
@@ -9854,7 +9854,7 @@ rules:
     description: Check for weak GitLab CI configurations.
     group: supply-chain-cicd-vulnerable-pipeline
     name: CKV_GITLABCI_3
-    pretty_name: 'CKV_GITLABCI_3: Detecting image usages in gitlab workflows'
+    pretty_name: 'Detecting image usages in gitlab workflows'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITLAB_1:
     categories:
@@ -9863,7 +9863,7 @@ rules:
     description: Check for weak GitLab configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GITLAB_1
-    pretty_name: 'CKV_GITLAB_1: Merge requests should require at least 2 approvals'
+    pretty_name: 'Merge requests should require at least 2 approvals'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GITLAB_2:
     categories:
@@ -9874,7 +9874,7 @@ rules:
     description: Check for weak GitLab configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GITLAB_2
-    pretty_name: 'CKV_GITLAB_2: Ensure all Gitlab groups require two factor authentication'
+    pretty_name: 'Ensure all Gitlab groups require two factor authentication'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GIT_1:
     categories:
@@ -9883,7 +9883,7 @@ rules:
     description: Check for publicly accessible GitHub resources.
     group: cloud-resources-public-access
     name: CKV_GIT_1
-    pretty_name: 'CKV_GIT_1: Ensure GitHub repository is Private'
+    pretty_name: 'Ensure GitHub repository is Private'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GIT_2:
     categories:
@@ -9894,7 +9894,7 @@ rules:
     description: Check for unencrypted GitHub resources.
     group: cloud-unencrypted-resources
     name: CKV_GIT_2
-    pretty_name: 'CKV_GIT_2: Ensure GitHub repository webhooks are using HTTPS'
+    pretty_name: 'Ensure GitHub repository webhooks are using HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GIT_3:
     categories:
@@ -9905,7 +9905,7 @@ rules:
     description: Check for weak GitHub configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_GIT_3
-    pretty_name: 'CKV_GIT_3: Ensure GitHub repository has vulnerability alerts enabled'
+    pretty_name: 'Ensure GitHub repository has vulnerability alerts enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GIT_4:
     categories:
@@ -9916,7 +9916,7 @@ rules:
     description: Check for unencrypted GitHub resources.
     group: cloud-unencrypted-resources
     name: CKV_GIT_4
-    pretty_name: 'CKV_GIT_4: Ensure GitHub Actions secrets are encrypted'
+    pretty_name: 'Ensure GitHub Actions secrets are encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GIT_5:
     categories:
@@ -9925,7 +9925,7 @@ rules:
     description: Check for weak GitHub configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GIT_5
-    pretty_name: 'CKV_GIT_5: GitHub pull requests should require at least 2 approvals'
+    pretty_name: 'GitHub pull requests should require at least 2 approvals'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GIT_6:
     categories:
@@ -9935,7 +9935,7 @@ rules:
     description: Check for weak GitHub configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GIT_6
-    pretty_name: 'CKV_GIT_6: Ensure GitHub branch protection rules requires signed
+    pretty_name: 'Ensure GitHub branch protection rules requires signed
       commits'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GLB_1:
@@ -9945,7 +9945,7 @@ rules:
     description: Check for weak GitLab configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GLB_1
-    pretty_name: 'CKV_GLB_1: Ensure at least two approving reviews are required to
+    pretty_name: 'Ensure at least two approving reviews are required to
       merge a GitLab MR'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GLB_2:
@@ -9957,7 +9957,7 @@ rules:
     description: Check for weak GitLab configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GLB_2
-    pretty_name: 'CKV_GLB_2: Ensure GitLab branch protection rules does not allow
+    pretty_name: 'Ensure GitLab branch protection rules does not allow
       force pushes'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GLB_3:
@@ -9969,7 +9969,7 @@ rules:
     description: Check for weak GitLab configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GLB_3
-    pretty_name: 'CKV_GLB_3: Ensure GitLab prevent secrets is enabled'
+    pretty_name: 'Ensure GitLab prevent secrets is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_GLB_4:
     categories:
@@ -9979,7 +9979,7 @@ rules:
     description: Check for weak GitLab configurations.
     group: supply-chain-scm-weak-configuration
     name: CKV_GLB_4
-    pretty_name: 'CKV_GLB_4: Ensure GitLab commits are signed'
+    pretty_name: 'Ensure GitLab commits are signed'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_1:
     categories:
@@ -9990,7 +9990,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_1
-    pretty_name: 'CKV_K8S_1: Do not admit containers wishing to share the host process
+    pretty_name: 'Do not admit containers wishing to share the host process
       ID namespace'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_10:
@@ -10001,7 +10001,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_10
-    pretty_name: 'CKV_K8S_10: CPU requests should be set'
+    pretty_name: 'CPU requests should be set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_100:
     categories:
@@ -10012,7 +10012,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_100
-    pretty_name: 'CKV_K8S_100: Ensure that the --tls-cert-file and --tls-private-key-file
+    pretty_name: 'Ensure that the --tls-cert-file and --tls-private-key-file
       arguments are set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_102:
@@ -10024,7 +10024,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_102
-    pretty_name: 'CKV_K8S_102: Ensure that the --etcd-cafile argument is set as appropriate'
+    pretty_name: 'Ensure that the --etcd-cafile argument is set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_104:
     categories:
@@ -10035,7 +10035,7 @@ rules:
     description: Check for unencrypted Kubernetes resources.
     group: cloud-unencrypted-resources
     name: CKV_K8S_104
-    pretty_name: 'CKV_K8S_104: Ensure that encryption providers are appropriately
+    pretty_name: 'Ensure that encryption providers are appropriately
       configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_105:
@@ -10047,7 +10047,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_105
-    pretty_name: 'CKV_K8S_105: Ensure that the API Server only makes use of Strong
+    pretty_name: 'Ensure that the API Server only makes use of Strong
       Cryptographic Ciphers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_106:
@@ -10059,7 +10059,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_106
-    pretty_name: 'CKV_K8S_106: Ensure that the --terminated-pod-gc-threshold argument
+    pretty_name: 'Ensure that the --terminated-pod-gc-threshold argument
       is set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_107:
@@ -10071,7 +10071,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_107
-    pretty_name: 'CKV_K8S_107: Ensure that the --profiling argument is set to false'
+    pretty_name: 'Ensure that the --profiling argument is set to false'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_108:
     categories:
@@ -10082,7 +10082,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_108
-    pretty_name: 'CKV_K8S_108: Ensure that the --use-service-account-credentials argument
+    pretty_name: 'Ensure that the --use-service-account-credentials argument
       is set to true'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_11:
@@ -10093,7 +10093,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_11
-    pretty_name: 'CKV_K8S_11: CPU Limits should be set'
+    pretty_name: 'CPU Limits should be set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_110:
     categories:
@@ -10104,7 +10104,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_110
-    pretty_name: 'CKV_K8S_110: Ensure that the --service-account-private-key-file
+    pretty_name: 'Ensure that the --service-account-private-key-file
       argument is set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_111:
@@ -10116,7 +10116,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_111
-    pretty_name: 'CKV_K8S_111: Ensure that the --root-ca-file argument is set as appropriate'
+    pretty_name: 'Ensure that the --root-ca-file argument is set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_112:
     categories:
@@ -10127,7 +10127,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_112
-    pretty_name: 'CKV_K8S_112: Ensure that the RotateKubeletServerCertificate argument
+    pretty_name: 'Ensure that the RotateKubeletServerCertificate argument
       is set to true'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_113:
@@ -10139,7 +10139,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_113
-    pretty_name: 'CKV_K8S_113: Ensure that the --bind-address argument is set to 127.0.0.1'
+    pretty_name: 'Ensure that the --bind-address argument is set to 127.0.0.1'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_114:
     categories:
@@ -10150,7 +10150,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_114
-    pretty_name: 'CKV_K8S_114: Ensure that the --profiling argument is set to false'
+    pretty_name: 'Ensure that the --profiling argument is set to false'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_115:
     categories:
@@ -10161,7 +10161,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_115
-    pretty_name: 'CKV_K8S_115: Ensure that the --bind-address argument is set to 127.0.0.1'
+    pretty_name: 'Ensure that the --bind-address argument is set to 127.0.0.1'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_116:
     categories:
@@ -10172,7 +10172,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_116
-    pretty_name: 'CKV_K8S_116: Ensure that the --cert-file and --key-file arguments
+    pretty_name: 'Ensure that the --cert-file and --key-file arguments
       are set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_117:
@@ -10184,7 +10184,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_117
-    pretty_name: 'CKV_K8S_117: Ensure that the --client-cert-auth argument is set
+    pretty_name: 'Ensure that the --client-cert-auth argument is set
       to true'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_118:
@@ -10196,7 +10196,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_118
-    pretty_name: 'CKV_K8S_118: Ensure that the --auto-tls argument is not set to true'
+    pretty_name: 'Ensure that the --auto-tls argument is not set to true'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_119:
     categories:
@@ -10207,7 +10207,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_119
-    pretty_name: 'CKV_K8S_119: Ensure that the --peer-cert-file and --peer-key-file
+    pretty_name: 'Ensure that the --peer-cert-file and --peer-key-file
       arguments are set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_12:
@@ -10218,7 +10218,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_12
-    pretty_name: 'CKV_K8S_12: Memory Limits should be set'
+    pretty_name: 'Memory Limits should be set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_121:
     categories:
@@ -10229,7 +10229,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_121
-    pretty_name: 'CKV_K8S_121: Ensure that the --peer-client-cert-auth argument is
+    pretty_name: 'Ensure that the --peer-client-cert-auth argument is
       set to true'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_13:
@@ -10240,7 +10240,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_13
-    pretty_name: 'CKV_K8S_13: Memory requests should be set'
+    pretty_name: 'Memory requests should be set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_138:
     categories:
@@ -10251,7 +10251,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_138
-    pretty_name: 'CKV_K8S_138: Ensure that the --anonymous-auth argument is set to
+    pretty_name: 'Ensure that the --anonymous-auth argument is set to
       false'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_139:
@@ -10263,7 +10263,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_139
-    pretty_name: 'CKV_K8S_139: Ensure that the --authorization-mode argument is not
+    pretty_name: 'Ensure that the --authorization-mode argument is not
       set to AlwaysAllow'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_14:
@@ -10274,7 +10274,7 @@ rules:
     description: Check for weak Kubernetes configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_K8S_14
-    pretty_name: 'CKV_K8S_14: Image Tag should be fixed - not latest or blank'
+    pretty_name: 'Image Tag should be fixed - not latest or blank'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_140:
     categories:
@@ -10285,7 +10285,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_140
-    pretty_name: 'CKV_K8S_140: Ensure that the --client-ca-file argument is set as
+    pretty_name: 'Ensure that the --client-ca-file argument is set as
       appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_141:
@@ -10297,7 +10297,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_141
-    pretty_name: 'CKV_K8S_141: Ensure that the --read-only-port argument is set to
+    pretty_name: 'Ensure that the --read-only-port argument is set to
       0'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_143:
@@ -10309,7 +10309,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_143
-    pretty_name: 'CKV_K8S_143: Ensure that the --streaming-connection-idle-timeout
+    pretty_name: 'Ensure that the --streaming-connection-idle-timeout
       argument is not set to 0'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_144:
@@ -10321,7 +10321,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_144
-    pretty_name: 'CKV_K8S_144: Ensure that the --protect-kernel-defaults argument
+    pretty_name: 'Ensure that the --protect-kernel-defaults argument
       is set to true'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_145:
@@ -10333,7 +10333,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_145
-    pretty_name: 'CKV_K8S_145: Ensure that the --make-iptables-util-chains argument
+    pretty_name: 'Ensure that the --make-iptables-util-chains argument
       is set to true'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_146:
@@ -10345,7 +10345,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_146
-    pretty_name: 'CKV_K8S_146: Ensure that the --hostname-override argument is not
+    pretty_name: 'Ensure that the --hostname-override argument is not
       set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_147:
@@ -10357,7 +10357,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_147
-    pretty_name: 'CKV_K8S_147: Ensure that the --event-qps argument is set to 0 or
+    pretty_name: 'Ensure that the --event-qps argument is set to 0 or
       a level which ensures appropriate event capture'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_148:
@@ -10369,7 +10369,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_148
-    pretty_name: 'CKV_K8S_148: Ensure that the --tls-cert-file and --tls-private-key-file
+    pretty_name: 'Ensure that the --tls-cert-file and --tls-private-key-file
       arguments are set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_149:
@@ -10381,7 +10381,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_149
-    pretty_name: 'CKV_K8S_149: Ensure that the --rotate-certificates argument is not
+    pretty_name: 'Ensure that the --rotate-certificates argument is not
       set to false'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_15:
@@ -10392,7 +10392,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_15
-    pretty_name: 'CKV_K8S_15: Image Pull Policy should be Always'
+    pretty_name: 'Image Pull Policy should be Always'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_151:
     categories:
@@ -10403,7 +10403,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_151
-    pretty_name: 'CKV_K8S_151: Ensure that the Kubelet only makes use of Strong Cryptographic
+    pretty_name: 'Ensure that the Kubelet only makes use of Strong Cryptographic
       Ciphers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_152:
@@ -10415,7 +10415,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_152
-    pretty_name: 'CKV_K8S_152: Prevent NGINX Ingress annotation snippets which contain
+    pretty_name: 'Prevent NGINX Ingress annotation snippets which contain
       LUA code execution. See CVE-2021-25742'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_153:
@@ -10427,7 +10427,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_153
-    pretty_name: 'CKV_K8S_153: Prevent All NGINX Ingress annotation snippets. See
+    pretty_name: 'Prevent All NGINX Ingress annotation snippets. See
       CVE-2021-25742'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_154:
@@ -10439,7 +10439,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_154
-    pretty_name: 'CKV_K8S_154: Prevent NGINX Ingress annotation snippets which contain
+    pretty_name: 'Prevent NGINX Ingress annotation snippets which contain
       alias statements See CVE-2021-25742'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_155:
@@ -10451,7 +10451,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV_K8S_155
-    pretty_name: 'CKV_K8S_155: Minimize ClusterRoles that grant control over validating
+    pretty_name: 'Minimize ClusterRoles that grant control over validating
       or mutating admission webhook configurations'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_156:
@@ -10463,7 +10463,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV_K8S_156
-    pretty_name: 'CKV_K8S_156: Minimize ClusterRoles that grant permissions to approve
+    pretty_name: 'Minimize ClusterRoles that grant permissions to approve
       CertificateSigningRequests'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_157:
@@ -10475,7 +10475,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV_K8S_157
-    pretty_name: 'CKV_K8S_157: Minimize Roles and ClusterRoles that grant permissions
+    pretty_name: 'Minimize Roles and ClusterRoles that grant permissions
       to bind RoleBindings or ClusterRoleBindings'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_158:
@@ -10487,7 +10487,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV_K8S_158
-    pretty_name: 'CKV_K8S_158: Minimize Roles and ClusterRoles that grant permissions
+    pretty_name: 'Minimize Roles and ClusterRoles that grant permissions
       to escalate Roles or ClusterRoles'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_16:
@@ -10499,7 +10499,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_16
-    pretty_name: 'CKV_K8S_16: Do not admit privileged containers'
+    pretty_name: 'Do not admit privileged containers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_17:
     categories:
@@ -10510,7 +10510,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_17
-    pretty_name: 'CKV_K8S_17: Do not admit containers wishing to share the host process
+    pretty_name: 'Do not admit containers wishing to share the host process
       ID namespace'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_18:
@@ -10522,7 +10522,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_18
-    pretty_name: 'CKV_K8S_18: Do not admit containers wishing to share the host IPC
+    pretty_name: 'Do not admit containers wishing to share the host IPC
       namespace'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_19:
@@ -10534,7 +10534,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_19
-    pretty_name: 'CKV_K8S_19: Do not admit containers wishing to share the host network
+    pretty_name: 'Do not admit containers wishing to share the host network
       namespace'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_2:
@@ -10546,7 +10546,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_2
-    pretty_name: 'CKV_K8S_2: Do not admit privileged containers'
+    pretty_name: 'Do not admit privileged containers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_20:
     categories:
@@ -10557,7 +10557,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_20
-    pretty_name: 'CKV_K8S_20: Containers should not run with allowPrivilegeEscalation'
+    pretty_name: 'Containers should not run with allowPrivilegeEscalation'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_21:
     categories:
@@ -10567,7 +10567,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_21
-    pretty_name: 'CKV_K8S_21: The default namespace should not be used'
+    pretty_name: 'The default namespace should not be used'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_22:
     categories:
@@ -10576,7 +10576,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_22
-    pretty_name: 'CKV_K8S_22: Use read-only filesystem for containers where possible'
+    pretty_name: 'Use read-only filesystem for containers where possible'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_23:
     categories:
@@ -10586,7 +10586,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_23
-    pretty_name: 'CKV_K8S_23: Minimize the admission of root containers'
+    pretty_name: 'Minimize the admission of root containers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_24:
     categories:
@@ -10597,7 +10597,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_24
-    pretty_name: 'CKV_K8S_24: Do not allow containers with added capability'
+    pretty_name: 'Do not allow containers with added capability'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_25:
     categories:
@@ -10608,7 +10608,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_25
-    pretty_name: 'CKV_K8S_25: Minimize the admission of containers with added capability'
+    pretty_name: 'Minimize the admission of containers with added capability'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_26:
     categories:
@@ -10619,7 +10619,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_26
-    pretty_name: 'CKV_K8S_26: Do not specify hostPort unless absolutely necessary'
+    pretty_name: 'Do not specify hostPort unless absolutely necessary'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_27:
     categories:
@@ -10630,7 +10630,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_27
-    pretty_name: 'CKV_K8S_27: Do not expose the docker daemon socket to containers'
+    pretty_name: 'Do not expose the docker daemon socket to containers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_28:
     categories:
@@ -10641,7 +10641,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_28
-    pretty_name: 'CKV_K8S_28: Minimize the admission of containers with the NET_RAW
+    pretty_name: 'Minimize the admission of containers with the NET_RAW
       capability'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_29:
@@ -10652,7 +10652,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_29
-    pretty_name: 'CKV_K8S_29: Apply security context to your pods and containers'
+    pretty_name: 'Apply security context to your pods and containers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_3:
     categories:
@@ -10663,7 +10663,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_3
-    pretty_name: 'CKV_K8S_3: Do not admit containers wishing to share the host IPC
+    pretty_name: 'Do not admit containers wishing to share the host IPC
       namespace'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_30:
@@ -10674,7 +10674,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_30
-    pretty_name: 'CKV_K8S_30: Apply security context to your pods and containers'
+    pretty_name: 'Apply security context to your pods and containers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_31:
     categories:
@@ -10684,7 +10684,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_31
-    pretty_name: 'CKV_K8S_31: Ensure that the seccomp profile is set to docker/default
+    pretty_name: 'Ensure that the seccomp profile is set to docker/default
       or runtime/default'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_32:
@@ -10695,7 +10695,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_32
-    pretty_name: 'CKV_K8S_32: Ensure default seccomp profile set to docker/default
+    pretty_name: 'Ensure default seccomp profile set to docker/default
       or runtime/default'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_33:
@@ -10707,7 +10707,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_33
-    pretty_name: 'CKV_K8S_33: Ensure the Kubernetes dashboard is not deployed'
+    pretty_name: 'Ensure the Kubernetes dashboard is not deployed'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_34:
     categories:
@@ -10718,7 +10718,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_34
-    pretty_name: 'CKV_K8S_34: Ensure that Tiller (Helm v2) is not deployed'
+    pretty_name: 'Ensure that Tiller (Helm v2) is not deployed'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_35:
     categories:
@@ -10727,7 +10727,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_35
-    pretty_name: 'CKV_K8S_35: Prefer using secrets as files over secrets as environment
+    pretty_name: 'Prefer using secrets as files over secrets as environment
       variables'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_36:
@@ -10739,7 +10739,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_36
-    pretty_name: 'CKV_K8S_36: Minimise the admission of containers with capabilities
+    pretty_name: 'Minimise the admission of containers with capabilities
       assigned'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_37:
@@ -10751,7 +10751,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_37
-    pretty_name: 'CKV_K8S_37: Minimise the admission of containers with capabilities
+    pretty_name: 'Minimise the admission of containers with capabilities
       assigned'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_38:
@@ -10762,7 +10762,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_38
-    pretty_name: 'CKV_K8S_38: Ensure that Service Account Tokens are only mounted
+    pretty_name: 'Ensure that Service Account Tokens are only mounted
       where necessary'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_39:
@@ -10774,7 +10774,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_39
-    pretty_name: 'CKV_K8S_39: Do not use the CAP_SYS_ADMIN linux capability'
+    pretty_name: 'Do not use the CAP_SYS_ADMIN linux capability'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_4:
     categories:
@@ -10785,7 +10785,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_4
-    pretty_name: 'CKV_K8S_4: Do not admit containers wishing to share the host network
+    pretty_name: 'Do not admit containers wishing to share the host network
       namespace'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_40:
@@ -10796,7 +10796,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_40
-    pretty_name: 'CKV_K8S_40: Containers should run as a high UID to avoid host conflict'
+    pretty_name: 'Containers should run as a high UID to avoid host conflict'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_41:
     categories:
@@ -10807,7 +10807,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV_K8S_41
-    pretty_name: 'CKV_K8S_41: Ensure that default service accounts are not actively
+    pretty_name: 'Ensure that default service accounts are not actively
       used'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_42:
@@ -10819,7 +10819,7 @@ rules:
     description: Check for weak Kubernetes permissions.
     group: cloud-insecure-iam
     name: CKV_K8S_42
-    pretty_name: 'CKV_K8S_42: Ensure that default service accounts are not actively
+    pretty_name: 'Ensure that default service accounts are not actively
       used'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_43:
@@ -10830,7 +10830,7 @@ rules:
     description: Check for weak Kubernetes configurations.
     group: supply-chain-cicd-weak-configuration
     name: CKV_K8S_43
-    pretty_name: 'CKV_K8S_43: Image should use digest'
+    pretty_name: 'Image should use digest'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_44:
     categories:
@@ -10841,7 +10841,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_44
-    pretty_name: 'CKV_K8S_44: Ensure that the Tiller Service (Helm v2) is deleted'
+    pretty_name: 'Ensure that the Tiller Service (Helm v2) is deleted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_45:
     categories:
@@ -10852,7 +10852,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_45
-    pretty_name: 'CKV_K8S_45: Ensure the Tiller Deployment (Helm V2) is not accessible
+    pretty_name: 'Ensure the Tiller Deployment (Helm V2) is not accessible
       from within the cluster'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_49:
@@ -10864,7 +10864,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_49
-    pretty_name: 'CKV_K8S_49: Minimize wildcard use in Roles and ClusterRoles'
+    pretty_name: 'Minimize wildcard use in Roles and ClusterRoles'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_5:
     categories:
@@ -10875,7 +10875,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_5
-    pretty_name: 'CKV_K8S_5: Containers should not run with allowPrivilegeEscalation'
+    pretty_name: 'Containers should not run with allowPrivilegeEscalation'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_6:
     categories:
@@ -10886,7 +10886,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_6
-    pretty_name: 'CKV_K8S_6: Do not admit root containers'
+    pretty_name: 'Do not admit root containers'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_68:
     categories:
@@ -10897,7 +10897,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_68
-    pretty_name: 'CKV_K8S_68: Ensure that the --anonymous-auth argument is set to
+    pretty_name: 'Ensure that the --anonymous-auth argument is set to
       false'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_69:
@@ -10909,7 +10909,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_69
-    pretty_name: 'CKV_K8S_69: Ensure that the --basic-auth-file argument is not set'
+    pretty_name: 'Ensure that the --basic-auth-file argument is not set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_7:
     categories:
@@ -10920,7 +10920,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_7
-    pretty_name: 'CKV_K8S_7: Do not admit containers with the NET_RAW capability'
+    pretty_name: 'Do not admit containers with the NET_RAW capability'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_70:
     categories:
@@ -10931,7 +10931,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_70
-    pretty_name: 'CKV_K8S_70: Ensure that the --token-auth-file argument is not set'
+    pretty_name: 'Ensure that the --token-auth-file argument is not set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_71:
     categories:
@@ -10942,7 +10942,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_71
-    pretty_name: 'CKV_K8S_71: Ensure that the --kubelet-https argument is set to true'
+    pretty_name: 'Ensure that the --kubelet-https argument is set to true'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_72:
     categories:
@@ -10953,7 +10953,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_72
-    pretty_name: 'CKV_K8S_72: Ensure that the --kubelet-client-certificate and --kubelet-client-key
+    pretty_name: 'Ensure that the --kubelet-client-certificate and --kubelet-client-key
       arguments are set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_73:
@@ -10965,7 +10965,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_73
-    pretty_name: 'CKV_K8S_73: Ensure that the --kubelet-certificate-authority argument
+    pretty_name: 'Ensure that the --kubelet-certificate-authority argument
       is set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_74:
@@ -10977,7 +10977,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_74
-    pretty_name: 'CKV_K8S_74: Ensure that the --authorization-mode argument is not
+    pretty_name: 'Ensure that the --authorization-mode argument is not
       set to AlwaysAllow'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_75:
@@ -10989,7 +10989,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_75
-    pretty_name: 'CKV_K8S_75: Ensure that the --authorization-mode argument includes
+    pretty_name: 'Ensure that the --authorization-mode argument includes
       Node'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_77:
@@ -11001,7 +11001,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_77
-    pretty_name: 'CKV_K8S_77: Ensure that the --authorization-mode argument includes
+    pretty_name: 'Ensure that the --authorization-mode argument includes
       RBAC'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_78:
@@ -11011,7 +11011,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_78
-    pretty_name: 'CKV_K8S_78: Ensure that the admission control plugin EventRateLimit
+    pretty_name: 'Ensure that the admission control plugin EventRateLimit
       is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_79:
@@ -11023,7 +11023,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_79
-    pretty_name: 'CKV_K8S_79: Ensure that the admission control plugin AlwaysAdmit
+    pretty_name: 'Ensure that the admission control plugin AlwaysAdmit
       is not set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_8:
@@ -11034,7 +11034,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_8
-    pretty_name: 'CKV_K8S_8: Liveness Probe Should be Configured'
+    pretty_name: 'Liveness Probe Should be Configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_80:
     categories:
@@ -11044,7 +11044,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_80
-    pretty_name: 'CKV_K8S_80: Ensure that the admission control plugin AlwaysPullImages
+    pretty_name: 'Ensure that the admission control plugin AlwaysPullImages
       is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_81:
@@ -11055,7 +11055,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_81
-    pretty_name: 'CKV_K8S_81: Ensure that the admission control plugin SecurityContextDeny
+    pretty_name: 'Ensure that the admission control plugin SecurityContextDeny
       is set if PodSecurityPolicy is not used'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_82:
@@ -11066,7 +11066,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_82
-    pretty_name: 'CKV_K8S_82: Ensure that the admission control plugin ServiceAccount
+    pretty_name: 'Ensure that the admission control plugin ServiceAccount
       is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_83:
@@ -11077,7 +11077,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_83
-    pretty_name: 'CKV_K8S_83: Ensure that the admission control plugin NamespaceLifecycle
+    pretty_name: 'Ensure that the admission control plugin NamespaceLifecycle
       is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_84:
@@ -11088,7 +11088,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_84
-    pretty_name: 'CKV_K8S_84: Ensure that the admission control plugin PodSecurityPolicy
+    pretty_name: 'Ensure that the admission control plugin PodSecurityPolicy
       is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_85:
@@ -11099,7 +11099,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_85
-    pretty_name: 'CKV_K8S_85: Ensure that the admission control plugin NodeRestriction
+    pretty_name: 'Ensure that the admission control plugin NodeRestriction
       is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_86:
@@ -11111,7 +11111,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_86
-    pretty_name: 'CKV_K8S_86: Ensure that the --insecure-bind-address argument is
+    pretty_name: 'Ensure that the --insecure-bind-address argument is
       not set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_88:
@@ -11123,7 +11123,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_88
-    pretty_name: 'CKV_K8S_88: Ensure that the --insecure-port argument is set to 0'
+    pretty_name: 'Ensure that the --insecure-port argument is set to 0'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_89:
     categories:
@@ -11134,7 +11134,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_89
-    pretty_name: 'CKV_K8S_89: Ensure that the --secure-port argument is not set to
+    pretty_name: 'Ensure that the --secure-port argument is not set to
       0'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_9:
@@ -11145,7 +11145,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_9
-    pretty_name: 'CKV_K8S_9: Readiness Probe Should be Configured'
+    pretty_name: 'Readiness Probe Should be Configured'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_90:
     categories:
@@ -11156,7 +11156,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_90
-    pretty_name: 'CKV_K8S_90: Ensure that the --profiling argument is set to false'
+    pretty_name: 'Ensure that the --profiling argument is set to false'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_91:
     categories:
@@ -11167,7 +11167,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_91
-    pretty_name: 'CKV_K8S_91: Ensure that the --audit-log-path argument is set'
+    pretty_name: 'Ensure that the --audit-log-path argument is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_92:
     categories:
@@ -11178,7 +11178,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_92
-    pretty_name: 'CKV_K8S_92: Ensure that the --audit-log-maxage argument is set to
+    pretty_name: 'Ensure that the --audit-log-maxage argument is set to
       30 or as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_93:
@@ -11190,7 +11190,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_93
-    pretty_name: 'CKV_K8S_93: Ensure that the --audit-log-maxbackup argument is set
+    pretty_name: 'Ensure that the --audit-log-maxbackup argument is set
       to 10 or as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_94:
@@ -11202,7 +11202,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_94
-    pretty_name: 'CKV_K8S_94: Ensure that the --audit-log-maxsize argument is set
+    pretty_name: 'Ensure that the --audit-log-maxsize argument is set
       to 100 or as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_95:
@@ -11214,7 +11214,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_95
-    pretty_name: 'CKV_K8S_95: Ensure that the --request-timeout argument is set as
+    pretty_name: 'Ensure that the --request-timeout argument is set as
       appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_96:
@@ -11226,7 +11226,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_96
-    pretty_name: 'CKV_K8S_96: Ensure that the --service-account-lookup argument is
+    pretty_name: 'Ensure that the --service-account-lookup argument is
       set to true'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_97:
@@ -11238,7 +11238,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_97
-    pretty_name: 'CKV_K8S_97: Ensure that the --service-account-key-file argument
+    pretty_name: 'Ensure that the --service-account-key-file argument
       is set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_K8S_99:
@@ -11250,7 +11250,7 @@ rules:
     description: Check for misconfigurations in Kubernetes resources.
     group: cloud-weak-configuration
     name: CKV_K8S_99
-    pretty_name: 'CKV_K8S_99: Ensure that the --etcd-certfile and --etcd-keyfile arguments
+    pretty_name: 'Ensure that the --etcd-certfile and --etcd-keyfile arguments
       are set as appropriate'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_LIN_1:
@@ -11262,7 +11262,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_LIN_1
-    pretty_name: 'CKV_LIN_1: Ensure no hard coded Linode tokens exist in provider'
+    pretty_name: 'Ensure no hard coded Linode tokens exist in provider'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_LIN_2:
     categories:
@@ -11273,7 +11273,7 @@ rules:
     description: Check for misconfigurations in Linode resources.
     group: cloud-weak-configuration
     name: CKV_LIN_2
-    pretty_name: 'CKV_LIN_2: Ensure SSH key set in authorized_keys'
+    pretty_name: 'Ensure SSH key set in authorized_keys'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_LIN_3:
     categories:
@@ -11284,7 +11284,7 @@ rules:
     description: Check for misconfigurations in Linode resources.
     group: cloud-weak-configuration
     name: CKV_LIN_3
-    pretty_name: 'CKV_LIN_3: Ensure email is set'
+    pretty_name: 'Ensure email is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_LIN_4:
     categories:
@@ -11295,7 +11295,7 @@ rules:
     description: Check for misconfigurations in Linode resources.
     group: cloud-weak-configuration
     name: CKV_LIN_4
-    pretty_name: 'CKV_LIN_4: Ensure username is set'
+    pretty_name: 'Ensure username is set'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_LIN_5:
     categories:
@@ -11306,7 +11306,7 @@ rules:
     description: Check for misconfigurations in Linode resources.
     group: cloud-weak-configuration
     name: CKV_LIN_5
-    pretty_name: 'CKV_LIN_5: Ensure Inbound Firewall Policy is not set to ACCEPT'
+    pretty_name: 'Ensure Inbound Firewall Policy is not set to ACCEPT'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_LIN_6:
     categories:
@@ -11317,7 +11317,7 @@ rules:
     description: Check for misconfigurations in Linode resources.
     group: cloud-weak-configuration
     name: CKV_LIN_6
-    pretty_name: 'CKV_LIN_6: Ensure Outbound Firewall Policy is not set to ACCEPT'
+    pretty_name: 'Ensure Outbound Firewall Policy is not set to ACCEPT'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_1:
     categories:
@@ -11327,7 +11327,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_1
-    pretty_name: 'CKV_NCP_1: Ensure HTTP HTTPS Target group defines Healthcheck'
+    pretty_name: 'Ensure HTTP HTTPS Target group defines Healthcheck'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_10:
     categories:
@@ -11338,7 +11338,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_10
-    pretty_name: 'CKV_NCP_10: Ensure no NACL allow inbound from 0.0.0.0:0 to port
+    pretty_name: 'Ensure no NACL allow inbound from 0.0.0.0:0 to port
       22'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_11:
@@ -11350,7 +11350,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_11
-    pretty_name: 'CKV_NCP_11: Ensure no NACL allow inbound from 0.0.0.0:0 to port
+    pretty_name: 'Ensure no NACL allow inbound from 0.0.0.0:0 to port
       3389'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_12:
@@ -11362,7 +11362,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_12
-    pretty_name: 'CKV_NCP_12: An inbound Network ACL rule should not allow ALL ports.'
+    pretty_name: 'An inbound Network ACL rule should not allow ALL ports.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_13:
     categories:
@@ -11373,7 +11373,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_13
-    pretty_name: 'CKV_NCP_13: Ensure LB Listener uses only secure protocols'
+    pretty_name: 'Ensure LB Listener uses only secure protocols'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_14:
     categories:
@@ -11383,7 +11383,7 @@ rules:
     description: Check for unencrypted Ncloud resources.
     group: cloud-unencrypted-resources
     name: CKV_NCP_14
-    pretty_name: 'CKV_NCP_14: Ensure NAS is securely encrypted'
+    pretty_name: 'Ensure NAS is securely encrypted'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_15:
     categories:
@@ -11394,7 +11394,7 @@ rules:
     description: Check for unencrypted Ncloud resources.
     group: cloud-unencrypted-resources
     name: CKV_NCP_15
-    pretty_name: 'CKV_NCP_15: Ensure Load Balancer Target Group is not using HTTP'
+    pretty_name: 'Ensure Load Balancer Target Group is not using HTTP'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_16:
     categories:
@@ -11405,7 +11405,7 @@ rules:
     description: Check for publicly accessible Ncloud resources.
     group: cloud-resources-public-access
     name: CKV_NCP_16
-    pretty_name: 'CKV_NCP_16: Ensure Load Balancer isn''t exposed to the internet'
+    pretty_name: 'Ensure Load Balancer isn''t exposed to the internet'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_19:
     categories:
@@ -11416,7 +11416,7 @@ rules:
     description: Check for publicly accessible Ncloud resources.
     group: cloud-resources-public-access
     name: CKV_NCP_19
-    pretty_name: 'CKV_NCP_19: Ensure Naver Kubernetes Service public endpoint disabled'
+    pretty_name: 'Ensure Naver Kubernetes Service public endpoint disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_2:
     categories:
@@ -11427,7 +11427,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_2
-    pretty_name: 'CKV_NCP_2: Ensure every access control groups rule has a description'
+    pretty_name: 'Ensure every access control groups rule has a description'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_20:
     categories:
@@ -11438,7 +11438,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_20
-    pretty_name: 'CKV_NCP_20: Ensure Routing Table associated with Web tier subnet
+    pretty_name: 'Ensure Routing Table associated with Web tier subnet
       have the default route (0.0.0.0/0) defined to allow connectivity'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_22:
@@ -11450,7 +11450,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_22
-    pretty_name: 'CKV_NCP_22: Ensure NKS control plane logging enabled for all log
+    pretty_name: 'Ensure NKS control plane logging enabled for all log
       types'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_23:
@@ -11462,7 +11462,7 @@ rules:
     description: Check for publicly accessible Ncloud resources.
     group: cloud-resources-public-access
     name: CKV_NCP_23
-    pretty_name: 'CKV_NCP_23: Ensure Server instance should not have public IP.'
+    pretty_name: 'Ensure Server instance should not have public IP.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_24:
     categories:
@@ -11473,7 +11473,7 @@ rules:
     description: Check for unencrypted Ncloud resources.
     group: cloud-unencrypted-resources
     name: CKV_NCP_24
-    pretty_name: 'CKV_NCP_24: Ensure Load Balancer Listener Using HTTPS'
+    pretty_name: 'Ensure Load Balancer Listener Using HTTPS'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_25:
     categories:
@@ -11484,7 +11484,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_25
-    pretty_name: 'CKV_NCP_25: Ensure no access control groups allow inbound from 0.0.0.0:0
+    pretty_name: 'Ensure no access control groups allow inbound from 0.0.0.0:0
       to port 80'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_3:
@@ -11495,7 +11495,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_3
-    pretty_name: 'CKV_NCP_3: Ensure no security group rules allow outbound traffic
+    pretty_name: 'Ensure no security group rules allow outbound traffic
       to 0.0.0.0/0'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_4:
@@ -11507,7 +11507,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_4
-    pretty_name: 'CKV_NCP_4: Ensure no access control groups allow inbound from 0.0.0.0:0
+    pretty_name: 'Ensure no access control groups allow inbound from 0.0.0.0:0
       to port 22'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_5:
@@ -11519,7 +11519,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_5
-    pretty_name: 'CKV_NCP_5: Ensure no access control groups allow inbound from 0.0.0.0:0
+    pretty_name: 'Ensure no access control groups allow inbound from 0.0.0.0:0
       to port 3389'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_6:
@@ -11531,7 +11531,7 @@ rules:
     description: Check for unencrypted Ncloud resources.
     group: cloud-unencrypted-resources
     name: CKV_NCP_6
-    pretty_name: 'CKV_NCP_6: Ensure Server instance is encrypted.'
+    pretty_name: 'Ensure Server instance is encrypted.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_7:
     categories:
@@ -11541,7 +11541,7 @@ rules:
     description: Check for unencrypted Ncloud resources.
     group: cloud-unencrypted-resources
     name: CKV_NCP_7
-    pretty_name: 'CKV_NCP_7: Ensure Basic Block storage is encrypted.'
+    pretty_name: 'Ensure Basic Block storage is encrypted.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_8:
     categories:
@@ -11552,7 +11552,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_8
-    pretty_name: 'CKV_NCP_8: Ensure no NACL allow inbound from 0.0.0.0:0 to port 20'
+    pretty_name: 'Ensure no NACL allow inbound from 0.0.0.0:0 to port 20'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_NCP_9:
     categories:
@@ -11563,7 +11563,7 @@ rules:
     description: Check for misconfigurations in Ncloud resources.
     group: cloud-weak-configuration
     name: CKV_NCP_9
-    pretty_name: 'CKV_NCP_9: Ensure no NACL allow inbound from 0.0.0.0:0 to port 21'
+    pretty_name: 'Ensure no NACL allow inbound from 0.0.0.0:0 to port 21'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_1:
     categories:
@@ -11574,7 +11574,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_OCI_1
-    pretty_name: 'CKV_OCI_1: Ensure no hard coded OCI private key in provider'
+    pretty_name: 'Ensure no hard coded OCI private key in provider'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_10:
     categories:
@@ -11585,7 +11585,7 @@ rules:
     description: Check for publicly accessible Oracle Cloud Infrastructure resources.
     group: cloud-resources-public-access
     name: CKV_OCI_10
-    pretty_name: 'CKV_OCI_10: Ensure OCI Object Storage is not Public'
+    pretty_name: 'Ensure OCI Object Storage is not Public'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_11:
     categories:
@@ -11596,7 +11596,7 @@ rules:
     description: Check for weak Oracle Cloud Infrastructure permissions.
     group: cloud-insecure-iam
     name: CKV_OCI_11
-    pretty_name: 'CKV_OCI_11: OCI IAM password policy - must contain lower case'
+    pretty_name: 'OCI IAM password policy - must contain lower case'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_12:
     categories:
@@ -11607,7 +11607,7 @@ rules:
     description: Check for weak Oracle Cloud Infrastructure permissions.
     group: cloud-insecure-iam
     name: CKV_OCI_12
-    pretty_name: 'CKV_OCI_12: OCI IAM password policy - must contain Numeric characters'
+    pretty_name: 'OCI IAM password policy - must contain Numeric characters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_13:
     categories:
@@ -11618,7 +11618,7 @@ rules:
     description: Check for weak Oracle Cloud Infrastructure permissions.
     group: cloud-insecure-iam
     name: CKV_OCI_13
-    pretty_name: 'CKV_OCI_13: OCI IAM password policy - must contain Special characters'
+    pretty_name: 'OCI IAM password policy - must contain Special characters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_14:
     categories:
@@ -11629,7 +11629,7 @@ rules:
     description: Check for weak Oracle Cloud Infrastructure permissions.
     group: cloud-insecure-iam
     name: CKV_OCI_14
-    pretty_name: 'CKV_OCI_14: OCI IAM password policy - must contain Uppercase characters'
+    pretty_name: 'OCI IAM password policy - must contain Uppercase characters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_15:
     categories:
@@ -11638,7 +11638,7 @@ rules:
     description: Check for unencrypted Oracle Cloud Infrastructure resources.
     group: cloud-unencrypted-resources
     name: CKV_OCI_15
-    pretty_name: 'CKV_OCI_15: Ensure OCI File System is Encrypted with a customer
+    pretty_name: 'Ensure OCI File System is Encrypted with a customer
       Managed Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_16:
@@ -11650,7 +11650,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_16
-    pretty_name: 'CKV_OCI_16: Ensure VCN has an inbound security list'
+    pretty_name: 'Ensure VCN has an inbound security list'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_17:
     categories:
@@ -11661,7 +11661,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_17
-    pretty_name: 'CKV_OCI_17: Ensure VCN inbound security lists are stateless'
+    pretty_name: 'Ensure VCN inbound security lists are stateless'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_18:
     categories:
@@ -11672,7 +11672,7 @@ rules:
     description: Check for weak Oracle Cloud Infrastructure permissions.
     group: cloud-insecure-iam
     name: CKV_OCI_18
-    pretty_name: 'CKV_OCI_18: OCI IAM password policy for local (non-federated) users
+    pretty_name: 'OCI IAM password policy for local (non-federated) users
       has a minimum length of 14 characters'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_19:
@@ -11684,7 +11684,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_19
-    pretty_name: 'CKV_OCI_19: Ensure no security list allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security list allow ingress from 0.0.0.0:0
       to port 22.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_2:
@@ -11695,7 +11695,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_2
-    pretty_name: 'CKV_OCI_2: Ensure OCI Block Storage Block Volume has backup enabled'
+    pretty_name: 'Ensure OCI Block Storage Block Volume has backup enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_20:
     categories:
@@ -11706,7 +11706,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_20
-    pretty_name: 'CKV_OCI_20: Ensure no security list allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security list allow ingress from 0.0.0.0:0
       to port 3389.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_21:
@@ -11718,7 +11718,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_21
-    pretty_name: 'CKV_OCI_21: Ensure security group has stateless ingress security
+    pretty_name: 'Ensure security group has stateless ingress security
       rules'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_22:
@@ -11730,7 +11730,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_22
-    pretty_name: 'CKV_OCI_22: Ensure no security groups rules allow ingress from 0.0.0.0/0
+    pretty_name: 'Ensure no security groups rules allow ingress from 0.0.0.0/0
       to port 22'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_3:
@@ -11740,7 +11740,7 @@ rules:
     description: Check for unencrypted Oracle Cloud Infrastructure resources.
     group: cloud-unencrypted-resources
     name: CKV_OCI_3
-    pretty_name: 'CKV_OCI_3: OCI Block Storage Block Volumes are not encrypted with
+    pretty_name: 'OCI Block Storage Block Volumes are not encrypted with
       a Customer Managed Key (CMK)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_4:
@@ -11750,7 +11750,7 @@ rules:
     description: Check for unencrypted Oracle Cloud Infrastructure resources.
     group: cloud-unencrypted-resources
     name: CKV_OCI_4
-    pretty_name: 'CKV_OCI_4: Ensure OCI Compute Instance boot volume has in-transit
+    pretty_name: 'Ensure OCI Compute Instance boot volume has in-transit
       data encryption enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_5:
@@ -11762,7 +11762,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_5
-    pretty_name: 'CKV_OCI_5: Ensure OCI Compute Instance has Legacy MetaData service
+    pretty_name: 'Ensure OCI Compute Instance has Legacy MetaData service
       endpoint disabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_6:
@@ -11774,7 +11774,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_6
-    pretty_name: 'CKV_OCI_6: Ensure OCI Compute Instance has monitoring enabled'
+    pretty_name: 'Ensure OCI Compute Instance has monitoring enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_7:
     categories:
@@ -11783,7 +11783,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_7
-    pretty_name: 'CKV_OCI_7: Ensure OCI Object Storage bucket can emit object events'
+    pretty_name: 'Ensure OCI Object Storage bucket can emit object events'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_8:
     categories:
@@ -11792,7 +11792,7 @@ rules:
     description: Check for misconfigurations in Oracle Cloud Infrastructure resources.
     group: cloud-weak-configuration
     name: CKV_OCI_8
-    pretty_name: 'CKV_OCI_8: Ensure OCI Object Storage has versioning enabled'
+    pretty_name: 'Ensure OCI Object Storage has versioning enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OCI_9:
     categories:
@@ -11801,7 +11801,7 @@ rules:
     description: Check for unencrypted Oracle Cloud Infrastructure resources.
     group: cloud-unencrypted-resources
     name: CKV_OCI_9
-    pretty_name: 'CKV_OCI_9: Ensure OCI Object Storage is encrypted with Customer
+    pretty_name: 'Ensure OCI Object Storage is encrypted with Customer
       Managed Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_1:
@@ -11813,7 +11813,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_1
-    pretty_name: 'CKV_OPENAPI_1: Ensure that securityDefinitions is defined and not
+    pretty_name: 'Ensure that securityDefinitions is defined and not
       empty - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_10:
@@ -11825,7 +11825,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_10
-    pretty_name: 'CKV_OPENAPI_10: Ensure that operation object does not use ''password''
+    pretty_name: 'Ensure that operation object does not use ''password''
       flow in OAuth2 authentication - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_11:
@@ -11837,7 +11837,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_11
-    pretty_name: 'CKV_OPENAPI_11: Ensure that operation object does not use ''password''
+    pretty_name: 'Ensure that operation object does not use ''password''
       flow in OAuth2 authentication - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_12:
@@ -11849,7 +11849,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_12
-    pretty_name: 'CKV_OPENAPI_12: Ensure no security definition is using implicit
+    pretty_name: 'Ensure no security definition is using implicit
       flow on OAuth2, which is deprecated - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_13:
@@ -11861,7 +11861,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_13
-    pretty_name: 'CKV_OPENAPI_13: Ensure security definitions do not use basic auth
+    pretty_name: 'Ensure security definitions do not use basic auth
       - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_14:
@@ -11873,7 +11873,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_14
-    pretty_name: 'CKV_OPENAPI_14: Ensure that operation objects do not use ''implicit''
+    pretty_name: 'Ensure that operation objects do not use ''implicit''
       flow, which is deprecated - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_15:
@@ -11885,7 +11885,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_15
-    pretty_name: 'CKV_OPENAPI_15: Ensure that operation objects do not use basic auth
+    pretty_name: 'Ensure that operation objects do not use basic auth
       - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_16:
@@ -11897,7 +11897,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_16
-    pretty_name: 'CKV_OPENAPI_16: Ensure that operation objects have ''produces''
+    pretty_name: 'Ensure that operation objects have ''produces''
       field defined for GET operations - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_17:
@@ -11909,7 +11909,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_17
-    pretty_name: 'CKV_OPENAPI_17: Ensure that operation objects have ''consumes''
+    pretty_name: 'Ensure that operation objects have ''consumes''
       field defined for PUT, POST and PATCH operations - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_18:
@@ -11921,7 +11921,7 @@ rules:
     description: Check for unencrypted OpenAPI resources.
     group: cloud-unencrypted-resources
     name: CKV_OPENAPI_18
-    pretty_name: 'CKV_OPENAPI_18: Ensure that global schemes use ''https'' protocol
+    pretty_name: 'Ensure that global schemes use ''https'' protocol
       instead of ''http''- version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_19:
@@ -11933,7 +11933,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_19
-    pretty_name: 'CKV_OPENAPI_19: Ensure that global security scope is defined in
+    pretty_name: 'Ensure that global security scope is defined in
       securityDefinitions - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_2:
@@ -11945,7 +11945,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_2
-    pretty_name: 'CKV_OPENAPI_2: Ensure that if the security scheme is not of type
+    pretty_name: 'Ensure that if the security scheme is not of type
       ''oauth2'', the array value must be empty - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_3:
@@ -11957,7 +11957,7 @@ rules:
     description: Check for unencrypted OpenAPI resources.
     group: cloud-unencrypted-resources
     name: CKV_OPENAPI_3
-    pretty_name: 'CKV_OPENAPI_3: Ensure that security schemes don''t allow cleartext
+    pretty_name: 'Ensure that security schemes don''t allow cleartext
       credentials over unencrypted channel - version 3.x.y files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_4:
@@ -11969,7 +11969,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_4
-    pretty_name: 'CKV_OPENAPI_4: Ensure that the global security field has rules defined'
+    pretty_name: 'Ensure that the global security field has rules defined'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_5:
     categories:
@@ -11980,7 +11980,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_5
-    pretty_name: 'CKV_OPENAPI_5: Ensure that security operations is not empty.'
+    pretty_name: 'Ensure that security operations is not empty.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_6:
     categories:
@@ -11991,7 +11991,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_6
-    pretty_name: 'CKV_OPENAPI_6: Ensure that security requirement defined in securityDefinitions
+    pretty_name: 'Ensure that security requirement defined in securityDefinitions
       - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_7:
@@ -12003,7 +12003,7 @@ rules:
     description: Check for unencrypted OpenAPI resources.
     group: cloud-unencrypted-resources
     name: CKV_OPENAPI_7
-    pretty_name: 'CKV_OPENAPI_7: Ensure that the path scheme does not support unencrypted
+    pretty_name: 'Ensure that the path scheme does not support unencrypted
       HTTP connection - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_8:
@@ -12015,7 +12015,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_8
-    pretty_name: 'CKV_OPENAPI_8: Ensure that security is not using ''password'' flow
+    pretty_name: 'Ensure that security is not using ''password'' flow
       in OAuth2 authentication - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENAPI_9:
@@ -12027,7 +12027,7 @@ rules:
     description: Check for misconfigurations in OpenAPI resources.
     group: cloud-weak-configuration
     name: CKV_OPENAPI_9
-    pretty_name: 'CKV_OPENAPI_9: Ensure that security scopes of operations are defined
+    pretty_name: 'Ensure that security scopes of operations are defined
       in securityDefinitions - version 2.0 files'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENSTACK_1:
@@ -12039,7 +12039,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_OPENSTACK_1
-    pretty_name: 'CKV_OPENSTACK_1: Ensure no hard coded OpenStack password, token,
+    pretty_name: 'Ensure no hard coded OpenStack password, token,
       or application_credential_secret exists in provider'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENSTACK_2:
@@ -12051,7 +12051,7 @@ rules:
     description: Check for misconfigurations in OpenStack resources.
     group: cloud-weak-configuration
     name: CKV_OPENSTACK_2
-    pretty_name: 'CKV_OPENSTACK_2: Ensure no security groups allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security groups allow ingress from 0.0.0.0:0
       to port 22 (tcp / udp)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENSTACK_3:
@@ -12063,7 +12063,7 @@ rules:
     description: Check for misconfigurations in OpenStack resources.
     group: cloud-weak-configuration
     name: CKV_OPENSTACK_3
-    pretty_name: 'CKV_OPENSTACK_3: Ensure no security groups allow ingress from 0.0.0.0:0
+    pretty_name: 'Ensure no security groups allow ingress from 0.0.0.0:0
       to port 3389 (tcp / udp)'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENSTACK_4:
@@ -12075,7 +12075,7 @@ rules:
     description: Check for misconfigurations in OpenStack resources.
     group: cloud-weak-configuration
     name: CKV_OPENSTACK_4
-    pretty_name: 'CKV_OPENSTACK_4: Ensure that instance does not use basic credentials'
+    pretty_name: 'Ensure that instance does not use basic credentials'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_OPENSTACK_5:
     categories:
@@ -12086,7 +12086,7 @@ rules:
     description: Check for misconfigurations in OpenStack resources.
     group: cloud-weak-configuration
     name: CKV_OPENSTACK_5
-    pretty_name: 'CKV_OPENSTACK_5: Ensure firewall rule set a destination IP'
+    pretty_name: 'Ensure firewall rule set a destination IP'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_1:
     categories:
@@ -12097,7 +12097,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_PAN_1
-    pretty_name: 'CKV_PAN_1: Ensure no hard coded PAN-OS credentials exist in provider'
+    pretty_name: 'Ensure no hard coded PAN-OS credentials exist in provider'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_10:
     categories:
@@ -12108,7 +12108,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_10
-    pretty_name: 'CKV_PAN_10: Ensure logging at session end is enabled within security
+    pretty_name: 'Ensure logging at session end is enabled within security
       policies'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_11:
@@ -12120,7 +12120,7 @@ rules:
     description: Check for unencrypted PAN-OS resources.
     group: cloud-unencrypted-resources
     name: CKV_PAN_11
-    pretty_name: 'CKV_PAN_11: Ensure IPsec profiles do not specify use of insecure
+    pretty_name: 'Ensure IPsec profiles do not specify use of insecure
       encryption algorithms'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_12:
@@ -12132,7 +12132,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_12
-    pretty_name: 'CKV_PAN_12: Ensure IPsec profiles do not specify use of insecure
+    pretty_name: 'Ensure IPsec profiles do not specify use of insecure
       authentication algorithms'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_13:
@@ -12144,7 +12144,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_13
-    pretty_name: 'CKV_PAN_13: Ensure IPsec profiles do not specify use of insecure
+    pretty_name: 'Ensure IPsec profiles do not specify use of insecure
       protocols'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_14:
@@ -12156,7 +12156,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_14
-    pretty_name: 'CKV_PAN_14: Ensure a Zone Protection Profile is defined within Security
+    pretty_name: 'Ensure a Zone Protection Profile is defined within Security
       Zones'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_15:
@@ -12168,7 +12168,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_15
-    pretty_name: 'CKV_PAN_15: Ensure an Include ACL is defined for a Zone when User-ID
+    pretty_name: 'Ensure an Include ACL is defined for a Zone when User-ID
       is enabled'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_2:
@@ -12180,7 +12180,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_2
-    pretty_name: 'CKV_PAN_2: Ensure plain-text management HTTP is not enabled for
+    pretty_name: 'Ensure plain-text management HTTP is not enabled for
       an Interface Management Profile'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_3:
@@ -12192,7 +12192,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_3
-    pretty_name: 'CKV_PAN_3: Ensure plain-text management Telnet is not enabled for
+    pretty_name: 'Ensure plain-text management Telnet is not enabled for
       an Interface Management Profile'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_4:
@@ -12204,7 +12204,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_4
-    pretty_name: 'CKV_PAN_4: Ensure DSRI is not enabled within security policies'
+    pretty_name: 'Ensure DSRI is not enabled within security policies'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_5:
     categories:
@@ -12215,7 +12215,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_5
-    pretty_name: 'CKV_PAN_5: Ensure security rules do not have ''applications'' set
+    pretty_name: 'Ensure security rules do not have ''applications'' set
       to ''any'' '
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_6:
@@ -12227,7 +12227,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_6
-    pretty_name: 'CKV_PAN_6: Ensure security rules do not have ''services'' set to
+    pretty_name: 'Ensure security rules do not have ''services'' set to
       ''any'' '
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_7:
@@ -12239,7 +12239,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_7
-    pretty_name: 'CKV_PAN_7: Ensure security rules do not have ''source_addresses''
+    pretty_name: 'Ensure security rules do not have ''source_addresses''
       and ''destination_addresses'' both containing values of ''any'' '
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_8:
@@ -12251,7 +12251,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_8
-    pretty_name: 'CKV_PAN_8: Ensure description is populated within security policies'
+    pretty_name: 'Ensure description is populated within security policies'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_PAN_9:
     categories:
@@ -12260,7 +12260,7 @@ rules:
     description: Check for misconfigurations in PAN-OS resources.
     group: cloud-weak-configuration
     name: CKV_PAN_9
-    pretty_name: 'CKV_PAN_9: Ensure a Log Forwarding Profile is selected for each
+    pretty_name: 'Ensure a Log Forwarding Profile is selected for each
       security policy rule'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_1:
@@ -12272,7 +12272,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_1
-    pretty_name: 'CKV_SECRET_1: Artifactory Credentials'
+    pretty_name: 'Artifactory Credentials'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_10:
     categories:
@@ -12283,7 +12283,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_10
-    pretty_name: 'CKV_SECRET_10: Secret Keyword'
+    pretty_name: 'Secret Keyword'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_11:
     categories:
@@ -12294,7 +12294,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_11
-    pretty_name: 'CKV_SECRET_11: Mailchimp Access Key'
+    pretty_name: 'Mailchimp Access Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_12:
     categories:
@@ -12305,7 +12305,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_12
-    pretty_name: 'CKV_SECRET_12: NPM tokens'
+    pretty_name: 'NPM tokens'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_13:
     categories:
@@ -12316,7 +12316,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_13
-    pretty_name: 'CKV_SECRET_13: Private Key'
+    pretty_name: 'Private Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_14:
     categories:
@@ -12327,7 +12327,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_14
-    pretty_name: 'CKV_SECRET_14: Slack Token'
+    pretty_name: 'Slack Token'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_15:
     categories:
@@ -12338,7 +12338,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_15
-    pretty_name: 'CKV_SECRET_15: SoftLayer Credentials'
+    pretty_name: 'SoftLayer Credentials'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_16:
     categories:
@@ -12349,7 +12349,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_16
-    pretty_name: 'CKV_SECRET_16: Square OAuth Secret'
+    pretty_name: 'Square OAuth Secret'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_17:
     categories:
@@ -12360,7 +12360,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_17
-    pretty_name: 'CKV_SECRET_17: Stripe Access Key'
+    pretty_name: 'Stripe Access Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_18:
     categories:
@@ -12371,7 +12371,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_18
-    pretty_name: 'CKV_SECRET_18: Twilio API Key'
+    pretty_name: 'Twilio API Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_19:
     categories:
@@ -12380,7 +12380,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_19
-    pretty_name: 'CKV_SECRET_19: Hex High Entropy String'
+    pretty_name: 'Hex High Entropy String'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_2:
     categories:
@@ -12389,7 +12389,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_2
-    pretty_name: 'CKV_SECRET_2: AWS Access Key'
+    pretty_name: 'AWS Access Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_3:
     categories:
@@ -12400,7 +12400,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_3
-    pretty_name: 'CKV_SECRET_3: Azure Storage Account access key'
+    pretty_name: 'Azure Storage Account access key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_4:
     categories:
@@ -12411,7 +12411,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_4
-    pretty_name: 'CKV_SECRET_4: Basic Auth Credentials'
+    pretty_name: 'Basic Auth Credentials'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_5:
     categories:
@@ -12422,7 +12422,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_5
-    pretty_name: 'CKV_SECRET_5: Cloudant Credentials'
+    pretty_name: 'Cloudant Credentials'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_6:
     categories:
@@ -12431,7 +12431,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_6
-    pretty_name: 'CKV_SECRET_6: Base64 High Entropy String'
+    pretty_name: 'Base64 High Entropy String'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_7:
     categories:
@@ -12442,7 +12442,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_7
-    pretty_name: 'CKV_SECRET_7: IBM Cloud IAM Key'
+    pretty_name: 'IBM Cloud IAM Key'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_8:
     categories:
@@ -12453,7 +12453,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_8
-    pretty_name: 'CKV_SECRET_8: IBM COS HMAC Credentials'
+    pretty_name: 'IBM COS HMAC Credentials'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_SECRET_9:
     categories:
@@ -12464,7 +12464,7 @@ rules:
     description: Check for secrets stored in configuration.
     group: stored-secrets
     name: CKV_SECRET_9
-    pretty_name: 'CKV_SECRET_9: JSON Web Token'
+    pretty_name: 'JSON Web Token'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_1:
     categories:
@@ -12475,7 +12475,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_1
-    pretty_name: 'CKV_YC_1: Ensure security group is assigned to database cluster.'
+    pretty_name: 'Ensure security group is assigned to database cluster.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_10:
     categories:
@@ -12486,7 +12486,7 @@ rules:
     description: Check for unencrypted Yandex Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_YC_10
-    pretty_name: 'CKV_YC_10: Ensure etcd database is encrypted with KMS key.'
+    pretty_name: 'Ensure etcd database is encrypted with KMS key.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_11:
     categories:
@@ -12497,7 +12497,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_11
-    pretty_name: 'CKV_YC_11: Ensure security group is assigned to network interface.'
+    pretty_name: 'Ensure security group is assigned to network interface.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_12:
     categories:
@@ -12508,7 +12508,7 @@ rules:
     description: Check for publicly accessible Yandex Cloud resources.
     group: cloud-resources-public-access
     name: CKV_YC_12
-    pretty_name: 'CKV_YC_12: Ensure public IP is not assigned to database cluster.'
+    pretty_name: 'Ensure public IP is not assigned to database cluster.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_13:
     categories:
@@ -12519,7 +12519,7 @@ rules:
     description: Check for weak Yandex Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_YC_13
-    pretty_name: 'CKV_YC_13: Ensure cloud member does not have elevated access.'
+    pretty_name: 'Ensure cloud member does not have elevated access.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_14:
     categories:
@@ -12530,7 +12530,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_14
-    pretty_name: 'CKV_YC_14: Ensure security group is assigned to Kubernetes cluster.'
+    pretty_name: 'Ensure security group is assigned to Kubernetes cluster.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_15:
     categories:
@@ -12541,7 +12541,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_15
-    pretty_name: 'CKV_YC_15: Ensure security group is assigned to Kubernetes node
+    pretty_name: 'Ensure security group is assigned to Kubernetes node
       group.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_16:
@@ -12552,7 +12552,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_16
-    pretty_name: 'CKV_YC_16: Ensure network policy is assigned to Kubernetes cluster.'
+    pretty_name: 'Ensure network policy is assigned to Kubernetes cluster.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_17:
     categories:
@@ -12563,7 +12563,7 @@ rules:
     description: Check for publicly accessible Yandex Cloud resources.
     group: cloud-resources-public-access
     name: CKV_YC_17
-    pretty_name: 'CKV_YC_17: Ensure storage bucket does not have public access permissions.'
+    pretty_name: 'Ensure storage bucket does not have public access permissions.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_18:
     categories:
@@ -12574,7 +12574,7 @@ rules:
     description: Check for publicly accessible Yandex Cloud resources.
     group: cloud-resources-public-access
     name: CKV_YC_18
-    pretty_name: 'CKV_YC_18: Ensure compute instance group does not have public IP.'
+    pretty_name: 'Ensure compute instance group does not have public IP.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_19:
     categories:
@@ -12585,7 +12585,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_19
-    pretty_name: 'CKV_YC_19: Ensure security group does not contain allow-all rules.'
+    pretty_name: 'Ensure security group does not contain allow-all rules.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_2:
     categories:
@@ -12596,7 +12596,7 @@ rules:
     description: Check for publicly accessible Yandex Cloud resources.
     group: cloud-resources-public-access
     name: CKV_YC_2
-    pretty_name: 'CKV_YC_2: Ensure compute instance does not have public IP.'
+    pretty_name: 'Ensure compute instance does not have public IP.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_20:
     categories:
@@ -12607,7 +12607,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_20
-    pretty_name: 'CKV_YC_20: Ensure security group rule is not allow-all.'
+    pretty_name: 'Ensure security group rule is not allow-all.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_21:
     categories:
@@ -12618,7 +12618,7 @@ rules:
     description: Check for weak Yandex Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_YC_21
-    pretty_name: 'CKV_YC_21: Ensure organization member does not have elevated access.'
+    pretty_name: 'Ensure organization member does not have elevated access.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_22:
     categories:
@@ -12629,7 +12629,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_22
-    pretty_name: 'CKV_YC_22: Ensure compute instance group has security group assigned.'
+    pretty_name: 'Ensure compute instance group has security group assigned.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_23:
     categories:
@@ -12640,7 +12640,7 @@ rules:
     description: Check for weak Yandex Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_YC_23
-    pretty_name: 'CKV_YC_23: Ensure folder member does not have elevated access.'
+    pretty_name: 'Ensure folder member does not have elevated access.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_24:
     categories:
@@ -12651,7 +12651,7 @@ rules:
     description: Check for weak Yandex Cloud permissions.
     group: cloud-insecure-iam
     name: CKV_YC_24
-    pretty_name: 'CKV_YC_24: Ensure passport account is not used for assignment. Use
+    pretty_name: 'Ensure passport account is not used for assignment. Use
       service accounts and federated accounts where possible.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_3:
@@ -12662,7 +12662,7 @@ rules:
     description: Check for unencrypted Yandex Cloud resources.
     group: cloud-unencrypted-resources
     name: CKV_YC_3
-    pretty_name: 'CKV_YC_3: Ensure storage bucket is encrypted.'
+    pretty_name: 'Ensure storage bucket is encrypted.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_4:
     categories:
@@ -12673,7 +12673,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_4
-    pretty_name: 'CKV_YC_4: Ensure compute instance does not have serial console enabled.'
+    pretty_name: 'Ensure compute instance does not have serial console enabled.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_5:
     categories:
@@ -12684,7 +12684,7 @@ rules:
     description: Check for publicly accessible Yandex Cloud resources.
     group: cloud-resources-public-access
     name: CKV_YC_5
-    pretty_name: 'CKV_YC_5: Ensure Kubernetes cluster does not have public IP address.'
+    pretty_name: 'Ensure Kubernetes cluster does not have public IP address.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_6:
     categories:
@@ -12695,7 +12695,7 @@ rules:
     description: Check for publicly accessible Yandex Cloud resources.
     group: cloud-resources-public-access
     name: CKV_YC_6
-    pretty_name: 'CKV_YC_6: Ensure Kubernetes cluster node group does not have public
+    pretty_name: 'Ensure Kubernetes cluster node group does not have public
       IP addresses.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_7:
@@ -12707,7 +12707,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_7
-    pretty_name: 'CKV_YC_7: Ensure Kubernetes cluster auto-upgrade is enabled.'
+    pretty_name: 'Ensure Kubernetes cluster auto-upgrade is enabled.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_8:
     categories:
@@ -12718,7 +12718,7 @@ rules:
     description: Check for misconfigurations in Yandex Cloud resources.
     group: cloud-weak-configuration
     name: CKV_YC_8
-    pretty_name: 'CKV_YC_8: Ensure Kubernetes node group auto-upgrade is enabled.'
+    pretty_name: 'Ensure Kubernetes node group auto-upgrade is enabled.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
   CKV_YC_9:
     categories:
@@ -12729,6 +12729,6 @@ rules:
     description: Check that ensures best practices in Yandex Cloud secrets management.
     group: cloud-weak-secrets-management
     name: CKV_YC_9
-    pretty_name: 'CKV_YC_9: Ensure KMS symmetric key is rotated.'
+    pretty_name: 'Ensure KMS symmetric key is rotated.'
     ref: https://www.checkov.io/5.Policy%20Index/all.html
 


### PR DESCRIPTION
This was done back when the original rule ID was hidden from the user and is now redundant.