### PR TITLE
[BST-9435] add script to output public config

### DIFF
--- a/scanners/boostsecurityio/codeql/module.yaml
+++ b/scanners/boostsecurityio/codeql/module.yaml
@@ -11,6 +11,17 @@ config:
   require_full_repo: true
 
 setup:
+  - name: Config
+    environment:
+      CODEQL_LANGUAGE: ${CODEQL_LANGUAGE}
+      CODEQL_CREATE_ARGS: ${CODEQL_CREATE_ARGS:-}
+      CODEQL_QUERY: ${CODEQL_QUERY:-}
+      CODEQL_ANALYZE_ARGS: ${CODEQL_ANALYZE_ARGS:-}
+    run: |
+      echo "CODEQL_LANGUAGE: '$CODEQL_LANGUAGE'"
+      echo "CODEQL_CREATE_ARGS: '$CODEQL_CREATE_ARGS'"
+      echo "CODEQL_QUERY: '$CODEQL_QUERY'"
+      echo "CODEQL_ANALYZE_ARGS: '$CODEQL_ANALYZE_ARGS'"
   - name: Download CodeQL bundle
     run: |
       case "$CODEQL_LANGUAGE" in

--- a/scanners/boostsecurityio/semgrep-pro/module.yaml
+++ b/scanners/boostsecurityio/semgrep-pro/module.yaml
@@ -13,6 +13,11 @@ config:
   - .semgrep/*
 
 setup:
+  - name: Config
+    environment:
+      SEMGREP_RULES: ${SEMGREP_RULES:-auto}
+    run: |
+      echo "SEMGREP_RULES: '$SEMGREP_RULES'"
   - name: Validate Semgrep API Key
     run: |
       if [ -z "$SEMGREP_APP_TOKEN" ]; then

--- a/scanners/boostsecurityio/semgrep/module.yaml
+++ b/scanners/boostsecurityio/semgrep/module.yaml
@@ -11,6 +11,13 @@ config:
   include_files:
   - .semgrep/*
 
+setup:
+  - name: Config
+    environment:
+      SEMGREP_RULES: ${SEMGREP_RULES:-auto}
+    run: |
+      echo "SEMGREP_RULES: '$SEMGREP_RULES'"
+
 steps:
   - scan:
       command:


### PR DESCRIPTION
For codeql, semgrep and semgrep pro, add a setup step where we output the config used based on the environment variables.

Note that the output will only be visible if you run the CLI in `TRACE` mode.