### PR TITLE
BST-11165: add license type & rule to boost-sca (#132)

### DIFF
--- a/scanners/boostsecurityio/boost-sca/rules.yaml
+++ b/scanners/boostsecurityio/boost-sca/rules.yaml
@@ -1,18 +1,3 @@
 import:
-  - boostsecurityio/sca-cve
+  - boostsecurityio/sbom-sca
   - boostsecurityio/oss-license
-
-rules:
-  dependency-with-malicious-behaviour:
-    categories:
-      - ALL
-      - boost-baseline
-      - boost-hardened
-      - supply-chain
-      - vulnerable-and-outdated-components
-      - dependency-with-malicious-behaviour
-    description: The dependency has been identified by the community to have malicious behaviour.
-    name: dependency-with-malicious-behaviour
-    group: top10-vulnerable-components
-    pretty_name: Dependency with known malicious behaviour
-    ref: https://github.com/ossf/malicious-packages/tree/main/osv/malicious


### PR DESCRIPTION
Since this scanner is a combination of the sbom-sca & license scanner, its rules are now just importing from those scanners, making sure they are in sync.