### PR TITLE
Fix binary detection

### DIFF
--- a/scanners/boostsecurityio/baseline/module.yaml
+++ b/scanners/boostsecurityio/baseline/module.yaml
@@ -12,30 +12,30 @@ scan_types:
 config:
   support_diff_scan: true
   include_files:
-    - *.crx
-    - *.deb
-    - *.dex
-    - *.dey
-    - *.elf
-    - *.o
-    - *.so
-    - *.iso
-    - *.class
-    - *.jar
-    - *.bundle
-    - *.dylib
-    - *.lib
-    - *.msi
-    - *.dll
-    - *.drv
-    - *.efi
-    - *.exe
-    - *.ocx
-    - *.pyc
-    - *.pyo
-    - *.par
-    - *.rpm
-    - *.whl
+    - "*.crx"
+    - "*.deb"
+    - "*.dex"
+    - "*.dey"
+    - "*.elf"
+    - "*.o"
+    - "*.so"
+    - "*.iso"
+    - "*.class"
+    - "*.jar"
+    - "*.bundle"
+    - "*.dylib"
+    - "*.lib"
+    - "*.msi"
+    - "*.dll"
+    - "*.drv"
+    - "*.efi"
+    - "*.exe"
+    - "*.ocx"
+    - "*.pyc"
+    - "*.pyo"
+    - "*.par"
+    - "*.rpm"
+    - "*.whl"
 
 steps:
     - scan:

--- a/scanners/boostsecurityio/baseline/module.yaml
+++ b/scanners/boostsecurityio/baseline/module.yaml
@@ -11,7 +11,31 @@ scan_types:
 
 config:
   support_diff_scan: true
-
+  include_files:
+    - *.crx
+    - *.deb
+    - *.dex
+    - *.dey
+    - *.elf
+    - *.o
+    - *.so
+    - *.iso
+    - *.class
+    - *.jar
+    - *.bundle
+    - *.dylib
+    - *.lib
+    - *.msi
+    - *.dll
+    - *.drv
+    - *.efi
+    - *.exe
+    - *.ocx
+    - *.pyc
+    - *.pyo
+    - *.par
+    - *.rpm
+    - *.whl
 
 steps:
     - scan:


### PR DESCRIPTION
**Description:**

In some cases, the detection of binary files in code repository wasn't working properly due to the boostignore configuration. This PR fix the issue by forcing the inclusion of the detected binary file in the native scanner.

**Smoke tests:**

- https://github.com/boost-sandbox/module-tests-native/actions/runs/16445802130