### PR TITLE
BST-12323: reenable validating secrets by default in gitleaks

### DIFF
--- a/scanners/boostsecurityio/gitleaks-full/module.yaml
+++ b/scanners/boostsecurityio/gitleaks-full/module.yaml
@@ -68,6 +68,6 @@ steps:
             image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:a13a131@sha256:97321d82da1b4adfbc1cd7fddb23a2ef57b8f9c2db0ccbc007f15f7adefb0086
         - docker:
             command: process --gitleaks-full
-            image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:6524873@sha256:f9310e1e1856d75c217d828350f9be0bfbde0c374cbaad5d00a2438965611281
+            image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:458e3dd@sha256:6b611b085271e2c8ed15590f536fd4a29221a11752ef7525bbb60be9ad241902
             environment:
               VALIDATE_SECRET: ${GITLEAKS_VALIDATE_SECRETS:-}

--- a/scanners/boostsecurityio/gitleaks/module.yaml
+++ b/scanners/boostsecurityio/gitleaks/module.yaml
@@ -67,6 +67,6 @@ steps:
             image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:a13a131@sha256:97321d82da1b4adfbc1cd7fddb23a2ef57b8f9c2db0ccbc007f15f7adefb0086
         - docker:
             command: process
-            image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:6524873@sha256:f9310e1e1856d75c217d828350f9be0bfbde0c374cbaad5d00a2438965611281
+            image: public.ecr.aws/boostsecurityio/boost-scanner-keyscope:458e3dd@sha256:6b611b085271e2c8ed15590f536fd4a29221a11752ef7525bbb60be9ad241902
             environment:
               VALIDATE_SECRET: ${GITLEAKS_VALIDATE_SECRETS:-}


### PR DESCRIPTION
This update the keyscope post-processor version to enable validation the secrets by default.