### PR TITLE
BST-12156: fix Gitleaks reported secret type

### DIFF
--- a/scanners/boostsecurityio/gitleaks-full/module.yaml
+++ b/scanners/boostsecurityio/gitleaks-full/module.yaml
@@ -65,7 +65,7 @@ steps:
       post-processor:
         - docker:
             command: process --git-scan
-            image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:ff4afb9@sha256:340366c142d2b3673c306ceb46a4e5d3d24bdf0e9a6c772a0404728390d07342
+            image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:f674cf7@sha256:8887d40f6e7ac83877a2b6c478f6c3a8307ea1385a9b56fccea0ed95216353a5
         - docker:
             command: process
             image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:9c5fa4f@sha256:278c59d3fc3d6404da448688f25c8584f740225b5277a4b8d50ed8776c6b07e0

--- a/scanners/boostsecurityio/gitleaks-full/module.yaml
+++ b/scanners/boostsecurityio/gitleaks-full/module.yaml
@@ -63,6 +63,11 @@ steps:
           cat $SETUP_PATH/gitleaks-output.sarif
 
       post-processor:
-        docker:
-          command: process --git-scan
-          image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:005aa11@sha256:605f7ac26f64a1ec766f0023a09fbca95146546ea2abae5d32ffe62e180fda79
+        - docker:
+            command: process --git-scan
+            image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:ff4afb9@sha256:340366c142d2b3673c306ceb46a4e5d3d24bdf0e9a6c772a0404728390d07342
+        - docker:
+            command: process
+            image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:9c5fa4f@sha256:278c59d3fc3d6404da448688f25c8584f740225b5277a4b8d50ed8776c6b07e0
+            environment:
+              VALIDATE_SECRET: ${BOOST_VALIDATE_SECRET:-}

--- a/scanners/boostsecurityio/gitleaks/module.yaml
+++ b/scanners/boostsecurityio/gitleaks/module.yaml
@@ -64,7 +64,7 @@ steps:
       post-processor:
         - docker:
             command: process
-            image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:ff4afb9@sha256:340366c142d2b3673c306ceb46a4e5d3d24bdf0e9a6c772a0404728390d07342
+            image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:f674cf7@sha256:8887d40f6e7ac83877a2b6c478f6c3a8307ea1385a9b56fccea0ed95216353a5
         - docker:
             command: process
             image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:9c5fa4f@sha256:278c59d3fc3d6404da448688f25c8584f740225b5277a4b8d50ed8776c6b07e0

--- a/scanners/boostsecurityio/gitleaks/module.yaml
+++ b/scanners/boostsecurityio/gitleaks/module.yaml
@@ -64,7 +64,7 @@ steps:
       post-processor:
         - docker:
             command: process
-            image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:9e578dc@sha256:b2e393aa68d78059a1f9320414425f352aa0f166d73591f61e75c8d9cab38895
+            image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:ff4afb9@sha256:340366c142d2b3673c306ceb46a4e5d3d24bdf0e9a6c772a0404728390d07342
         - docker:
             command: process
             image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:9c5fa4f@sha256:278c59d3fc3d6404da448688f25c8584f740225b5277a4b8d50ed8776c6b07e0


### PR DESCRIPTION
The secret type reported by the previous version of the gitleaks-convertor was based on the Gitleaks rule name, which are a long description of the secret found, not a short secret type.

This also adds the keyscope post-processor to the gitleaks-full scanner.