### PR TITLE
Add CWE-399 to mitre-cwe rules for Brakeman v7.0.0 coverage

### DIFF
--- a/rules-realm/boostsecurityio/mitre-cwe/rules.yaml
+++ b/rules-realm/boostsecurityio/mitre-cwe/rules.yaml
@@ -5693,6 +5693,16 @@ rules:
     name: CWE-40
     pretty_name: 'CWE-40: Path Traversal: ''\\UNC\share\name\'' (Windows UNC Share)'
     ref: https://cwe.mitre.org/data/definitions/40.html
+  CWE-399:
+    categories:
+    - ALL
+    - cwe-399
+    description: Weaknesses in this category are related to improper management of
+      system resources.
+    group: top10-insecure-design
+    name: CWE-399
+    pretty_name: 'CWE-399: Resource Management Errors'
+    ref: https://cwe.mitre.org/data/definitions/399.html
   CWE-400:
     categories:
     - ALL


### PR DESCRIPTION
## Summary

- Brakeman v7.0.0 emits `CWE-399` (Resource Management Errors) from two of its checks: `check_route_dos` (CVE-2015-7581) and
`check_mime_type_dos`
- `CWE-399` was missing from the `boostsecurityio/mitre-cwe` rules realm, causing those findings to fall back to
`CWE-UNKNOWN`
- Added the entry with appropriate metadata consistent with neighboring CWE entries