### PR TITLE
Make Elevated GitHub App rule a Severe Supply Chain finding

### DIFF
--- a/server-side-scanners/boostsecurityio/cicd/rules.yaml
+++ b/server-side-scanners/boostsecurityio/cicd/rules.yaml
@@ -301,6 +301,7 @@ rules:
       - supply-chain
       - supply-chain-scm-weak-configuration
       - supply-chain-cicd-weak-configuration
+      - supply-chain-cicd-severe-issues
       - boost-hardened
     description: Checks for GitHub organizations with third-party applications that
       have elevated permissions.


### PR DESCRIPTION
Making a pass to make a `supply-chain-cicd-severe-issues` the Elevated GitHub App rule. Especially since now, we are allow listing our own app, we should show that other apps ask for more permissions.