### PR TITLE
Semgrep - Improve pre scan checks and ease of extending rules

### DIFF
--- a/scanners/boostsecurityio/semgrep/module.yaml
+++ b/scanners/boostsecurityio/semgrep/module.yaml
@@ -12,29 +12,22 @@ config:
   - .semgrep/*
 
 setup:
-  - name: Validate rules
-    environment:
-      SEMGREP_RULES: ${SEMGREP_RULES:-https://assets.build.boostsecurity.io/semgrep-rules/stable/all-sast-rules.yml}
+  - name: Utility scripts
     run: |
-      echo "SEMGREP_RULES set to: '$SEMGREP_RULES'"
-      for rule in $SEMGREP_RULES; do
-        case "$rule" in
-          .semgrep/*|http://*|https://*)
-            # valid rule token; do nothing
-            ;;
-          *)
-            echo "Semgrep Community Rules cannot be used. Provide a URL or relative path to rules file or leave blank for Boost curated rules."
-            exit 1
-            ;;
-        esac
-      done
+      mkdir -p $SETUP_PATH/pre-scan-checks/
+      cp $SETUP_PATH/../../registry/scanners/boostsecurityio/semgrep/prescan_checks.sh $SETUP_PATH/pre-scan-checks/semgrep
 
 steps:
+  - run: |
+      $SETUP_PATH/pre-scan-checks/semgrep
+    environment:
+      SEMGREP_RULES: ${SEMGREP_RULES:-boost/sast/rules/semgrep@stable}
   - scan:
       command:
         docker:
           image: returntocorp/semgrep:1.114.0@sha256:0cd75960cfec2215ff734a4f6379bbbb6edb82de0c24593dd0a70ec65e9860a9
-          command: semgrep scan --oss-only --sarif --quiet --disable-version-check --metrics=off .
+          command: |
+            semgrep scan --config ./.semgrep --oss-only --sarif --quiet --disable-version-check --metrics=off .
           workdir: /src
           environment:
             XDG_CONFIG_HOME: /tmp

--- a/scanners/boostsecurityio/semgrep/prescan_checks.sh
+++ b/scanners/boostsecurityio/semgrep/prescan_checks.sh
@@ -76,4 +76,5 @@ if [ "$(find .semgrep -regex '.*\.ya?ml' | wc -l)" == "0" ]
 then
   >&2 echo "Semgrep custom rules validation failed for $SEMGREP_RULES."
   >&2 echo "  Missing yaml configuration files"
+  exit 1
 fi

--- a/scanners/boostsecurityio/semgrep/prescan_checks.sh
+++ b/scanners/boostsecurityio/semgrep/prescan_checks.sh
@@ -13,7 +13,7 @@ fetch_remote() {
     if [ "$file_extension" != "yaml" ] && [ "$file_extension" != "yml" ]
     then
         >&2 echo "Semgrep custom rules validation failed."
-        >&2 echo " The provided URL do not point to a yaml file: $1."
+        >&2 echo " The provided URL does not point to a YAML file: $1."
         rm -rf $local_rules_dst
         exit 1
     fi

--- a/scanners/boostsecurityio/semgrep/prescan_checks.sh
+++ b/scanners/boostsecurityio/semgrep/prescan_checks.sh
@@ -47,6 +47,7 @@ for rule in $SEMGREP_RULES; do
           then
             >&2 echo "Semgrep custom rules validation failed."
             >&2 echo " The specific file or directory does not exist in the code repository: $rule."
+            exit 1
           fi
           cp -R -f "$local_rules_dst/$rule" .semgrep || true
         fi

--- a/scanners/boostsecurityio/semgrep/prescan_checks.sh
+++ b/scanners/boostsecurityio/semgrep/prescan_checks.sh
@@ -8,6 +8,7 @@ mkdir -p .semgrep
 
 fetch_remote() {
     file_name="${1##*/}"
+    file_name=$(echo $file_name | cut -d '#' -f 1 | cut -d '?' -f 1)
     file_extension="${file_name##*.}"
     if [ "$file_extension" != "yaml" ] && [ "$file_extension" != "yml" ]
     then

--- a/scanners/boostsecurityio/semgrep/prescan_checks.sh
+++ b/scanners/boostsecurityio/semgrep/prescan_checks.sh
@@ -38,7 +38,7 @@ for rule in $SEMGREP_RULES; do
     case "$rule" in
       .semgrep/*)
         # Local rules are allowed
-        cp -R $local_rules_dst/.semgrep/* .semgrep || true
+        cp -R -f $local_rules_dst/.semgrep/* .semgrep || true
         ;;
       http://*|https://*)
         fetch_remote $rule

--- a/scanners/boostsecurityio/semgrep/prescan_checks.sh
+++ b/scanners/boostsecurityio/semgrep/prescan_checks.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+local_rules_dst=$(mktemp -d)
+if [ -d ".semgrep" ]
+then
+    mv .semgrep/ "$local_rules_dst"
+fi
+mkdir -p .semgrep
+
+fetch_remote() {
+    file_name="${1##*/}"
+    file_extension="${file_name##*.}"
+    if [ "$file_extension" != "yaml" ] && [ "$file_extension" != "yml" ]
+    then
+        >&2 echo "Semgrep custom rules validation failed."
+        >&2 echo " The provided URL do not point to a yaml file: $1."
+        rm -rf $local_rules_dst
+        exit 1
+    fi
+  
+    dst_file=$(mktemp --suffix=.yml)
+    http_code=$(curl -s -L --fail -w '%{http_code}\n' -o $dst_file $1)
+    if [ "${http_code}" == "200" ]
+    then
+        cp $dst_file .semgrep/
+        rm -f $dst_file
+        return 0
+    fi
+
+    >&2 echo "Semgrep custom rules - Cannot fetch $1."
+    rm -f $dst_file
+    rm -rf $local_rules_dst
+    exit 1
+}
+
+SEMGREP_RULES=${SEMGREP_RULES:-boost/sast/rules/semgrep@stable}
+for rule in $SEMGREP_RULES; do
+    case "$rule" in
+      .semgrep/*)
+        # Local rules are allowed
+        cp -R $local_rules_dst/.semgrep/* .semgrep || true
+        ;;
+      http://*|https://*)
+        fetch_remote $rule
+        ;;
+      boost/sast/rules/semgrep@*)
+        # Boost
+        version=$(echo "$rule" | cut -d '@' -f 2)
+        fetch_remote "https://assets.build.boostsecurity.io/semgrep-rules/$version/all-sast-rules.yml"
+        ;;
+      *)
+        >&2 echo "Semgrep custom rules validation failed on $rule."
+        >&2 echo "  Community rules cannot be used."
+        >&2 echo "  Provide a URL or relative path to rules file or leave blank for Boost curated rules."
+        rm -rf $local_rules_dst
+        exit 1
+        ;;
+    esac
+done
+
+rm -rf $local_rules_dst


### PR DESCRIPTION
**Improve pre-scan checks:**

Modified the pre-scan check to ensure that custom rules are well-defined:
- Move the check from the module _setup_ to _pre scan step_ so the error details could be visible in boost interface
- Added the following checks:
   - A file of a remote URL must be either a ``.yaml`` or ``.yml``
   - Fetching the URL must returns a HTTP 200 OK code
   - Ensure that the local files or directories exists in the code repository.
   - Ensure that the ``.semgrep`` directoy includes at least one yaml file.

**Ease of extending rules:**

- Boost Semgrep rules set can now be referenced by ``boost/sast/rules/semgrep@stable`` or ``boost/sast/rules/semgrep@canary`` instead of providing an URL.
- Local rules support a top level wildcard.

**Smoke tests:**
Smoke tests definition was updated to add tests cases for both valid and invalid custom ruleset.
https://github.com/boost-sandbox/module-tests-semgrep/actions/runs/16124713060