### PR TITLE
Adds error handling for missing lockfiles

### DIFF
--- a/scanners/boostsecurityio/npm-audit/module.yaml
+++ b/scanners/boostsecurityio/npm-audit/module.yaml
@@ -16,7 +16,7 @@ steps:
   - scan:
       command:
         docker:
-          image: node:18.12-alpine3.16@sha256:1f09c210a17508d34277971b19541a47a26dc5a641dedc03bd28cff095052996
+          image: node:22-alpine3.21@sha256:ad1aedbcc1b0575074a91ac146d6956476c1f9985994810e4ee02efd932a68fd
           command: |
             sh -c 'npm audit --json $NPM_AUDIT_ARGS || true'
           workdir: /src

--- a/scanners/boostsecurityio/npm-audit/module.yaml
+++ b/scanners/boostsecurityio/npm-audit/module.yaml
@@ -26,7 +26,7 @@ steps:
       format: sarif
       post-processor:
         docker:
-            image: public.ecr.aws/boostsecurityio/boost-converter-sca:6e4b6c1@sha256:417c90b672b016b01dac84a4cf24d3a042503b6ddcfd1ba22ebd24d229f78883
+            image: public.ecr.aws/boostsecurityio/boost-converter-sca:5ba4f55@sha256:2637c3b9f21dbc418e095c91f3068bd8dfecbd8e25654f71893f068a68b96487
             command: |
               process --scanner npm-audit
             environment:


### PR DESCRIPTION
The sarif now reports the invocation error to the BE instead of failing with a json error in the pipeline.

Fix stdout issues by updating node version, in previous versions of node the json is not being outputted to stdout making it impossible to parse the error.