### PR TITLE
BST-12156: add keyscope post-processor to gitleaks

### DIFF
--- a/scanners/boostsecurityio/gitleaks/module.yaml
+++ b/scanners/boostsecurityio/gitleaks/module.yaml
@@ -58,10 +58,15 @@ steps:
         environment:
           GITLEAKS_CONFIG: ${GITLEAKS_CONFIG:-}
         run: |
-          $SETUP_PATH/gitleaks detect --no-banner --exit-code 0 --redact --report-format sarif --no-git --report-path $SETUP_PATH/gitleaks-output.sarif --source .
+          $SETUP_PATH/gitleaks detect --no-banner --exit-code 0 --report-format sarif --no-git --report-path $SETUP_PATH/gitleaks-output.sarif --source .
           cat $SETUP_PATH/gitleaks-output.sarif
 
       post-processor:
-        docker:
-          command: process
-          image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:cc6e72e@sha256:a157c5eafcecde97cf5ec4ce8ec8fed3838d3f64c8e141746b40a97b57b1a80a
+        - docker:
+            command: process
+            image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:9e578dc@sha256:b2e393aa68d78059a1f9320414425f352aa0f166d73591f61e75c8d9cab38895
+        - docker:
+            command: process
+            image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:9c5fa4f@sha256:278c59d3fc3d6404da448688f25c8584f740225b5277a4b8d50ed8776c6b07e0
+            environment:
+              VALIDATE_SECRET: ${BOOST_VALIDATE_SECRET:-}


### PR DESCRIPTION
Adds a new post-processor to the existing gitleaks scanner to run keyscope on the gitleaks results to check if any found secret is still active or not.

The gitleaks post-processor was also updated to return new properties on the sarif results that maps to a secret finding type. Also, it no longer strip the secret values, since keyscope needs them to work. This was not an issue, because the cli sarif processor would always remove them anyway.