### PR TITLE
Update CodeQL scanner version to latest

### DIFF
--- a/scanners/boostsecurityio/codeql/module.yaml
+++ b/scanners/boostsecurityio/codeql/module.yaml
@@ -32,9 +32,9 @@ setup:
            exit 1;;
       esac
 
-      curl -fsSL -O "https://github.com/github/codeql-action/releases/download/codeql-bundle-20230524/codeql-bundle-linux64.tar.gz"
+      curl -fsSL -O "https://github.com/github/codeql-action/releases/download/codeql-bundle-v2.17.2/codeql-bundle-linux64.tar.gz"
 
-      echo "4331b56293066197e34796f29f0a495bb2015ca2f80e1af47eea01e103be0300  codeql-bundle-linux64.tar.gz" | sha256sum --check
+      echo "0f82b9b22f9d3f9e7a9ac0f6cccc8ac30dc10cc0eff7935682223ee4ff8c156d  codeql-bundle-linux64.tar.gz" | sha256sum --check
 
       tar -xzf codeql-bundle-linux64.tar.gz
 


### PR DESCRIPTION
Was tested on boost sandbox, with branch https://github.com/boost-sandbox/module-tests-codeql/tree/test-new-codeql-version
i.e. with this registry version.
<img width="1333" alt="Screenshot 2024-05-14 at 4 29 00 PM" src="https://github.com/boostsecurityio/dev-registry/assets/7815288/428f428a-0c61-42a1-b3c6-d090abc17bd8">
