### PR TITLE
BST-10456: update supply-chain inventory scanner version

### DIFF
--- a/scanners/boostsecurityio/supply-chain-inventory/module.yaml
+++ b/scanners/boostsecurityio/supply-chain-inventory/module.yaml
@@ -16,7 +16,7 @@ steps:
       format: supply_chain_inventory
       command:
         docker:
-          image: public.ecr.aws/boostsecurityio/boost-scanner-composition:f9c5372@sha256:30b885b536fa0382b51c15ba4f1d8307bf997d7d6ef1a151ad4b4ca9f7b00c63
+          image: public.ecr.aws/boostsecurityio/boost-scanner-composition:972e077@sha256:93caadb50ca242ff90abd98f35a731e9a841f59e7d7e24f3952c9071e72a4129
           command: inventory
           workdir: /src
           environment:


### PR DESCRIPTION
This version of the scanner report the package names with the subpath included so that two package from the same repository doesn't show as the same.