### PR TITLE
[BST-11709] Updates osv-scanner to use image and support reachability.

### DIFF
--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -54,7 +54,7 @@ steps:
           export BOOST_SCAN_CMD_EXEC_PATH="/project/${BOOST_SCAN_PATH}"
         fi
         export PYTHONIOENCODING="utf-8"
-        docker run -i public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639 'process --scanner osv'
+        docker run -i public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639 process --scanner osv
 #      docker:
 #          image: public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639
 #          command: process --scanner osv

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -31,14 +31,6 @@ config:
     - renv.lock
     - yarn.lock
 
-setup:
-  - name: Set relative base path
-    run: |
-      if [ -z "$BOOST_SCAN_PATH" ]; then
-         export BOOST_RELATIVE_TO="/project"
-      else
-         export BOOST_RELATIVE_TO="/project/${BOOST_SCAN_PATH}"
-      fi
 
 steps:
 - scan:
@@ -57,4 +49,4 @@ steps:
               PYTHONIOENCODING: utf-8
               # Need to set the BOOST_SCAN_CMD_EXEC_PATH env variable since the osv-scanner docker image
               # doesn't deal with the absolute paths.
-              BOOST_SCAN_CMD_EXEC_PATH: ${BOOST_RELATIVE_TO}
+              BOOST_SCAN_CMD_EXEC_PATH: /project

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -31,60 +31,21 @@ config:
     - renv.lock
     - yarn.lock
 
-setup:
-  - name: Install OSV-Scanner
-    environment:
-      VERSION: 1.7.3
-      MACOS_X86_64_SHA: af5c7432fe17f5e3f98658a5f5407ce7e1456eb750153a47ce24a6eedd8cfb1a
-      MACOS_ARM64_SHA: e0c38f4c886036951016ea72c807ff7c9d482ba2b5a65f134182def05316c72e
-      LINUX_X86_64_SHA: ae8dc75d66ae6fbdcb7d4010d32567e37cbc3ac21aa649a65cb33e0d45cbe78a
-      LINUX_ARM64_SHA: ed527974c44eca991a6c3a9e4aa8a74199c9a7f460242342b0eccfb400ee4c16
-    run: |
-      BINARY_URL="https://github.com/google/osv-scanner/releases/download/v${VERSION}"
-      ARCH=$(uname -m)
-      case "$(uname -sm)" in
-        "Darwin x86_64")
-          BINARY_URL="${BINARY_URL}/osv-scanner_darwin_amd64"
-          SHA="${MACOS_X86_64_SHA} osv-scanner"
-          ;;
-        "Darwin arm64")
-          BINARY_URL="${BINARY_URL}/osv-scanner_darwin_arm64"
-          SHA="${MACOS_ARM64_SHA} osv-scanner"
-          ;;
-        "Linux x86_64")
-          BINARY_URL="${BINARY_URL}/osv-scanner_linux_amd64"
-          SHA="${LINUX_X86_64_SHA} osv-scanner"
-          ;;
-        "Linux aarch64")
-          BINARY_URL="${BINARY_URL}/osv-scanner_linux_arm64"
-          SHA="${LINUX_ARM64_SHA} osv-scanner"
-          ;;
-        *)
-          echo "Unsupported machine: ${OPTARG}"
-          exit 1
-          ;;
-      esac
-      curl -o osv-scanner -fsSL "${BINARY_URL}"
-      echo "${SHA}" | sha256sum --check
-      
-      chmod +x osv-scanner
-
 steps:
 - scan:
     command:
-      run: |
-        if ! $SETUP_PATH/osv-scanner scan --recursive --call-analysis=all --format json .; then
-          if test $? -gt 2; then
-            echo "osv-scanner failed to execute"
-            exit 1
-          fi
-        fi
-      environment:
-        HOME: /tmp
+      docker:
+        image: public.ecr.aws/boostsecurityio/boost-scanner-osv:eb33e00@sha256:9781255c0c6af6f45bd117b44f6b73368fbf73a961e1287b461552aa40412afb
+        command: |
+           -c 'osv-scanner scan --recursive --call-analysis=all --format json . 2> /dev/null; exit_code=$?; if [ $exit_code -gt 126 ]; then exit $exit_code; fi'
+        workdir: /project
     format: sarif
     post-processor:
       docker:
-          image: public.ecr.aws/boostsecurityio/boost-converter-sca:af34fec@sha256:3d3ef2564450ffb4b79a7f88a92b36137fd7ea191ac521bba257d33ac011028d
+          image: public.ecr.aws/boostsecurityio/boost-converter-sca:af34fec@sha256:d8834c4687f7c82f33a489899de15455d4bf00b8f7dabde4c035bbcd67316b14
           command: process --scanner osv
           environment:
               PYTHONIOENCODING: utf-8
+              # Need to set the BOOST_SCAN_CMD_EXEC_PATH env variable since the osv-scanner docker image
+              # doesn't deal with the absolute paths.
+              BOOST_SCAN_CMD_EXEC_PATH: /project

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -31,6 +31,11 @@ config:
     - renv.lock
     - yarn.lock
 
+setup:
+  - name: Get Values
+    run: |
+      echo "Boost Scan Path: ${BOOST_SCAN_PATH}"
+      echo "Boost EXec Path: ${BOOST_SCAN_CMD_EXEC_PATH}"
 
 steps:
 - scan:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -47,11 +47,18 @@ steps:
         workdir: /project
     format: sarif
     post-processor:
-      docker:
-          image: public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639
-          command: process --scanner osv
-          environment:
-              PYTHONIOENCODING: utf-8
+      run: |
+        if [ -z "$BOOST_SCAN_PATH" ]; then
+          export BOOST_SCAN_CMD_EXEC_PATH="/project"
+        else
+          export BOOST_SCAN_CMD_EXEC_PATH="/project/${BOOST_SCAN_PATH}"
+        export PYTHONIOENCODING="utf-8"
+        docker run -i public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639 -c 'process --scanner osv'
+#      docker:
+#          image: public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639
+#          command: process --scanner osv
+#          environment:
+#              PYTHONIOENCODING: utf-8
               # Need to set the BOOST_SCAN_CMD_EXEC_PATH env variable since the osv-scanner docker image
               # doesn't deal with the absolute paths.
-              BOOST_SCAN_CMD_EXEC_PATH: /project
+#              BOOST_SCAN_CMD_EXEC_PATH: /project

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -48,4 +48,4 @@ steps:
               PYTHONIOENCODING: utf-8
               # Need to set the BOOST_SCAN_CMD_EXEC_PATH env variable since the osv-scanner docker image
               # doesn't deal with the absolute paths.
-              BOOST_SCAN_CMD_EXEC_PATH: /project
+              BOOST_SCAN_CMD_EXEC_PATH: /project/${BOOST_SCAN_PATH}

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -54,7 +54,7 @@ steps:
           export BOOST_SCAN_CMD_EXEC_PATH="/project/${BOOST_SCAN_PATH}"
         fi
         export PYTHONIOENCODING="utf-8"
-        docker run -i public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639 -c 'process --scanner osv'
+        docker run -i public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639 'process --scanner osv'
 #      docker:
 #          image: public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639
 #          command: process --scanner osv

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -54,7 +54,7 @@ steps:
           export BOOST_SCAN_CMD_EXEC_PATH="/project/${BOOST_SCAN_PATH}"
         fi
         export PYTHONIOENCODING="utf-8"
-        docker run -i public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639 process --scanner osv
+        docker run -i -e BOOST_SCAN_CMD_EXEC_PATH="$BOOST_SCAN_CMD_EXEC_PATH" public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639 process --scanner osv
 #      docker:
 #          image: public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639
 #          command: process --scanner osv

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -48,4 +48,4 @@ steps:
               PYTHONIOENCODING: utf-8
               # Need to set the BOOST_SCAN_CMD_EXEC_PATH env variable since the osv-scanner docker image
               # doesn't deal with the absolute paths.
-              BOOST_SCAN_CMD_EXEC_PATH: /project/${BOOST_SCAN_PATH}
+              BOOST_SCAN_CMD_EXEC_PATH: /project/${BOOST_SCAN_PATH:-''}

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -35,9 +35,9 @@ setup:
   - name: Set relative base path
     run: |
       if [ -z "$BOOST_SCAN_PATH" ]; then
-         BOOST_RELATIVE_TO="/project"
+         export BOOST_RELATIVE_TO="/project"
       else
-         BOOST_RELATIVE_TO="/project/${BOOST_SCAN_PATH}"
+         export BOOST_RELATIVE_TO="/project/${BOOST_SCAN_PATH}"
       fi
 
 steps:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -48,4 +48,4 @@ steps:
               PYTHONIOENCODING: utf-8
               # Need to set the BOOST_SCAN_CMD_EXEC_PATH env variable since the osv-scanner docker image
               # doesn't deal with the absolute paths.
-              BOOST_SCAN_CMD_EXEC_PATH: /project/${BOOST_SCAN_PATH:-''}
+              BOOST_SCAN_CMD_EXEC_PATH: /project

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -52,6 +52,7 @@ steps:
           export BOOST_SCAN_CMD_EXEC_PATH="/project"
         else
           export BOOST_SCAN_CMD_EXEC_PATH="/project/${BOOST_SCAN_PATH}"
+        fi
         export PYTHONIOENCODING="utf-8"
         docker run -i public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639 -c 'process --scanner osv'
 #      docker:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -54,7 +54,7 @@ steps:
           export BOOST_SCAN_CMD_EXEC_PATH="/project/${BOOST_SCAN_PATH}"
         fi
         export PYTHONIOENCODING="utf-8"
-        docker run -i -e BOOST_SCAN_CMD_EXEC_PATH="$BOOST_SCAN_CMD_EXEC_PATH" public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639 process --scanner osv
+        docker run -i -e BOOST_SCAN_CMD_EXEC_PATH="$BOOST_SCAN_CMD_EXEC_PATH" -e PYTHONIOENCODING="utf-8" public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639 process --scanner osv
 #      docker:
 #          image: public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639
 #          command: process --scanner osv

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -43,7 +43,7 @@ steps:
     format: sarif
     post-processor:
       docker:
-          image: public.ecr.aws/boostsecurityio/boost-converter-sca:af34fec@sha256:d8834c4687f7c82f33a489899de15455d4bf00b8f7dabde4c035bbcd67316b14
+          image: public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639
           command: process --scanner osv
           environment:
               PYTHONIOENCODING: utf-8

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -38,6 +38,7 @@ setup:
          BOOST_RELATIVE_TO="/project"
       else
          BOOST_RELATIVE_TO="/project/${BOOST_SCAN_PATH}"
+      fi
 
 steps:
 - scan:

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -31,11 +31,6 @@ config:
     - renv.lock
     - yarn.lock
 
-setup:
-  - name: Get Values
-    run: |
-      echo "Boost Scan Path: ${BOOST_SCAN_PATH}"
-      echo "Boost EXec Path: ${BOOST_SCAN_CMD_EXEC_PATH}"
 
 steps:
 - scan:
@@ -49,17 +44,11 @@ steps:
     post-processor:
       run: |
         if [ -z "$BOOST_SCAN_PATH" ]; then
+          # set since osv-scanner generates absolute paths instead of relative
           export BOOST_SCAN_CMD_EXEC_PATH="/project"
         else
+          # set the path prefix for the case of monorepo
           export BOOST_SCAN_CMD_EXEC_PATH="/project/${BOOST_SCAN_PATH}"
         fi
         export PYTHONIOENCODING="utf-8"
-        docker run -i -e BOOST_SCAN_CMD_EXEC_PATH="$BOOST_SCAN_CMD_EXEC_PATH" -e PYTHONIOENCODING="utf-8" public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639 process --scanner osv
-#      docker:
-#          image: public.ecr.aws/boostsecurityio/boost-converter-sca:0fa5bd7@sha256:2175fb91a33d9a254b3bc6f7f5f330773bc43f5e9e044be8c4456ebc14526639
-#          command: process --scanner osv
-#          environment:
-#              PYTHONIOENCODING: utf-8
-              # Need to set the BOOST_SCAN_CMD_EXEC_PATH env variable since the osv-scanner docker image
-              # doesn't deal with the absolute paths.
-#              BOOST_SCAN_CMD_EXEC_PATH: /project
+        docker run -i -e BOOST_SCAN_CMD_EXEC_PATH="$BOOST_SCAN_CMD_EXEC_PATH" -e PYTHONIOENCODING="utf-8" public.ecr.aws/boostsecurityio/boost-converter-sca:af34fec@sha256:ace32e44fb61fe313c52856bb219ea7bb5a87fd09383d8746c1aeb71a21b6e0a process --scanner osv

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -31,6 +31,14 @@ config:
     - renv.lock
     - yarn.lock
 
+setup:
+  - name: Set relative base path
+    run: |
+      if [ -z "$BOOST_SCAN_PATH" ]; then
+         BOOST_RELATIVE_TO="/project"
+      else
+         BOOST_RELATIVE_TO="/project/${BOOST_SCAN_PATH}"
+
 steps:
 - scan:
     command:
@@ -48,4 +56,4 @@ steps:
               PYTHONIOENCODING: utf-8
               # Need to set the BOOST_SCAN_CMD_EXEC_PATH env variable since the osv-scanner docker image
               # doesn't deal with the absolute paths.
-              BOOST_SCAN_CMD_EXEC_PATH: /project
+              BOOST_SCAN_CMD_EXEC_PATH: ${BOOST_RELATIVE_TO}


### PR DESCRIPTION
Previously the module was making use of the osv-scanner binary. However, in order for the reachability analysis to work for go, the go compiler needs to be present on the server.  Reachability was therefore not working for gitlab runners, ado, etc.
The module is moved to using a container image with osv-scanner and go, enabling reachability analysis on all pipelines.
