### PR TITLE
Update SAST scanners

### DIFF
--- a/scanners/boostsecurityio/bearer-pii/module.yaml
+++ b/scanners/boostsecurityio/bearer-pii/module.yaml
@@ -54,5 +54,5 @@ steps:
     format: metadata
     post-processor:
       docker:
-        image: public.ecr.aws/boostsecurityio/boost-scanner-bearer:fc69f64@sha256:bc2df1892c6fc13afc81e66c75e86a36835dd6b85282cdb9dabc12bbeca0f05a
+        image: public.ecr.aws/boostsecurityio/boost-scanner-bearer:d09e202@sha256:fc9dcdc0e044dbb120428c68866ecb23c9d96cda9086b8962897a0e493fba8df
         command: privacy -

--- a/scanners/boostsecurityio/bearer/module.yaml
+++ b/scanners/boostsecurityio/bearer/module.yaml
@@ -54,5 +54,5 @@ steps:
     format: sarif
     post-processor:
       docker:
-        image: public.ecr.aws/boostsecurityio/boost-scanner-bearer:fc69f64@sha256:bc2df1892c6fc13afc81e66c75e86a36835dd6b85282cdb9dabc12bbeca0f05a
+        image: public.ecr.aws/boostsecurityio/boost-scanner-bearer:d09e202@sha256:fc9dcdc0e044dbb120428c68866ecb23c9d96cda9086b8962897a0e493fba8df
         command: sast -

--- a/scanners/boostsecurityio/brakeman/module.yaml
+++ b/scanners/boostsecurityio/brakeman/module.yaml
@@ -20,4 +20,4 @@ steps:
       format: sarif
       post-processor:
         docker:
-          image: public.ecr.aws/boostsecurityio/boost-scanner-brakeman:0b71fa2@sha256:1cf820c9b7eb7c5869814ca125b220d788f6a0cf02f83266bb722a9a2674240a
+          image: public.ecr.aws/boostsecurityio/boost-scanner-brakeman:010d3e8@sha256:ed80eeacd3554d2fb6643c916a4d81c3a82cac9efb12f529819392b6f66c3911

--- a/scanners/boostsecurityio/codeql/module.yaml
+++ b/scanners/boostsecurityio/codeql/module.yaml
@@ -63,7 +63,7 @@ steps:
 
       post-processor:
         docker:
-          image: public.ecr.aws/boostsecurityio/boost-scanner-codeql:c0368a1@sha256:48a99a6408126eec7beddf7a7e61057bbc6b9a4ad4a810f438f28c4328f41bc6
+          image: public.ecr.aws/boostsecurityio/boost-scanner-codeql:74de82a@sha256:49c5895e8e43f34dafce91f90a8d1d542f66baa6ff7c67fa187bb49156e3568e
           command: process
           environment:
             PYTHONIOENCODING: utf-8

--- a/scanners/boostsecurityio/gitleaks-full/module.yaml
+++ b/scanners/boostsecurityio/gitleaks-full/module.yaml
@@ -65,4 +65,4 @@ steps:
       post-processor:
         docker:
           command: process --git-scan
-          image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:17a8fa2@sha256:af16cd8a6c7e57e3d20bd67b97440249109777757311041dfcded36e46a84a4e
+          image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:005aa11@sha256:605f7ac26f64a1ec766f0023a09fbca95146546ea2abae5d32ffe62e180fda79

--- a/scanners/boostsecurityio/gitleaks/module.yaml
+++ b/scanners/boostsecurityio/gitleaks/module.yaml
@@ -64,4 +64,4 @@ steps:
       post-processor:
         docker:
           command: process
-          image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:17a8fa2@sha256:af16cd8a6c7e57e3d20bd67b97440249109777757311041dfcded36e46a84a4e
+          image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:005aa11@sha256:605f7ac26f64a1ec766f0023a09fbca95146546ea2abae5d32ffe62e180fda79

--- a/scanners/boostsecurityio/gosec/module.yaml
+++ b/scanners/boostsecurityio/gosec/module.yaml
@@ -12,14 +12,6 @@ config:
   require_full_repo: true
   support_diff_scan: true
 
-
-setup:
-  - name: Install post-processing dependency
-    run: |
-      curl -fsSL -O "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64"
-      echo "af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44  jq-linux64" | sha256sum --check
-      chmod +x jq-linux64
-
 steps:
   - scan:
       command:
@@ -31,4 +23,8 @@ steps:
             HOME: /tmp/gosec
       format: sarif
       post-processor:
-        run: $SETUP_PATH/jq-linux64 'walk(if type == "object" and has("id") and has("name") then del(.name) else . end) | walk(if type == "object" and has("ruleIndex") and has("ruleId") then del(.ruleIndex) else . end)'
+        docker:
+          image: public.ecr.aws/boostsecurityio/boost-scanner-gosec:8874fb4@sha256:9b85ad1c04c61c025da40d6772654bebf077266a9b61d4f0ec6974b08c296608
+          command: process
+          environment:
+            PYTHONIOENCODING: utf-8


### PR DESCRIPTION
- Follow up of https://github.com/boostsecurityio/dev-registry/pull/88 for gosec, codeql, brakeman, bearer and gitleaks.