### PR TITLE
bump trivy version to 0.48.2 (fs and image sbom)

### DIFF
--- a/scanners/boostsecurityio/trivy-sbom-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom-image/module.yaml
@@ -12,11 +12,11 @@ config:
 setup:
   - name: download trivy
     environment:
-      VERSION: 0.42.1
-      LINUX_X86_64_SHA: 305a4c6dbde3abac8e103376021e82c464478f829442e39a0fd980a77946bb22
-      LINUX_ARM64_SHA: cad74fc7c0a6a96ad0721987acda2e529b0b77db754c67e65bec8667b50d9ca5
-      MACOS_X86_64_SHA: a13af5f4d04b10ba181b12cc86f8735e441ab8eca7b6d23692b5061ae767411e
-      MACOS_ARM64_SHA: cebe7abc5d427f7bdedb506c2ae9b33259812ec5a779901b34efbac41bba572a
+      VERSION: 0.48.2
+      LINUX_X86_64_SHA: 2820ce6c8314ac39d3d9f470322506d029fe5cb5cbce12a826968f9bcc68c783
+      LINUX_ARM64_SHA: 3a04f78d66d0920a28af17673dd9d993decfc6186a64c3d4385ef40dcc58c360
+      MACOS_X86_64_SHA: 2a7889e845d0b8a7b006832c28701c1522c0c561a28591166ae6ced8a8c0ac85
+      MACOS_ARM64_SHA: c2a3a05b7a34241160d859cf2c950de7f8ffd47e59acbc275c92611297b7ac08
     run: |
       BINARY_URL="https://github.com/aquasecurity/trivy/releases/download/v${VERSION}"
       ARCH=$(uname -m)

--- a/scanners/boostsecurityio/trivy-sbom/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom/module.yaml
@@ -12,11 +12,11 @@ config:
 setup:
   - name: download trivy
     environment:
-      VERSION: 0.42.1
-      LINUX_X86_64_SHA: 305a4c6dbde3abac8e103376021e82c464478f829442e39a0fd980a77946bb22
-      LINUX_ARM64_SHA: cad74fc7c0a6a96ad0721987acda2e529b0b77db754c67e65bec8667b50d9ca5
-      MACOS_X86_64_SHA: a13af5f4d04b10ba181b12cc86f8735e441ab8eca7b6d23692b5061ae767411e
-      MACOS_ARM64_SHA: cebe7abc5d427f7bdedb506c2ae9b33259812ec5a779901b34efbac41bba572a
+      VERSION: 0.48.2
+      LINUX_X86_64_SHA: 2820ce6c8314ac39d3d9f470322506d029fe5cb5cbce12a826968f9bcc68c783
+      LINUX_ARM64_SHA: 3a04f78d66d0920a28af17673dd9d993decfc6186a64c3d4385ef40dcc58c360
+      MACOS_X86_64_SHA: 2a7889e845d0b8a7b006832c28701c1522c0c561a28591166ae6ced8a8c0ac85
+      MACOS_ARM64_SHA: c2a3a05b7a34241160d859cf2c950de7f8ffd47e59acbc275c92611297b7ac08
     run: |
       BINARY_URL="https://github.com/aquasecurity/trivy/releases/download/v${VERSION}"
       ARCH=$(uname -m)


### PR DESCRIPTION
# Problem
* Trivy version before 0.45.0 didn't support swift projects/packages

# Solution
* Bump trivy version used in sbom