### PR TITLE
BST-14070 - Remove stored-secrets tag on CWE-200

### DIFF
--- a/rules-realm/boostsecurityio/mitre-cwe/rules.yaml
+++ b/rules-realm/boostsecurityio/mitre-cwe/rules.yaml
@@ -3547,7 +3547,6 @@ rules:
     categories:
     - ALL
     - cwe-200
-    - stored-secrets
     - boost-hardened
     - owasp-top-10
     description: The product exposes sensitive information to an actor that is not


### PR DESCRIPTION
CWE-200 is pretty broad and SARIF scanners reporting on CWE would get the category / label / tag `stored-secrets` which collides with Gitleaks. 

Some semgrep rules have CWE-200 (for instance public S3 bucket on terraform stuff) and it's clearly not a "stored secrets" like Gitleaks would find - so default policies don't jive well with that.

We decided to drop the tag to avoid confusion