### PR TITLE
BST-13818 Update composition/sci scanner to latest

### DIFF
--- a/scanners/boostsecurityio/baseline/module.yaml
+++ b/scanners/boostsecurityio/baseline/module.yaml
@@ -17,7 +17,7 @@ steps:
     - scan:
         command:
           docker:
-            image: public.ecr.aws/boostsecurityio/boost-scanner-native:44a65bf@sha256:cefdba826edb2138b6d219d7ff398181158caac3755e6542171ba6d8c06e594f
+            image: public.ecr.aws/boostsecurityio/boost-scanner-native:9f3dd13@sha256:3c516265c193f9b62fa2899276efd52d214c8b49a2df8c1891d068b845485000
             command: scanner scan
             workdir: /src
           name: scanner

--- a/scanners/boostsecurityio/baseline/module.yaml
+++ b/scanners/boostsecurityio/baseline/module.yaml
@@ -17,7 +17,7 @@ steps:
     - scan:
         command:
           docker:
-            image: public.ecr.aws/boostsecurityio/boost-scanner-native:9f3dd13@sha256:3c516265c193f9b62fa2899276efd52d214c8b49a2df8c1891d068b845485000
+            image: public.ecr.aws/boostsecurityio/boost-scanner-native:44a65bf@sha256:cefdba826edb2138b6d219d7ff398181158caac3755e6542171ba6d8c06e594f
             command: scanner scan
             workdir: /src
           name: scanner

--- a/scanners/boostsecurityio/composition/module.yaml
+++ b/scanners/boostsecurityio/composition/module.yaml
@@ -17,7 +17,7 @@ steps:
       format: metadata
       command:
         docker:
-          image: public.ecr.aws/boostsecurityio/boost-scanner-composition:b5ed688@sha256:a68838c47601fa6b98c6583cc099e3bc7748bf37adf33ca9a05a74efb719066c
+          image: public.ecr.aws/boostsecurityio/boost-scanner-composition:7d13d0e@sha256:eb4b18beb1834a59a66092bc263d32808dbf9f14290938388950f3ca70c1ffa9
           command: scan
           workdir: /src
           environment:

--- a/scanners/boostsecurityio/supply-chain-inventory/module.yaml
+++ b/scanners/boostsecurityio/supply-chain-inventory/module.yaml
@@ -16,7 +16,7 @@ steps:
       format: supply_chain_inventory
       command:
         docker:
-          image: public.ecr.aws/boostsecurityio/boost-scanner-composition:33167e0@sha256:0c2d1a78ffb097d4fba7b193f314ac065bec523a7a5b78830452fd688119f342
+          image: public.ecr.aws/boostsecurityio/boost-scanner-composition:7d13d0e@sha256:eb4b18beb1834a59a66092bc263d32808dbf9f14290938388950f3ca70c1ffa9
           command: inventory
           workdir: /src
           environment:


### PR DESCRIPTION
This brings the extra resilience to invalid files from the semgrep scanner.