### PR TITLE
BST-13480 Add the baseline group and server module definitions

### DIFF
--- a/server-side-scanners/boostsecurityio/baseline-server/module.yaml
+++ b/server-side-scanners/boostsecurityio/baseline-server/module.yaml
@@ -1,0 +1,3 @@
+name: BoostSecurity Scanner (Server)
+namespace: boostsecurityio/baseline-server
+group: boostsecurityio/groups/baseline

--- a/server-side-scanners/boostsecurityio/baseline-server/module.yaml
+++ b/server-side-scanners/boostsecurityio/baseline-server/module.yaml
@@ -1,3 +1,8 @@
 name: BoostSecurity Scanner (Server)
 namespace: boostsecurityio/baseline-server
 group: boostsecurityio/groups/baseline
+scan_types:
+  - cicd
+  - license
+  - sca
+  - sci

--- a/server-side-scanners/boostsecurityio/baseline-server/rules.yaml
+++ b/server-side-scanners/boostsecurityio/baseline-server/rules.yaml
@@ -1,0 +1,8 @@
+import:
+  - boostsecurityio/cicd
+  - boostsecurityio/oss-license
+  - boostsecurityio/sbom-sca
+  - boostsecurityio/sci
+  - boostsecurityio/sci-sca
+
+rules: {}

--- a/server-side-scanners/boostsecurityio/groups/baseline/module.yaml
+++ b/server-side-scanners/boostsecurityio/groups/baseline/module.yaml
@@ -1,0 +1,4 @@
+name: BoostSecurity Scanner
+namespace: boostsecurityio/baseline
+scan_types:
+  - supply-chain

--- a/server-side-scanners/boostsecurityio/groups/baseline/module.yaml
+++ b/server-side-scanners/boostsecurityio/groups/baseline/module.yaml
@@ -2,4 +2,4 @@ name: BoostSecurity Scanner
 id: boostsecurityio/groups/baseline
 namespace: boostsecurityio/groups/baseline
 scan_types:
-  - supply-chain
+  - supply_chain

--- a/server-side-scanners/boostsecurityio/groups/baseline/module.yaml
+++ b/server-side-scanners/boostsecurityio/groups/baseline/module.yaml
@@ -1,4 +1,5 @@
 name: BoostSecurity Scanner
-namespace: boostsecurityio/baseline
+id: boostsecurityio/groups/baseline
+namespace: boostsecurityio/groups/baseline
 scan_types:
   - supply-chain

--- a/server-side-scanners/boostsecurityio/groups/baseline/rules.yaml
+++ b/server-side-scanners/boostsecurityio/groups/baseline/rules.yaml
@@ -1,0 +1,5 @@
+import:
+  - boostsecurityio/baseline
+  - boostsecurityio/baseline-server
+
+rules: {}


### PR DESCRIPTION
The server will aggregate analyses from the CICD, SCA from SBOM, License from SBOM, SCA from SCI server scanners.

The group will join the server and the cli scanners.