### PR TITLE
BST-9547: change boost sbom oss scanner to license

### DIFF
--- a/server-side-scanners/boostsecurityio/cicd/module.yaml
+++ b/server-side-scanners/boostsecurityio/cicd/module.yaml
@@ -1,4 +1,4 @@
 name: BoostSecurity CI/CD
 namespace: boostsecurityio/cicd
-scan_type:
+scan_types:
   - cicd

--- a/server-side-scanners/boostsecurityio/dependabot/module.yaml
+++ b/server-side-scanners/boostsecurityio/dependabot/module.yaml
@@ -1,4 +1,4 @@
 name: Dependabot
 namespace: boostsecurityio/dependabot
-scan_type:
+scan_types:
   - sca

--- a/server-side-scanners/boostsecurityio/oss-license/module.yaml
+++ b/server-side-scanners/boostsecurityio/oss-license/module.yaml
@@ -1,4 +1,4 @@
 name: BoostSecurity OSS License
 namespace: boostsecurityio/oss-license
-scan_type:
-  - sca
+scan_types:
+  - license

--- a/server-side-scanners/boostsecurityio/sbom-sca/module.yaml
+++ b/server-side-scanners/boostsecurityio/sbom-sca/module.yaml
@@ -1,4 +1,4 @@
 name: BoostSecurity SBOM SCA
 namespace: boostsecurityio/sbom-sca
-scan_type:
+scan_types:
   - sca

--- a/server-side-scanners/boostsecurityio/snyk-provider/module.yaml
+++ b/server-side-scanners/boostsecurityio/snyk-provider/module.yaml
@@ -1,5 +1,5 @@
 name: Snyk Provider
 namespace: boostsecurityio/snyk-provider
-scan_type:
+scan_types:
   - sca
   - sast

--- a/server-side-scanners/boostsecurityio/sonarqube/module.yaml
+++ b/server-side-scanners/boostsecurityio/sonarqube/module.yaml
@@ -1,4 +1,4 @@
 name: BoostSecurity SonarQube
 namespace: boostsecurityio/sonarqube
-scan_type:
+scan_types:
   - sast


### PR DESCRIPTION
drive-by: fix invalid `scan-types` key for several scanners.