### PR TITLE
BST-10447: update trivy scanners for error reporting

### DIFF
--- a/scanners/boostsecurityio/trivy-fs/module.yaml
+++ b/scanners/boostsecurityio/trivy-fs/module.yaml
@@ -74,13 +74,14 @@ steps:
   - scan:
       command:
         environment:
+          NO_COLOR: "true"
           TRIVY_ADDITIONAL_ARGS: ${TRIVY_ADDITIONAL_ARGS---ignore-unfixed}
         run: |
-          $SETUP_PATH/trivy fs ${TRIVY_ADDITIONAL_ARGS} --format json --scanners vuln --quiet .
+          $SETUP_PATH/trivy fs ${TRIVY_ADDITIONAL_ARGS} --format json --no-progress --scanners vuln .
       format: sarif
       post-processor:
         docker:
-          image: public.ecr.aws/boostsecurityio/boost-scanner-trivy:60f6c43@sha256:b6832610688ddf8e0a7b14339aefdc8dbccd33b842cc9d192b73e770acf6f7fe
+          image: public.ecr.aws/boostsecurityio/boost-scanner-trivy:c5a58c2@sha256:fc8f004380a61d147855179159d4e1bb66b49d6461a18ef0bfa56de09afc990e
           command: process
           environment:
             PYTHONIOENCODING: utf-8

--- a/scanners/boostsecurityio/trivy-sbom/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom/module.yaml
@@ -53,13 +53,15 @@ setup:
 
 steps:
   - scan:
+      environment:
+        NO_COLOR: "true"
       command:
         run: |
-            $SETUP_PATH/trivy fs --format=cyclonedx --license-full --cache-dir=/tmp/trivy/ .
+            $SETUP_PATH/trivy fs --format=cyclonedx --license-full --no-progress --cache-dir=/tmp/trivy/ .
       format: cyclonedx
       post-processor:
         docker:
-          image: public.ecr.aws/boostsecurityio/boost-scanner-trivy-sbom:2077b09@sha256:9acea8e0566becbbf19a51b7de326cda23d124254091f38cf5e2132f298a1301
+          image: public.ecr.aws/boostsecurityio/boost-scanner-trivy-sbom::4ab519c@sha256:4406a5e85ae8e05db126ff242a6bea6619cb2a016c25d0a9d609955a1dc4535b
           command: process
           environment:
             PYTHONIOENCODING: utf-8


### PR DESCRIPTION
updates the trivy scanners for reporting on missing package lock files
