### PR TITLE
upgrade trivy client and add additional repository urls

### DIFF
--- a/scanners/boostsecurityio/trivy-fs/module.yaml
+++ b/scanners/boostsecurityio/trivy-fs/module.yaml
@@ -31,11 +31,11 @@ config:
 setup:
   - name: download trivy
     environment:
-      VERSION: 0.53.0
-      LINUX_X86_64_SHA: 9ddc7209f575990d07babe824e4c66e5dcb9eea010cc93a7c7a4f2014d1d6190
-      LINUX_ARM64_SHA: 81e6920b904a0ea40b16d911ff4e7dfc546bff749062f86164188f9272686457
-      MACOS_X86_64_SHA: 8d9f8b763eb8271dbdb6a2e8289ec2df3ae31e4f1ae58c7c437b981dc3b1c98b
-      MACOS_ARM64_SHA: dfb17fad8b25af497bf9c27f6946aed8d13e2375add3e17e372369f2a8305f96
+      VERSION: 0.56.1
+      LINUX_X86_64_SHA: 66aacdb5bdc90cef055430078d64414ecb99e37b1ca4ba0a4c0955e694aa9040
+      LINUX_ARM64_SHA: c1067e0e3717175f5d53679978c33ffdd937ee433e5ae70380a39e0d3f10a888
+      MACOS_X86_64_SHA: dd84313a547e36a447e26f4eb1cfcad3eaf442b1e7215eaffa883f90283b0741
+      MACOS_ARM64_SHA: 01efe7c0702cd9f95daa0cbd3b3d0abd192ac037c6491c1f1eb41f525d163a94
     run: |
       BINARY_URL="https://github.com/aquasecurity/trivy/releases/download/v${VERSION}"
       ARCH=$(uname -m)
@@ -76,6 +76,7 @@ steps:
         environment:
           NO_COLOR: "true"
           TRIVY_ADDITIONAL_ARGS: ${TRIVY_ADDITIONAL_ARGS---ignore-unfixed}
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
         run: |
           $SETUP_PATH/trivy fs ${TRIVY_ADDITIONAL_ARGS} --format json --no-progress --scanners vuln . 2>&1
       format: sarif

--- a/scanners/boostsecurityio/trivy-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-image/module.yaml
@@ -13,11 +13,11 @@ config:
 setup:
   - name: download trivy
     environment:
-      VERSION: 0.54.1
-      LINUX_X86_64_SHA: bbaaf8278b2a9bb49aa848fe23c8bfe19f7db4f5dc7b55a9793357cd78cb5ec5
-      LINUX_ARM64_SHA: 26f8ee5a44ca027082c426d982ce95a37b88cf66defa1e982641eb4497bf1e99
-      MACOS_X86_64_SHA: d182c2de5496504120269b8d50b543e88b4837f8c9876055e54248f0a4e93d77
-      MACOS_ARM64_SHA: 0ea077b074e38c3bce419d3cfaa417581c36e985beb9e571c06c01293158ff6f
+      VERSION: 0.56.1
+      LINUX_X86_64_SHA: 66aacdb5bdc90cef055430078d64414ecb99e37b1ca4ba0a4c0955e694aa9040
+      LINUX_ARM64_SHA: c1067e0e3717175f5d53679978c33ffdd937ee433e5ae70380a39e0d3f10a888
+      MACOS_X86_64_SHA: dd84313a547e36a447e26f4eb1cfcad3eaf442b1e7215eaffa883f90283b0741
+      MACOS_ARM64_SHA: 01efe7c0702cd9f95daa0cbd3b3d0abd192ac037c6491c1f1eb41f525d163a94
     run: |
       BINARY_URL="https://github.com/aquasecurity/trivy/releases/download/v${VERSION}"
       ARCH=$(uname -m)
@@ -58,6 +58,7 @@ steps:
         environment:
           IMAGE_NAME: ${BOOST_IMAGE_NAME}
           TRIVY_ADDITIONAL_ARGS: ${TRIVY_ADDITIONAL_ARGS---ignore-unfixed}
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
         run: |
             $SETUP_PATH/trivy image ${TRIVY_ADDITIONAL_ARGS} --format json --scanners vuln \
               --quiet ${BOOST_IMAGE_NAME}

--- a/scanners/boostsecurityio/trivy-sbom-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom-image/module.yaml
@@ -12,11 +12,11 @@ config:
 setup:
   - name: download trivy
     environment:
-      VERSION: 0.53.0
-      LINUX_X86_64_SHA: 9ddc7209f575990d07babe824e4c66e5dcb9eea010cc93a7c7a4f2014d1d6190
-      LINUX_ARM64_SHA: 81e6920b904a0ea40b16d911ff4e7dfc546bff749062f86164188f9272686457
-      MACOS_X86_64_SHA: 8d9f8b763eb8271dbdb6a2e8289ec2df3ae31e4f1ae58c7c437b981dc3b1c98b
-      MACOS_ARM64_SHA: dfb17fad8b25af497bf9c27f6946aed8d13e2375add3e17e372369f2a8305f96
+      VERSION: 0.56.1
+      LINUX_X86_64_SHA: 66aacdb5bdc90cef055430078d64414ecb99e37b1ca4ba0a4c0955e694aa9040
+      LINUX_ARM64_SHA: c1067e0e3717175f5d53679978c33ffdd937ee433e5ae70380a39e0d3f10a888
+      MACOS_X86_64_SHA: dd84313a547e36a447e26f4eb1cfcad3eaf442b1e7215eaffa883f90283b0741
+      MACOS_ARM64_SHA: 01efe7c0702cd9f95daa0cbd3b3d0abd192ac037c6491c1f1eb41f525d163a94
     run: |
       BINARY_URL="https://github.com/aquasecurity/trivy/releases/download/v${VERSION}"
       ARCH=$(uname -m)
@@ -56,6 +56,7 @@ steps:
       command:
         environment:
           IMAGE_NAME: ${BOOST_IMAGE_NAME}
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
         run: |
             $SETUP_PATH/trivy image ${TRIVY_ADDITIONAL_ARGS} --format cyclonedx --license-full ${BOOST_IMAGE_NAME}
       format: cyclonedx

--- a/scanners/boostsecurityio/trivy-sbom/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom/module.yaml
@@ -12,11 +12,11 @@ config:
 setup:
   - name: download trivy
     environment:
-      VERSION: 0.53.0
-      LINUX_X86_64_SHA: 9ddc7209f575990d07babe824e4c66e5dcb9eea010cc93a7c7a4f2014d1d6190
-      LINUX_ARM64_SHA: 81e6920b904a0ea40b16d911ff4e7dfc546bff749062f86164188f9272686457
-      MACOS_X86_64_SHA: 8d9f8b763eb8271dbdb6a2e8289ec2df3ae31e4f1ae58c7c437b981dc3b1c98b
-      MACOS_ARM64_SHA: dfb17fad8b25af497bf9c27f6946aed8d13e2375add3e17e372369f2a8305f96
+      VERSION: 0.56.1
+      LINUX_X86_64_SHA: 66aacdb5bdc90cef055430078d64414ecb99e37b1ca4ba0a4c0955e694aa9040
+      LINUX_ARM64_SHA: c1067e0e3717175f5d53679978c33ffdd937ee433e5ae70380a39e0d3f10a888
+      MACOS_X86_64_SHA: dd84313a547e36a447e26f4eb1cfcad3eaf442b1e7215eaffa883f90283b0741
+      MACOS_ARM64_SHA: 01efe7c0702cd9f95daa0cbd3b3d0abd192ac037c6491c1f1eb41f525d163a94
     run: |
       BINARY_URL="https://github.com/aquasecurity/trivy/releases/download/v${VERSION}"
       ARCH=$(uname -m)
@@ -56,6 +56,7 @@ steps:
       command:
         environment:
           NO_COLOR: "true"
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
         run: |
             $SETUP_PATH/trivy fs --format=cyclonedx --license-full --no-progress --scanners vuln --cache-dir=/tmp/trivy/ . 2>&1
       format: cyclonedx


### PR DESCRIPTION
trivy has started experiencing a number of rate limits when pulling the vulnerability database
to mitigate this issue, they have implemented a repo cache in ECR as well as added support for
pulling from multiple vulnerability databases. 

