### PR TITLE
Update genric-api-key rule to remove false positive

### DIFF
--- a/scanners/boostsecurityio/gitleaks/boost.toml
+++ b/scanners/boostsecurityio/gitleaks/boost.toml
@@ -6,7 +6,20 @@ useDefault = true
 [[rules]]
 id = "generic-api-key"
 
- [[rules.allowlists]]
- regexTarget = "line"  
- regexes = [ '''(?i)publicKeyToken="[^"]+"''' ]
- paths = [ '''(?i)web\.config''' ]
+    [[rules.allowlists]]
+    description = "Don't report on URI"
+    regexTarget = "match"
+    regexes = [
+        '''(?i)(?:[\w]+\.)+[\w]+:[0-9]{1,5}(?:/[\w]+)+''',
+    ]
+    
+    [[rules.allowlists]]
+    regexTarget = "line"  
+    regexes = [ '''(?i)publicKeyToken="[^"]+"''' ]
+    paths = [ '''(?i)web\.config''' ]
+    
+    [[rules.allowlists]]
+    description = "Don't report on translation"
+    regexTarget = "line"
+    regexes = [ '''(?i)xmi:type="utility:TranslatableString"''' ]
+    paths = [ '''(?i)\.msgflow$''' ]


### PR DESCRIPTION
Description:

This PR update the Boost Gitleaks default configuration to remove false positive of the generic-api-key rule.