### PR TITLE
Updated trivy-image post-processor

### DIFF
--- a/scanners/boostsecurityio/trivy-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-image/module.yaml
@@ -64,7 +64,7 @@ steps:
       format: sarif
       post-processor:
         docker:
-          image: public.ecr.aws/boostsecurityio/boost-scanner-trivy:8bb5614@sha256:8d70e4b8c6de956e2b233becd5afc293b50364290800b3668cb398a938f6a402
+          image: public.ecr.aws/boostsecurityio/boost-scanner-trivy:b870d4f@sha256:0c80eea0daa00c214ea8179563261376730af8151e5feef29c9a40decdf2e73d
           command: process
           environment:
             PYTHONIOENCODING: utf-8


### PR DESCRIPTION
This update is to handle missing `Metadata.RepoTags` from the trivy output (ref: https://github.com/boostsecurityio/boostsec-scanner-trivy/pull/23)