### PR TITLE
BST-12323: rename gitleaks validate secret env var

### DIFF
--- a/scanners/boostsecurityio/gitleaks-full/module.yaml
+++ b/scanners/boostsecurityio/gitleaks-full/module.yaml
@@ -70,4 +70,4 @@ steps:
             command: process --gitleaks-full
             image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:6524873@sha256:f9310e1e1856d75c217d828350f9be0bfbde0c374cbaad5d00a2438965611281
             environment:
-              VALIDATE_SECRET: ${BOOST_VALIDATE_SECRET:-}
+              VALIDATE_SECRET: ${GITLEAKS_VALIDATE_SECRETS:-}

--- a/scanners/boostsecurityio/gitleaks/module.yaml
+++ b/scanners/boostsecurityio/gitleaks/module.yaml
@@ -69,4 +69,4 @@ steps:
             command: process
             image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:6524873@sha256:f9310e1e1856d75c217d828350f9be0bfbde0c374cbaad5d00a2438965611281
             environment:
-              VALIDATE_SECRET: ${BOOST_VALIDATE_SECRET:-}
+              VALIDATE_SECRET: ${GITLEAKS_VALIDATE_SECRETS:-}


### PR DESCRIPTION
The env var to enabled/disabled if gitleaks scanner should validate secrets has been renamed to match with the other gitleaks vars.