### PR TITLE
update trivy-sbom to run scanners

### DIFF
--- a/scanners/boostsecurityio/trivy-sbom/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom/module.yaml
@@ -57,7 +57,7 @@ steps:
         environment:
           NO_COLOR: "true"
         run: |
-            $SETUP_PATH/trivy fs --format=cyclonedx --license-full --no-progress --cache-dir=/tmp/trivy/ . 2>&1
+            $SETUP_PATH/trivy fs --format=cyclonedx --license-full --no-progress --scanners vuln --cache-dir=/tmp/trivy/ . 2>&1
       format: cyclonedx
       post-processor:
         docker:


### PR DESCRIPTION
we update trivy-sbom to always run scanners as this is
the trivy code path that does language detections
otherwise an error is throw indicating no scanners are running