### PR TITLE
BST-12156: strip secret snippet in keyscope post-processor

### DIFF
--- a/scanners/boostsecurityio/gitleaks-full/module.yaml
+++ b/scanners/boostsecurityio/gitleaks-full/module.yaml
@@ -67,7 +67,7 @@ steps:
             command: process --git-scan
             image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:a13a131@sha256:97321d82da1b4adfbc1cd7fddb23a2ef57b8f9c2db0ccbc007f15f7adefb0086
         - docker:
-            command: process
-            image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:a0a6761@sha256:67df8000dc158207ae6d7823a55af1ec6cf5bb11432749fc8b5be9e0c28ba5d0
+            command: process --gitleaks-full
+            image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:6524873@sha256:f9310e1e1856d75c217d828350f9be0bfbde0c374cbaad5d00a2438965611281
             environment:
               VALIDATE_SECRET: ${BOOST_VALIDATE_SECRET:-}

--- a/scanners/boostsecurityio/gitleaks-full/module.yaml
+++ b/scanners/boostsecurityio/gitleaks-full/module.yaml
@@ -68,6 +68,6 @@ steps:
             image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:a13a131@sha256:97321d82da1b4adfbc1cd7fddb23a2ef57b8f9c2db0ccbc007f15f7adefb0086
         - docker:
             command: process
-            image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:79d1eca@sha256:c1b3c99e77b423bd407bb0932b4cda20feba204afc445d3de783a4e81f794b21
+            image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:a0a6761@sha256:67df8000dc158207ae6d7823a55af1ec6cf5bb11432749fc8b5be9e0c28ba5d0
             environment:
               VALIDATE_SECRET: ${BOOST_VALIDATE_SECRET:-}

--- a/scanners/boostsecurityio/gitleaks/module.yaml
+++ b/scanners/boostsecurityio/gitleaks/module.yaml
@@ -67,6 +67,6 @@ steps:
             image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:a13a131@sha256:97321d82da1b4adfbc1cd7fddb23a2ef57b8f9c2db0ccbc007f15f7adefb0086
         - docker:
             command: process
-            image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:a0a6761@sha256:67df8000dc158207ae6d7823a55af1ec6cf5bb11432749fc8b5be9e0c28ba5d0
+            image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:6524873@sha256:f9310e1e1856d75c217d828350f9be0bfbde0c374cbaad5d00a2438965611281
             environment:
               VALIDATE_SECRET: ${BOOST_VALIDATE_SECRET:-}

--- a/scanners/boostsecurityio/gitleaks/module.yaml
+++ b/scanners/boostsecurityio/gitleaks/module.yaml
@@ -67,6 +67,6 @@ steps:
             image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:a13a131@sha256:97321d82da1b4adfbc1cd7fddb23a2ef57b8f9c2db0ccbc007f15f7adefb0086
         - docker:
             command: process
-            image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:79d1eca@sha256:c1b3c99e77b423bd407bb0932b4cda20feba204afc445d3de783a4e81f794b21
+            image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:a0a6761@sha256:67df8000dc158207ae6d7823a55af1ec6cf5bb11432749fc8b5be9e0c28ba5d0
             environment:
               VALIDATE_SECRET: ${BOOST_VALIDATE_SECRET:-}


### PR DESCRIPTION
This updaste gitleaks post-processor (keyscope) to strip the secret snippets in order to avoid any change to current finding id (boost-id).

For the gitleaks-full scanner, the snippets are still let trough to comply with legacy behavior.

> [!NOTE]
> The CLI was already stripping those value, but because it was done in previous version of gitleaks convertor, this needs to be replicated.