### PR TITLE
OSV Scanner Module for reachable analysis

### DIFF
--- a/.github/workflows/registry-scanner.yaml
+++ b/.github/workflows/registry-scanner.yaml
@@ -14,7 +14,7 @@ on:
 
 permissions:
   contents: read
-  
+
 jobs:
   scan_job:
     name: Scanner Registry Action
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Scan Registry
-        uses: boostsecurityio/scanner-registry-action@bcec6e2aedd41802de36511587d46e2eb47e8805 # v1.5.3
+        uses: boostsecurityio/scanner-registry-action@7c3690aed2453f790be130a209d644c41b333fb7 # v1.5.4
         with:
           api_endpoint: ${{ vars.BOOST_API_ENDPOINT }}
           api_token: ${{ secrets.BOOST_SYSTEM_API_KEY_REGISTRY }}

--- a/scanners/boostsecurityio/boost-sca/module.yaml
+++ b/scanners/boostsecurityio/boost-sca/module.yaml
@@ -5,6 +5,7 @@ name: BoostSecurity SCA
 namespace: boostsecurityio/boost-sca
 scan_types:
   - sca
+  - license
 
 config:
   require_full_repo: true

--- a/scanners/boostsecurityio/boost-sca/rules.yaml
+++ b/scanners/boostsecurityio/boost-sca/rules.yaml
@@ -1,5 +1,6 @@
 import:
   - boostsecurityio/sca-cve
+  - boostsecurityio/oss-license
 
 rules:
   dependency-with-malicious-behaviour:

--- a/scanners/boostsecurityio/boost-sca/rules.yaml
+++ b/scanners/boostsecurityio/boost-sca/rules.yaml
@@ -1,18 +1,3 @@
 import:
-  - boostsecurityio/sca-cve
+  - boostsecurityio/sbom-sca
   - boostsecurityio/oss-license
-
-rules:
-  dependency-with-malicious-behaviour:
-    categories:
-      - ALL
-      - boost-baseline
-      - boost-hardened
-      - supply-chain
-      - vulnerable-and-outdated-components
-      - dependency-with-malicious-behaviour
-    description: The dependency has been identified by the community to have malicious behaviour.
-    name: dependency-with-malicious-behaviour
-    group: top10-vulnerable-components
-    pretty_name: Dependency with known malicious behaviour
-    ref: https://github.com/ossf/malicious-packages/tree/main/osv/malicious

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,7 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:4fc96e5bc990db5dc6adb89ad42938a03c86d9cd6352649588928f255ca38b82
         command: |
-           'osv-scanner scan --recursive --call-analysis=all --format json .'
+           sh -c 'osv-scanner scan --recursive --call-analysis=all --format json .'
 #          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
 #                   exit_code=$?
 #                   if [ $exit_code -gt 128 ]; then

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -36,7 +36,7 @@ steps:
 - scan:
     command:
       docker:
-        image: slef05/osv-scanner-go:v1@sha256:4fc96e5bc990db5dc6adb89ad42938a03c86d9cd6352649588928f255ca38b82
+        image: slef05/osv-scanner-go:v1@sha256:0cc22c68f6f15437c0bf47fc0812d44d040c04dcfe2fda10ba1e355cfdc2990f
         command: |
            -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
 #           -c 'if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,7 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:60887bfca904f8beeddcb98a0e81c715eb7868d63f9c9ea2dcf30e9302905b25
         command: |
-           cd /project;osv-scanner scan --recursive --call-analysis=all --format json .
+           sh -c 'cd /project;osv-scanner scan --recursive --call-analysis=all --format json .'
 #          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
 #                   exit_code=$?
 #                   if [ $exit_code -gt 128 ]; then

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,7 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:0cc22c68f6f15437c0bf47fc0812d44d040c04dcfe2fda10ba1e355cfdc2990f
         command: |
-           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null; exit_code=$?'
+           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null; exit_code=$?; if [ $exit_code -gt 128 ]; then exit $exit_code; fi'
  #          -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
  #          -c 'osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; exit_code=$?; if [ $exit_code -gt 128 ]; then exit $exit_code; fi'        
         workdir: /project

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -37,7 +37,7 @@ steps:
     command:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:47f9f76b2f723dccfd0b915365530f19743065d76e7bdf5733d65474bfe09247
-        command: scan --recursive --call-analysis=all --format json /project
+        command: scan --recursive --call-analysis=all --format json
         workdir: /project
     format: sarif
     post-processor:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,7 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:0cc22c68f6f15437c0bf47fc0812d44d040c04dcfe2fda10ba1e355cfdc2990f
         command: |
-           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null; exit_code=$?; if [ $exit_code -gt 126 ]; then exit $exit_code; fi'
+           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null; exit_code=$?; if [ $exit_code -gt 126 ]; then exit 1; fi'
  #          -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
  #          -c 'osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; exit_code=$?; if [ $exit_code -gt 128 ]; then exit $exit_code; fi'        
         workdir: /project

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,7 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:4fc96e5bc990db5dc6adb89ad42938a03c86d9cd6352649588928f255ca38b82
         command: |
-           -c 'osv-scanner scan --recursive --call-analysis=all --format json . || true'
+           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
 #           -c 'if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
 #                   exit_code=$?
 #                   if [ $exit_code -gt 128 ]; then

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,13 +38,14 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:60887bfca904f8beeddcb98a0e81c715eb7868d63f9c9ea2dcf30e9302905b25
         command: |
-          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
-                   exit_code=$?
-                   if [ $exit_code -gt 128 ]; then
-                      exit $exit_code
-                   fi
-                 fi
-                '        
+           sh -c 'cd project;ls'
+#          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
+#                   exit_code=$?
+#                   if [ $exit_code -gt 128 ]; then
+#                      exit $exit_code
+#                   fi
+#                 fi
+#                '        
         workdir: /project
     format: sarif
     post-processor:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -37,7 +37,14 @@ steps:
     command:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:47f9f76b2f723dccfd0b915365530f19743065d76e7bdf5733d65474bfe09247
-        command: scan --recursive --call-analysis=all --format json /project
+        command: |
+          sh -c 'if ! osv-scanner scan --recursive --call-analysis=all --format json /project ; then
+                   exit_code=$?
+                   if [ $exit_code -gt 128 ]; then
+                      exit $exit_code
+                   fi
+                 fi
+                '        
         workdir: /project
     format: sarif
     post-processor:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -37,7 +37,7 @@ steps:
     command:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:bd8c8caf84d152f81ec36663c9bd74c2a4d3f9f25ad0d99f22f15c3ec0919263
-        command: scan --recursive --call-analysis=all --format json
+        command: scan --recursive --call-analysis=all --format json /project
         workdir: /project
     format: sarif
     post-processor:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,7 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:0cc22c68f6f15437c0bf47fc0812d44d040c04dcfe2fda10ba1e355cfdc2990f
         command: |
-           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
+           -c '/root/osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
 #           -c 'if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
 #                   exit_code=$?
 #                   if [ $exit_code -gt 128 ]; then

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -36,7 +36,7 @@ steps:
 - scan:
     command:
       docker:
-        image: slef05/osv-scanner-go:v1@sha256:47f9f76b2f723dccfd0b915365530f19743065d76e7bdf5733d65474bfe09247
+        image: ghcr.io/google/osv-scanner:v1.8.1@sha256:9688a213460220e85f86b988e414464ebb61982191d5231ad1c69219e2b13afd
         command: scan --recursive --call-analysis=all --format json /project
         workdir: /project
     format: sarif

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,7 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:60887bfca904f8beeddcb98a0e81c715eb7868d63f9c9ea2dcf30e9302905b25
         command: |
-           sh -c 'cd project;osv-scanner scan --recursive --call-analysis=all --format json .'
+           cd project;osv-scanner scan --recursive --call-analysis=all --format json .
 #          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
 #                   exit_code=$?
 #                   if [ $exit_code -gt 128 ]; then

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,7 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:0cc22c68f6f15437c0bf47fc0812d44d040c04dcfe2fda10ba1e355cfdc2990f
         command: |
-           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null; exit_code=$?; if [ $exit_code -gt 126 ]; then exit 1; fi'
+           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null; exit_code=$?; if [ $exit_code -gt 126 ]; then exit $exit_code; fi'
  #          -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
  #          -c 'osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; exit_code=$?; if [ $exit_code -gt 128 ]; then exit $exit_code; fi'        
         workdir: /project

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -36,7 +36,7 @@ steps:
 - scan:
     command:
       docker:
-        image: slef05/osv-scanner-go:v1@sha256:sha256:1f42e3aafec4671cd409176c2694afa14c4397398e2a57dcfe50403aaf8faf9a
+        image: slef05/osv-scanner-go:v1@sha256:1f42e3aafec4671cd409176c2694afa14c4397398e2a57dcfe50403aaf8faf9a
         command: scan --recursive --call-analysis=all --format json /project
         workdir: /project
     format: sarif

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,7 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:4fc96e5bc990db5dc6adb89ad42938a03c86d9cd6352649588928f255ca38b82
         command: |
-           sh -c 'osv-scanner scan --recursive --call-analysis=all --format json .'
+           -c 'osv-scanner scan --recursive --call-analysis=all --format json .'
 #          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
 #                   exit_code=$?
 #                   if [ $exit_code -gt 128 ]; then

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,13 +38,14 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:a82cfc3dcdb17f5a52831013dca31bbd4007ec87545105c3bbcd1f8faf52f96c
         command: |
-          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
-                   exit_code=$?
-                   if [ $exit_code -gt 128 ]; then
-                      exit $exit_code
-                   fi
-                 fi
-                '        
+           cd project;osv-scanner scan --recursive --call-analysis=all --format json .
+#          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
+#                   exit_code=$?
+#                   if [ $exit_code -gt 128 ]; then
+#                      exit $exit_code
+#                   fi
+#                 fi
+#                '        
         workdir: /project
     format: sarif
     post-processor:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -39,8 +39,6 @@ steps:
         image: slef05/osv-scanner-go:v1@sha256:47f9f76b2f723dccfd0b915365530f19743065d76e7bdf5733d65474bfe09247
         command: scan --recursive --call-analysis=all --format json /project
         workdir: /project
-        environment:
-          GOCACHE: /root
     format: sarif
     post-processor:
       docker:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -84,7 +84,7 @@ steps:
     format: sarif
     post-processor:
       docker:
-          image: public.ecr.aws/boostsecurityio/boost-converter-sca:3fd32ff@sha256:f21a1539e5ed32f2cb97ee7048ec9ca825b491bfbfd86d1ac6f324cc04b5e9f4
+          image: public.ecr.aws/boostsecurityio/boost-converter-sca:be29374@sha256:06d9d8712018128444eab3388215e58c18ab07952172792d89ad1093f18a6052
           command: process --scanner osv
           environment:
               PYTHONIOENCODING: utf-8

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,8 +38,8 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:0cc22c68f6f15437c0bf47fc0812d44d040c04dcfe2fda10ba1e355cfdc2990f
         command: |
-           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
-#          -c 'osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; exit_code=$?; if [ $exit_code -gt 128 ]; then exit $exit_code; fi'        
+ #          -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
+           -c 'osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; exit_code=$?; if [ $exit_code -gt 128 ]; then exit $exit_code; fi'        
         workdir: /project
     format: sarif
     post-processor:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,7 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:8a1bb06ffc1511dbaef3ede88d742d221e04f3e68e32ebe663bf43334b650b0e
         command: |
-          sh -c 'if ! ./osv-scanner scan --recursive --call-analysis=all --format json /project ; then
+          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
                    exit_code=$?
                    if [ $exit_code -gt 128 ]; then
                       exit $exit_code

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,14 +38,14 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:4fc96e5bc990db5dc6adb89ad42938a03c86d9cd6352649588928f255ca38b82
         command: |
-#           -c 'osv-scanner scan --recursive --call-analysis=all --format json .'
-           -c 'if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
-                   exit_code=$?
-                   if [ $exit_code -gt 128 ]; then
-                      exit $exit_code
-                   fi
-                 fi
-                '        
+           -c 'osv-scanner scan --recursive --call-analysis=all --format json . || true'
+#           -c 'if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
+#                   exit_code=$?
+#                   if [ $exit_code -gt 128 ]; then
+#                      exit $exit_code
+#                   fi
+#                 fi
+#                '        
         workdir: /project
     format: sarif
     post-processor:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -36,7 +36,7 @@ steps:
 - scan:
     command:
       docker:
-        image: ghcr.io/google/osv-scanner:v1.8.1@sha256:9688a213460220e85f86b988e414464ebb61982191d5231ad1c69219e2b13afd
+        image: slef05/osv-scanner-go:v1@sha256:47f9f76b2f723dccfd0b915365530f19743065d76e7bdf5733d65474bfe09247
         command: scan --recursive --call-analysis=all --format json /project
         workdir: /project
         environment:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,7 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:60887bfca904f8beeddcb98a0e81c715eb7868d63f9c9ea2dcf30e9302905b25
         command: |
-           sh -c 'cd /project;osv-scanner scan --recursive --call-analysis=all --format json .'
+           cd /project;osv-scanner scan --recursive --call-analysis=all --format json .
 #          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
 #                   exit_code=$?
 #                   if [ $exit_code -gt 128 ]; then

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -36,9 +36,9 @@ steps:
 - scan:
     command:
       docker:
-        image: slef05/osv-scanner-go:v1@sha256:8e326b8fe1f78258a7af28a9f46f2ae33b3f2e11b3babdf9bfbf263148210f00
+        image: slef05/osv-scanner-go:v1@sha256:4fc96e5bc990db5dc6adb89ad42938a03c86d9cd6352649588928f255ca38b82
         command: |
-           sh -c osv-scanner scan --recursive --call-analysis=all --format json .
+           'osv-scanner scan --recursive --call-analysis=all --format json .'
 #          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
 #                   exit_code=$?
 #                   if [ $exit_code -gt 128 ]; then

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,7 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:0cc22c68f6f15437c0bf47fc0812d44d040c04dcfe2fda10ba1e355cfdc2990f
         command: |
-           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null; exit_code=$?; if [ $exit_code -gt 1 ]; then exit $exit_code; fi'
+           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null; exit_code=$?; if [ $exit_code -gt 126 ]; then exit $exit_code; fi'
  #          -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
  #          -c 'osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; exit_code=$?; if [ $exit_code -gt 128 ]; then exit $exit_code; fi'        
         workdir: /project

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -54,3 +54,4 @@ steps:
           command: process --scanner osv
           environment:
               PYTHONIOENCODING: utf-8
+              BOOST_SCAN_CMD_EXEC_PATH: /project

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,6 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:47f9f76b2f723dccfd0b915365530f19743065d76e7bdf5733d65474bfe09247
         command: scan --recursive --call-analysis=all --format json /project
+        workdir: /project
     format: sarif
     post-processor:
       docker:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -36,9 +36,9 @@ steps:
 - scan:
     command:
       docker:
-        image: slef05/osv-scanner-go:v1@sha256:d7c01aab63f69ecb85e6959e24c58927e6f9a4bb70637b571596058dfd61850d
+        image: slef05/osv-scanner-go:v1@sha256:8a1bb06ffc1511dbaef3ede88d742d221e04f3e68e32ebe663bf43334b650b0e
         command: |
-          sh -c 'if ! osv-scanner scan --recursive --call-analysis=all --format json /project ; then
+          sh -c 'if ! ./osv-scanner scan --recursive --call-analysis=all --format json /project ; then
                    exit_code=$?
                    if [ $exit_code -gt 128 ]; then
                       exit $exit_code

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -39,13 +39,7 @@ steps:
         image: slef05/osv-scanner-go:v1@sha256:0cc22c68f6f15437c0bf47fc0812d44d040c04dcfe2fda10ba1e355cfdc2990f
         command: |
 #           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
-           -c 'if ! osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; then
-                   exit_code=$?
-                   if [ $exit_code -gt 128 ]; then
-                      exit $exit_code
-                   fi
-                 fi
-                '        
+           -c 'if ! osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; then exit_code=$? if [ $exit_code -gt 128 ]; then exit $exit_code fi fi'        
         workdir: /project
     format: sarif
     post-processor:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -37,8 +37,7 @@ steps:
     command:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:47f9f76b2f723dccfd0b915365530f19743065d76e7bdf5733d65474bfe09247
-        command: scan --recursive --call-analysis=all --format json
-        workdir: /project
+        command: scan --recursive --call-analysis=all --format json /project
     format: sarif
     post-processor:
       docker:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,7 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:0cc22c68f6f15437c0bf47fc0812d44d040c04dcfe2fda10ba1e355cfdc2990f
         command: |
-           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null; exit_code=$?; if [ $exit_code -gt 128 ]; then exit $exit_code; fi'
+           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null; exit_code=$?; if [ $exit_code -gt 1 ]; then exit $exit_code; fi'
  #          -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
  #          -c 'osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; exit_code=$?; if [ $exit_code -gt 128 ]; then exit $exit_code; fi'        
         workdir: /project

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -36,16 +36,15 @@ steps:
 - scan:
     command:
       docker:
-        image: slef05/osv-scanner-go:v1@sha256:60887bfca904f8beeddcb98a0e81c715eb7868d63f9c9ea2dcf30e9302905b25
+        image: slef05/osv-scanner-go:v1@sha256:a82cfc3dcdb17f5a52831013dca31bbd4007ec87545105c3bbcd1f8faf52f96c
         command: |
-           cd /project;osv-scanner scan --recursive --call-analysis=all --format json .
-#          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
-#                   exit_code=$?
-#                   if [ $exit_code -gt 128 ]; then
-#                      exit $exit_code
-#                   fi
-#                 fi
-#                '        
+          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
+                   exit_code=$?
+                   if [ $exit_code -gt 128 ]; then
+                      exit $exit_code
+                   fi
+                 fi
+                '        
         workdir: /project
     format: sarif
     post-processor:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -36,7 +36,7 @@ steps:
 - scan:
     command:
       docker:
-        image: slef05/osv-scanner-go:v1@sha256:f851569e4e1aa549d9369b488cc0c0de821fa7030979f73e0cbf1d5d40766d84
+        image: slef05/osv-scanner-go:v1@sha256:d7c01aab63f69ecb85e6959e24c58927e6f9a4bb70637b571596058dfd61850d
         command: |
           sh -c 'if ! osv-scanner scan --recursive --call-analysis=all --format json /project ; then
                    exit_code=$?

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,14 +38,14 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:4fc96e5bc990db5dc6adb89ad42938a03c86d9cd6352649588928f255ca38b82
         command: |
-           -c 'osv-scanner scan --recursive --call-analysis=all --format json .'
-#          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
-#                   exit_code=$?
-#                   if [ $exit_code -gt 128 ]; then
-#                      exit $exit_code
-#                   fi
-#                 fi
-#                '        
+#           -c 'osv-scanner scan --recursive --call-analysis=all --format json .'
+           -c 'if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
+                   exit_code=$?
+                   if [ $exit_code -gt 128 ]; then
+                      exit $exit_code
+                   fi
+                 fi
+                '        
         workdir: /project
     format: sarif
     post-processor:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -31,56 +31,14 @@ config:
     - renv.lock
     - yarn.lock
 
-setup:
-  - name: Install OSV-Scanner
-    environment:
-      VERSION: 1.7.3
-      MACOS_X86_64_SHA: af5c7432fe17f5e3f98658a5f5407ce7e1456eb750153a47ce24a6eedd8cfb1a
-      MACOS_ARM64_SHA: e0c38f4c886036951016ea72c807ff7c9d482ba2b5a65f134182def05316c72e
-      LINUX_X86_64_SHA: ae8dc75d66ae6fbdcb7d4010d32567e37cbc3ac21aa649a65cb33e0d45cbe78a
-      LINUX_ARM64_SHA: ed527974c44eca991a6c3a9e4aa8a74199c9a7f460242342b0eccfb400ee4c16
-    run: |
-      BINARY_URL="https://github.com/google/osv-scanner/releases/download/v${VERSION}"
-      ARCH=$(uname -m)
-      case "$(uname -sm)" in
-        "Darwin x86_64")
-          BINARY_URL="${BINARY_URL}/osv-scanner_darwin_amd64"
-          SHA="${MACOS_X86_64_SHA} osv-scanner"
-          ;;
-        "Darwin arm64")
-          BINARY_URL="${BINARY_URL}/osv-scanner_darwin_arm64"
-          SHA="${MACOS_ARM64_SHA} osv-scanner"
-          ;;
-        "Linux x86_64")
-          BINARY_URL="${BINARY_URL}/osv-scanner_linux_amd64"
-          SHA="${LINUX_X86_64_SHA} osv-scanner"
-          ;;
-        "Linux aarch64")
-          BINARY_URL="${BINARY_URL}/osv-scanner_linux_arm64"
-          SHA="${LINUX_ARM64_SHA} osv-scanner"
-          ;;
-        *)
-          echo "Unsupported machine: ${OPTARG}"
-          exit 1
-          ;;
-      esac
-      curl -o osv-scanner -fsSL "${BINARY_URL}"
-      echo "${SHA}" | sha256sum --check
-      
-      chmod +x osv-scanner
 
 steps:
 - scan:
     command:
-      run: |
-        if ! $SETUP_PATH/osv-scanner scan --recursive --call-analysis=all --format json .; then
-          if test $? -gt 2; then
-            echo "osv-scanner failed to execute"
-            exit 1
-          fi
-        fi
-      environment:
-        HOME: /tmp
+      docker:
+        image: slef05/osv-scanner-go:v1@sha256:bd8c8caf84d152f81ec36663c9bd74c2a4d3f9f25ad0d99f22f15c3ec0919263
+        command: scan --recursive --call-analysis=all --format json
+        workdir: /project
     format: sarif
     post-processor:
       docker:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -39,7 +39,7 @@ steps:
         image: slef05/osv-scanner-go:v1@sha256:0cc22c68f6f15437c0bf47fc0812d44d040c04dcfe2fda10ba1e355cfdc2990f
         command: |
 #           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
-           -c 'if ! osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; then exit_code=$? if [ $exit_code -gt 128 ]; then exit $exit_code fi fi'        
+           -c 'osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; exit_code=$?; if [ $exit_code -gt 128 ]; then exit $exit_code; fi'        
         workdir: /project
     format: sarif
     post-processor:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -36,7 +36,6 @@ steps:
 - scan:
     command:
       docker:
-        image: slef05/osv-scanner-go:v1@sha256:f28efbfccd1a63b23e5f91ecb2df5f656e4008be9534b5e5c4bf78b0bf501893
         image: public.ecr.aws/boostsecurityio/boost-scanner-osv:eb33e00@sha256:9781255c0c6af6f45bd117b44f6b73368fbf73a961e1287b461552aa40412afb
         command: |
            -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null; exit_code=$?; if [ $exit_code -gt 126 ]; then exit $exit_code; fi'       

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -36,7 +36,7 @@ steps:
 - scan:
     command:
       docker:
-        image: slef05/osv-scanner-go:v1@sha256:215409b5a7c7b32045de37ffb9bf4a1e11f1c6d382b39b3d27c91ea910f6cf94
+        image: slef05/osv-scanner-go:v1@sha256:f28efbfccd1a63b23e5f91ecb2df5f656e4008be9534b5e5c4bf78b0bf501893
         command: |
            -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null; exit_code=$?; if [ $exit_code -gt 126 ]; then exit $exit_code; fi'
  #          -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -36,7 +36,7 @@ steps:
 - scan:
     command:
       docker:
-        image: slef05/osv-scanner-go:v1@sha256:47f9f76b2f723dccfd0b915365530f19743065d76e7bdf5733d65474bfe09247
+        image: slef05/osv-scanner-go:v1@sha256:f851569e4e1aa549d9369b488cc0c0de821fa7030979f73e0cbf1d5d40766d84
         command: |
           sh -c 'if ! osv-scanner scan --recursive --call-analysis=all --format json /project ; then
                    exit_code=$?

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -39,6 +39,8 @@ steps:
         image: ghcr.io/google/osv-scanner:v1.8.1@sha256:9688a213460220e85f86b988e414464ebb61982191d5231ad1c69219e2b13afd
         command: scan --recursive --call-analysis=all --format json /project
         workdir: /project
+        environment:
+          GOCACHE: /root
     format: sarif
     post-processor:
       docker:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,8 +38,8 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:0cc22c68f6f15437c0bf47fc0812d44d040c04dcfe2fda10ba1e355cfdc2990f
         command: |
-#           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
-          -c 'osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; exit_code=$?; if [ $exit_code -gt 128 ]; then exit $exit_code; fi'        
+           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
+#          -c 'osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; exit_code=$?; if [ $exit_code -gt 128 ]; then exit $exit_code; fi'        
         workdir: /project
     format: sarif
     post-processor:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -54,4 +54,6 @@ steps:
           command: process --scanner osv
           environment:
               PYTHONIOENCODING: utf-8
+              # Need to set the BOOST_SCAN_CMD_EXEC_PATH env variable since the osv-scanner docker image
+              # doesn't deal with the absolute paths.
               BOOST_SCAN_CMD_EXEC_PATH: /project

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,7 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:60887bfca904f8beeddcb98a0e81c715eb7868d63f9c9ea2dcf30e9302905b25
         command: |
-           sh -c 'cd project;ls'
+           sh -c 'cd project;osv-scanner scan --recursive --call-analysis=all --format json .'
 #          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
 #                   exit_code=$?
 #                   if [ $exit_code -gt 128 ]; then

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,7 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:60887bfca904f8beeddcb98a0e81c715eb7868d63f9c9ea2dcf30e9302905b25
         command: |
-           cd project;osv-scanner scan --recursive --call-analysis=all --format json .
+           cd /project;osv-scanner scan --recursive --call-analysis=all --format json .
 #          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
 #                   exit_code=$?
 #                   if [ $exit_code -gt 128 ]; then

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,7 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:8e326b8fe1f78258a7af28a9f46f2ae33b3f2e11b3babdf9bfbf263148210f00
         command: |
-           osv-scanner scan --recursive --call-analysis=all --format json .
+           sh -c osv-scanner scan --recursive --call-analysis=all --format json .
 #          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
 #                   exit_code=$?
 #                   if [ $exit_code -gt 128 ]; then

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -36,7 +36,7 @@ steps:
 - scan:
     command:
       docker:
-        image: slef05/osv-scanner-go:v1@sha256:1f42e3aafec4671cd409176c2694afa14c4397398e2a57dcfe50403aaf8faf9a
+        image: slef05/osv-scanner-go:v1@sha256:6452de6204366f1c0efb0c704584c5372bbc05f792da36a86d13730d034cc0f8
         command: scan --recursive --call-analysis=all --format json /project
         workdir: /project
     format: sarif

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -39,7 +39,7 @@ steps:
         image: slef05/osv-scanner-go:v1@sha256:0cc22c68f6f15437c0bf47fc0812d44d040c04dcfe2fda10ba1e355cfdc2990f
         command: |
 #           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
-           -c 'osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; exit_code=$?; if [ $exit_code -gt 128 ]; then exit $exit_code; fi'        
+          -c 'osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; exit_code=$?; if [ $exit_code -gt 128 ]; then exit $exit_code; fi'        
         workdir: /project
     format: sarif
     post-processor:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,14 +38,14 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:0cc22c68f6f15437c0bf47fc0812d44d040c04dcfe2fda10ba1e355cfdc2990f
         command: |
-           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
-#           -c 'if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
-#                   exit_code=$?
-#                   if [ $exit_code -gt 128 ]; then
-#                      exit $exit_code
-#                   fi
-#                 fi
-#                '        
+#           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
+           -c 'if ! osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; then
+                   exit_code=$?
+                   if [ $exit_code -gt 128 ]; then
+                      exit $exit_code
+                   fi
+                 fi
+                '        
         workdir: /project
     format: sarif
     post-processor:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -50,7 +50,7 @@ steps:
     format: sarif
     post-processor:
       docker:
-          image: public.ecr.aws/boostsecurityio/boost-converter-sca:be29374@sha256:06d9d8712018128444eab3388215e58c18ab07952172792d89ad1093f18a6052
+          image: public.ecr.aws/boostsecurityio/boost-converter-sca:af34fec@sha256:d8834c4687f7c82f33a489899de15455d4bf00b8f7dabde4c035bbcd67316b14
           command: process --scanner osv
           environment:
               PYTHONIOENCODING: utf-8

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,8 +38,9 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:0cc22c68f6f15437c0bf47fc0812d44d040c04dcfe2fda10ba1e355cfdc2990f
         command: |
+           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null; exit_code=$?'
  #          -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
-           -c 'osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; exit_code=$?; if [ $exit_code -gt 128 ]; then exit $exit_code; fi'        
+ #          -c 'osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; exit_code=$?; if [ $exit_code -gt 128 ]; then exit $exit_code; fi'        
         workdir: /project
     format: sarif
     post-processor:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -36,7 +36,7 @@ steps:
 - scan:
     command:
       docker:
-        image: slef05/osv-scanner-go:v1@sha256:8a1bb06ffc1511dbaef3ede88d742d221e04f3e68e32ebe663bf43334b650b0e
+        image: slef05/osv-scanner-go:v1@sha256:60887bfca904f8beeddcb98a0e81c715eb7868d63f9c9ea2dcf30e9302905b25
         command: |
           sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
                    exit_code=$?

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,7 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:0cc22c68f6f15437c0bf47fc0812d44d040c04dcfe2fda10ba1e355cfdc2990f
         command: |
-           -c '/root/osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
+           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
 #           -c 'if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
 #                   exit_code=$?
 #                   if [ $exit_code -gt 128 ]; then

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -37,10 +37,9 @@ steps:
     command:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:f28efbfccd1a63b23e5f91ecb2df5f656e4008be9534b5e5c4bf78b0bf501893
+        image: public.ecr.aws/boostsecurityio/boost-scanner-osv:eb33e00@sha256:9781255c0c6af6f45bd117b44f6b73368fbf73a961e1287b461552aa40412afb
         command: |
-           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null; exit_code=$?; if [ $exit_code -gt 126 ]; then exit $exit_code; fi'
- #          -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'
- #          -c 'osv-scanner scan --recursive --call-analysis=all --format json .  2> /dev/null; exit_code=$?; if [ $exit_code -gt 128 ]; then exit $exit_code; fi'        
+           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null; exit_code=$?; if [ $exit_code -gt 126 ]; then exit $exit_code; fi'       
         workdir: /project
     format: sarif
     post-processor:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,7 +38,7 @@ steps:
       docker:
         image: slef05/osv-scanner-go:v1@sha256:8e326b8fe1f78258a7af28a9f46f2ae33b3f2e11b3babdf9bfbf263148210f00
         command: |
-           cd project;osv-scanner scan --recursive --call-analysis=all --format json .
+           osv-scanner scan --recursive --call-analysis=all --format json .
 #          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then
 #                   exit_code=$?
 #                   if [ $exit_code -gt 128 ]; then

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -36,7 +36,7 @@ steps:
 - scan:
     command:
       docker:
-        image: slef05/osv-scanner-go:v1@sha256:a82cfc3dcdb17f5a52831013dca31bbd4007ec87545105c3bbcd1f8faf52f96c
+        image: slef05/osv-scanner-go:v1@sha256:8e326b8fe1f78258a7af28a9f46f2ae33b3f2e11b3babdf9bfbf263148210f00
         command: |
            cd project;osv-scanner scan --recursive --call-analysis=all --format json .
 #          sh -c 'cd project;if ! osv-scanner scan --recursive --call-analysis=all --format json . ; then

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -36,7 +36,7 @@ steps:
 - scan:
     command:
       docker:
-        image: slef05/osv-scanner-go:v1@sha256:bd8c8caf84d152f81ec36663c9bd74c2a4d3f9f25ad0d99f22f15c3ec0919263
+        image: slef05/osv-scanner-go:v1@sha256:sha256:1f42e3aafec4671cd409176c2694afa14c4397398e2a57dcfe50403aaf8faf9a
         command: scan --recursive --call-analysis=all --format json /project
         workdir: /project
     format: sarif

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -36,7 +36,7 @@ steps:
 - scan:
     command:
       docker:
-        image: slef05/osv-scanner-go:v1@sha256:6452de6204366f1c0efb0c704584c5372bbc05f792da36a86d13730d034cc0f8
+        image: slef05/osv-scanner-go:v1@sha256:47f9f76b2f723dccfd0b915365530f19743065d76e7bdf5733d65474bfe09247
         command: scan --recursive --call-analysis=all --format json /project
         workdir: /project
     format: sarif

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -36,7 +36,7 @@ steps:
 - scan:
     command:
       docker:
-        image: slef05/osv-scanner-go:v1@sha256:0cc22c68f6f15437c0bf47fc0812d44d040c04dcfe2fda10ba1e355cfdc2990f
+        image: slef05/osv-scanner-go:v1@sha256:215409b5a7c7b32045de37ffb9bf4a1e11f1c6d382b39b3d27c91ea910f6cf94
         command: |
            -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null; exit_code=$?; if [ $exit_code -gt 126 ]; then exit $exit_code; fi'
  #          -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null || true'


### PR DESCRIPTION
The scanner module used to run from the binary version of osv-scanner.  However in order for reachability analysis to work, go needs to be installed when scanning go apps. 
The existing scanner module works properly on GH Action, github has go installed, but the reachability analysis doesn't work on Gitlab runners for example.
This change switches to the osv-scanner image in order to enable reachability for all environments. 