### PR TITLE
[BST-13457] Removes prefix BoostSecurity for 3rd party scanners.

### DIFF
--- a/scanners/boostsecurityio/brakeman/module.yaml
+++ b/scanners/boostsecurityio/brakeman/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/brakeman
-name: BoostSecurity Brakeman
+name: Brakeman
 namespace: boostsecurityio/brakeman
 scan_types:
   - sast

--- a/scanners/boostsecurityio/bundler-audit/module.yaml
+++ b/scanners/boostsecurityio/bundler-audit/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/bundler-audit
-name: BoostSecurity bundler-audit
+name: Bundler-audit
 namespace: boostsecurityio/bundler-audit
 scan_types:
   - sca

--- a/scanners/boostsecurityio/bundler-audit/module.yaml
+++ b/scanners/boostsecurityio/bundler-audit/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/bundler-audit
-name: Bundler-audit
+name: bundler-audit
 namespace: boostsecurityio/bundler-audit
 scan_types:
   - sca

--- a/scanners/boostsecurityio/checkov-tf-plan/module.yaml
+++ b/scanners/boostsecurityio/checkov-tf-plan/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/checkov-tf-plan
-name: BoostSecurity Checkov TF Plan
+name: Checkov TF Plan
 namespace: boostsecurityio/checkov-tf-plan
 scan_types:
   - iac

--- a/scanners/boostsecurityio/checkov/module.yaml
+++ b/scanners/boostsecurityio/checkov/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/checkov
-name: BoostSecurity Checkov
+name: Checkov
 namespace: boostsecurityio/checkov
 scan_types:
   - iac

--- a/scanners/boostsecurityio/codeql/module.yaml
+++ b/scanners/boostsecurityio/codeql/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/codeql
-name: BoostSecurity CodeQL
+name: CodeQL
 namespace: boostsecurityio/codeql
 scan_types:
   - sast

--- a/scanners/boostsecurityio/gitleaks-full/module.yaml
+++ b/scanners/boostsecurityio/gitleaks-full/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/gitleaks-full
-name: BoostSecurity Gitleaks Git Scan
+name: Gitleaks Git Scan
 namespace: boostsecurityio/gitleaks-full
 scan_types:
   - secrets

--- a/scanners/boostsecurityio/gitleaks/module.yaml
+++ b/scanners/boostsecurityio/gitleaks/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/gitleaks
-name: BoostSecurity Gitleaks
+name: Gitleaks
 namespace: boostsecurityio/gitleaks
 scan_types:
   - secrets

--- a/scanners/boostsecurityio/gosec/module.yaml
+++ b/scanners/boostsecurityio/gosec/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/gosec
-name: Gosec
+name: gosec
 namespace: boostsecurityio/gosec
 scan_types:
   - sast

--- a/scanners/boostsecurityio/gosec/module.yaml
+++ b/scanners/boostsecurityio/gosec/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/gosec
-name: BoostSecurity gosec
+name: Gosec
 namespace: boostsecurityio/gosec
 scan_types:
   - sast

--- a/scanners/boostsecurityio/modelscan/module.yaml
+++ b/scanners/boostsecurityio/modelscan/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/modelscan
-name: BoostSecurity Modelscan
+name: Modelscan
 namespace: boostsecurityio/modelscan
 scan_types:
   - sast

--- a/scanners/boostsecurityio/nancy/module.yaml
+++ b/scanners/boostsecurityio/nancy/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/nancy
-name: BoostSecurity nancy
+name: Nancy
 namespace: boostsecurityio/nancy
 scan_types:
   - sca

--- a/scanners/boostsecurityio/npm-audit/module.yaml
+++ b/scanners/boostsecurityio/npm-audit/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/npm-audit
-name: BoostSecurity npm-audit
+name: Npm-audit
 namespace: boostsecurityio/npm-audit
 scan_types:
   - sca

--- a/scanners/boostsecurityio/npm-audit/module.yaml
+++ b/scanners/boostsecurityio/npm-audit/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/npm-audit
-name: Npm-audit
+name: npm-audit
 namespace: boostsecurityio/npm-audit
 scan_types:
   - sca

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/osv-scanner
-name: OSV Scanner
+name: OSV-Scanner
 namespace: boostsecurityio/osv-scanner
 scan_types:
   - sca

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/osv-scanner
-name: BoostSecurity osv-scanner
+name: OSV Scanner
 namespace: boostsecurityio/osv-scanner
 scan_types:
   - sca

--- a/scanners/boostsecurityio/safety/module.yaml
+++ b/scanners/boostsecurityio/safety/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/safety
-name: BoostSecurity Safety
+name: Safety
 namespace: boostsecurityio/safety
 scan_types:
   - sca

--- a/scanners/boostsecurityio/semgrep-pro/module.yaml
+++ b/scanners/boostsecurityio/semgrep-pro/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/semgrep-pro
-name: BoostSecurity semgrep Pro
+name: Semgrep Pro
 namespace: boostsecurityio/semgrep-pro
 scan_types:
   - sast

--- a/scanners/boostsecurityio/semgrep/module.yaml
+++ b/scanners/boostsecurityio/semgrep/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/semgrep
-name: Ssemgrep
+name: Semgrep
 namespace: boostsecurityio/semgrep
 scan_types:
   - sast

--- a/scanners/boostsecurityio/semgrep/module.yaml
+++ b/scanners/boostsecurityio/semgrep/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/semgrep
-name: BoostSecurity semgrep
+name: Ssemgrep
 namespace: boostsecurityio/semgrep
 scan_types:
   - sast

--- a/scanners/boostsecurityio/snyk-test/module.yaml
+++ b/scanners/boostsecurityio/snyk-test/module.yaml
@@ -2,7 +2,7 @@ api_version: 1.0
 
 
 id: boostsecurityio/snyk-test
-name: BoostSecurity Snyk SCA
+name: Snyk SCA
 namespace: boostsecurityio/snyk-test
 scan_types:
   - sca

--- a/scanners/boostsecurityio/trivy-fs/module.yaml
+++ b/scanners/boostsecurityio/trivy-fs/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/trivy-fs
-name: BoostSecurity Trivy (Filesystem scanning)
+name: Trivy (Filesystem scanning)
 namespace: boostsecurityio/trivy-fs
 scan_types:
   - sca

--- a/scanners/boostsecurityio/trivy-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-image/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/trivy-image
-name: BoostSecurity Trivy (Image scanning)
+name: Trivy (Image scanning)
 namespace: boostsecurityio/trivy-image
 scan_types:
   - sca_container

--- a/scanners/boostsecurityio/trivy-sbom-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom-image/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/trivy-sbom-image
-name: BoostSecurity Trivy (Image SBOM)
+name: Trivy (Image SBOM)
 namespace: boostsecurityio/trivy-sbom-image
 scan_types:
   - sbom

--- a/scanners/boostsecurityio/trivy-sbom/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 id: boostsecurityio/trivy-sbom
-name: BoostSecurity Trivy (FS SBOM)
+name: Trivy (FS SBOM)
 namespace: boostsecurityio/trivy-sbom
 scan_types:
   - sbom

--- a/server-side-scanners/boostsecurityio/blackduck/module.yaml
+++ b/server-side-scanners/boostsecurityio/blackduck/module.yaml
@@ -1,4 +1,4 @@
-name: BoostSecurity BlackDuck
+name: BlackDuck
 namespace: boostsecurityio/blackduck
 scan_types:
   - sca

--- a/server-side-scanners/boostsecurityio/sonarqube/module.yaml
+++ b/server-side-scanners/boostsecurityio/sonarqube/module.yaml
@@ -1,4 +1,4 @@
-name: BoostSecurity SonarQube
+name: SonarQube
 namespace: boostsecurityio/sonarqube
 scan_types:
   - sast


### PR DESCRIPTION
For 3rd party scanners, we're to remove the prefix BoostSecurity, recommended to avoid issues with the 3rd parties.