### PR TITLE
Updated trivy version to 0.61.0

### DIFF
--- a/scanners/boostsecurityio/trivy-fs/module.yaml
+++ b/scanners/boostsecurityio/trivy-fs/module.yaml
@@ -31,11 +31,11 @@ config:
 setup:
   - name: download trivy
     environment:
-      VERSION: 0.57.0
-      LINUX_X86_64_SHA: cf08a8cd861e5192631fc03bb21efde27c1d93e4407ab70bab32e572bafcbf07
-      LINUX_ARM64_SHA: 29012fdb5ba18da506d1c8b6f389c2ec9d113db965c254971f35267ebb45dd64
-      MACOS_X86_64_SHA: e7955b6d38d8125d4aa8936e6af51b0de2b0e0840b4feb90b44002bf7f47bf13
-      MACOS_ARM64_SHA: 61230c8a56e463e8eba2bf922bc688b7bd40352187e1f725c79861b0801437f0
+      VERSION: 0.61.0
+      LINUX_X86_64_SHA: 31af7049380abcdc422094638cc33364593f0ccc89c955dd69d27aca288ae79c
+      LINUX_ARM64_SHA: d18a9ec7d408d541182e7f3165cdaa934fd05f586e4f22ce547ed1f1640e8c3f
+      MACOS_X86_64_SHA: 7454cd0d31dec55498baa2fbec9c4034c23ab52df45bb256c29297f2099129f8
+      MACOS_ARM64_SHA: 9ad04f68b7823109b93d3c6b4e069d932348bf2847e4ccd197787f87f346138e
     run: |
       BINARY_URL="https://github.com/aquasecurity/trivy/releases/download/v${VERSION}"
       ARCH=$(uname -m)

--- a/scanners/boostsecurityio/trivy-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-image/module.yaml
@@ -13,11 +13,11 @@ config:
 setup:
   - name: download trivy
     environment:
-      VERSION: 0.57.0
-      LINUX_X86_64_SHA: cf08a8cd861e5192631fc03bb21efde27c1d93e4407ab70bab32e572bafcbf07
-      LINUX_ARM64_SHA: 29012fdb5ba18da506d1c8b6f389c2ec9d113db965c254971f35267ebb45dd64
-      MACOS_X86_64_SHA: e7955b6d38d8125d4aa8936e6af51b0de2b0e0840b4feb90b44002bf7f47bf13
-      MACOS_ARM64_SHA: 61230c8a56e463e8eba2bf922bc688b7bd40352187e1f725c79861b0801437f0
+      VERSION: 0.61.0
+      LINUX_X86_64_SHA: 31af7049380abcdc422094638cc33364593f0ccc89c955dd69d27aca288ae79c
+      LINUX_ARM64_SHA: d18a9ec7d408d541182e7f3165cdaa934fd05f586e4f22ce547ed1f1640e8c3f
+      MACOS_X86_64_SHA: 7454cd0d31dec55498baa2fbec9c4034c23ab52df45bb256c29297f2099129f8
+      MACOS_ARM64_SHA: 9ad04f68b7823109b93d3c6b4e069d932348bf2847e4ccd197787f87f346138e
     run: |
       BINARY_URL="https://github.com/aquasecurity/trivy/releases/download/v${VERSION}"
       ARCH=$(uname -m)

--- a/scanners/boostsecurityio/trivy-sbom-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom-image/module.yaml
@@ -12,11 +12,11 @@ config:
 setup:
   - name: download trivy
     environment:
-      VERSION: 0.57.0
-      LINUX_X86_64_SHA: cf08a8cd861e5192631fc03bb21efde27c1d93e4407ab70bab32e572bafcbf07
-      LINUX_ARM64_SHA: 29012fdb5ba18da506d1c8b6f389c2ec9d113db965c254971f35267ebb45dd64
-      MACOS_X86_64_SHA: e7955b6d38d8125d4aa8936e6af51b0de2b0e0840b4feb90b44002bf7f47bf13
-      MACOS_ARM64_SHA: 61230c8a56e463e8eba2bf922bc688b7bd40352187e1f725c79861b0801437f0
+      VERSION: 0.61.0
+      LINUX_X86_64_SHA: 31af7049380abcdc422094638cc33364593f0ccc89c955dd69d27aca288ae79c
+      LINUX_ARM64_SHA: d18a9ec7d408d541182e7f3165cdaa934fd05f586e4f22ce547ed1f1640e8c3f
+      MACOS_X86_64_SHA: 7454cd0d31dec55498baa2fbec9c4034c23ab52df45bb256c29297f2099129f8
+      MACOS_ARM64_SHA: 9ad04f68b7823109b93d3c6b4e069d932348bf2847e4ccd197787f87f346138e
     run: |
       BINARY_URL="https://github.com/aquasecurity/trivy/releases/download/v${VERSION}"
       ARCH=$(uname -m)

--- a/scanners/boostsecurityio/trivy-sbom/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom/module.yaml
@@ -12,11 +12,11 @@ config:
 setup:
   - name: download trivy
     environment:
-      VERSION: 0.57.0
-      LINUX_X86_64_SHA: cf08a8cd861e5192631fc03bb21efde27c1d93e4407ab70bab32e572bafcbf07
-      LINUX_ARM64_SHA: 29012fdb5ba18da506d1c8b6f389c2ec9d113db965c254971f35267ebb45dd64
-      MACOS_X86_64_SHA: e7955b6d38d8125d4aa8936e6af51b0de2b0e0840b4feb90b44002bf7f47bf13
-      MACOS_ARM64_SHA: 61230c8a56e463e8eba2bf922bc688b7bd40352187e1f725c79861b0801437f0
+      VERSION: 0.61.0
+      LINUX_X86_64_SHA: 31af7049380abcdc422094638cc33364593f0ccc89c955dd69d27aca288ae79c
+      LINUX_ARM64_SHA: d18a9ec7d408d541182e7f3165cdaa934fd05f586e4f22ce547ed1f1640e8c3f
+      MACOS_X86_64_SHA: 7454cd0d31dec55498baa2fbec9c4034c23ab52df45bb256c29297f2099129f8
+      MACOS_ARM64_SHA: 9ad04f68b7823109b93d3c6b4e069d932348bf2847e4ccd197787f87f346138e
     run: |
       BINARY_URL="https://github.com/aquasecurity/trivy/releases/download/v${VERSION}"
       ARCH=$(uname -m)


### PR DESCRIPTION
Smoke tests: https://github.com/boost-sandbox/module-tests-trivy/actions/runs/14516569664