### PR TITLE
Address BOOSTSP-795 - Trivy silently failing

### DIFF
--- a/scanners/boostsecurityio/boost-sca/module.yaml
+++ b/scanners/boostsecurityio/boost-sca/module.yaml
@@ -104,15 +104,15 @@ steps:
           SCANNER_REPORT_PATH: ${SCANNER_REPORT_PATH:-report.cdx.json}
           SCANNER_LOGS: ${SCANNER_LOGS:-scanner.log}
           TRIVY_CACHE_DIR: ${TRIVY_CACHE_DIR:-/tmp/trivy/}  
-        run: >
+        run: |
           $SETUP_PATH/trivy fs ${TRIVY_ADDITIONAL_ARGS} \
                                --no-progress \
                                --skip-version-check \
                                --debug \
+                               --license-full \
                                --format=cyclonedx \
-                               --scanners ${TRIVY_SCANNERS} \
-                               --license-full \ 
                                --output ${SCANNER_REPORT_PATH} \
+                               --scanners ${TRIVY_SCANNERS} \
                                . > ${SCANNER_LOGS} 2>&1 && exit_code=$? || exit_code=$?
           if [ "$exit_code" != "0" ]
           then 

--- a/scanners/boostsecurityio/boost-sca/module.yaml
+++ b/scanners/boostsecurityio/boost-sca/module.yaml
@@ -97,18 +97,29 @@ steps:
       command:
         environment:
           NO_COLOR: "true"
-          TRIVY_ADDITIONAL_ARGS: ${TRIVY_ADDITIONAL_ARGS---ignore-unfixed}
+          TRIVY_ADDITIONAL_ARGS: ${TRIVY_ADDITIONAL_ARGS:-}
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1
+          TRIVY_SCANNERS: vuln
+          SCANNER_REPORT_PATH: ${SCANNER_REPORT_PATH:-report.cdx.json}
+          SCANNER_LOGS: ${SCANNER_LOGS:-scanner.log}
+          TRIVY_CACHE_DIR: ${TRIVY_CACHE_DIR:-/tmp/trivy/}  
         run: >
-          $SETUP_PATH/trivy fs 
-          --cache-dir=/tmp/trivy/
-          --format=cyclonedx
-          --license-full
-          --no-progress
-          --scanners vuln
-          --skip-version-check 
-          . 2>&1
+          $SETUP_PATH/trivy fs ${TRIVY_ADDITIONAL_ARGS} \
+                               --no-progress \
+                               --skip-version-check \
+                               --debug \
+                               --format=cyclonedx \
+                               --scanners ${TRIVY_SCANNERS} \
+                               --license-full \ 
+                               --output ${SCANNER_REPORT_PATH} \
+                               . > ${SCANNER_LOGS} 2>&1 && exit_code=$? || exit_code=$?
+          if [ "$exit_code" != "0" ]
+          then 
+              cat ${SCANNER_LOGS}
+              exit 0
+          fi
+          cat ${SCANNER_REPORT_PATH}     
       format: cyclonedx
       post-processor:
         docker:

--- a/scanners/boostsecurityio/trivy-fs/module.yaml
+++ b/scanners/boostsecurityio/trivy-fs/module.yaml
@@ -101,14 +101,24 @@ steps:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1
           TRIVY_SCANNERS: vuln
-        run: >
-          $SETUP_PATH/trivy fs 
-          ${TRIVY_ADDITIONAL_ARGS} 
-          --format json
-          --no-progress
-          --scanners ${TRIVY_SCANNERS}
-          --skip-version-check 
-          . 2>&1
+          SCANNER_REPORT_PATH: ${SCANNER_REPORT_PATH:-report.json}
+          SCANNER_LOGS: ${SCANNER_LOGS:-scanner.log}
+          TRIVY_CACHE_DIR: ${TRIVY_CACHE_DIR:-/tmp/trivy/}  
+        run: |
+          $SETUP_PATH/trivy fs ${TRIVY_ADDITIONAL_ARGS} \
+                               --no-progress \
+                               --skip-version-check \
+                               --debug \
+                               --scanners ${TRIVY_SCANNERS} \
+                               --format json \
+                               --output ${SCANNER_REPORT_PATH} \
+                               . > ${SCANNER_LOGS} 2>&1 && exit_code=$? || exit_code=$?
+          if [ "$exit_code" != "0" ]
+          then 
+              cat ${SCANNER_LOGS}
+              exit 0
+          fi
+          cat ${SCANNER_REPORT_PATH}     
       format: sarif
       post-processor:
         docker:

--- a/scanners/boostsecurityio/trivy-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-image/module.yaml
@@ -55,15 +55,25 @@ steps:
           TRIVY_ADDITIONAL_ARGS: ${TRIVY_ADDITIONAL_ARGS---ignore-unfixed}
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1
-          TRIVY_SCANNERS: vuln,secret
-        run: >
-          $SETUP_PATH/trivy image 
-          ${TRIVY_ADDITIONAL_ARGS} 
-          --format json 
-          --scanners ${TRIVY_SCANNERS}
-          --skip-version-check 
-          --quiet 
-          ${BOOST_IMAGE_NAME}
+          TRIVY_SCANNERS: ${TRIVY_SCANNERS:-vuln,secret}
+          SCANNER_REPORT_PATH: ${SCANNER_REPORT_PATH:-report.json}
+          SCANNER_LOGS: ${SCANNER_LOGS:-scanner.log}
+          TRIVY_CACHE_DIR: ${TRIVY_CACHE_DIR:-/tmp/trivy/}          
+        run: |
+          $SETUP_PATH/trivy image ${TRIVY_ADDITIONAL_ARGS} \
+                               --skip-version-check \
+                               --debug \
+                               --no-progress \
+                               --format json \
+                               --scanners ${TRIVY_SCANNERS} \
+                               --output ${SCANNER_REPORT_PATH} \
+                               ${BOOST_IMAGE_NAME} > ${SCANNER_LOGS} 2>&1 && exit_code=$? || exit_code=$?
+          if [ "$exit_code" != "0" ]
+          then 
+              cat ${SCANNER_LOGS}
+              exit 0
+          fi
+          cat ${SCANNER_REPORT_PATH}            
       format: sarif
       post-processor:
         docker:

--- a/scanners/boostsecurityio/trivy-sbom-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom-image/module.yaml
@@ -52,13 +52,25 @@ steps:
           IMAGE_NAME: ${BOOST_IMAGE_NAME}
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1
-        run: >
-          $SETUP_PATH/trivy image 
-          ${TRIVY_ADDITIONAL_ARGS}
-          --format cyclonedx 
-          --license-full
-          --skip-version-check
-          ${BOOST_IMAGE_NAME}
+          TRIVY_ADDITIONAL_ARGS: ${TRIVY_ADDITIONAL_ARGS:-}
+          TRIVY_CACHE_DIR: ${TRIVY_CACHE_DIR:-/tmp/trivy/}
+          SCANNER_REPORT_PATH: ${SCANNER_REPORT_PATH:-report.cdx.json}
+          SCANNER_LOGS: ${SCANNER_LOGS:-scanner.log}
+        run: |
+          $SETUP_PATH/trivy image ${TRIVY_ADDITIONAL_ARGS} \
+                               --no-progress \
+                               --skip-version-check \
+                               --debug \
+                               --format cyclonedx \
+                               --license-full \
+                               --output ${SCANNER_REPORT_PATH} \
+                               ${BOOST_IMAGE_NAME} > ${SCANNER_LOGS} 2>&1 && exit_code=$? || exit_code=$?
+          if [ "$exit_code" != "0" ]
+          then 
+              cat ${SCANNER_LOGS}
+              exit 0
+          fi
+          cat ${SCANNER_REPORT_PATH}
       format: cyclonedx
       post-processor:
         docker:

--- a/scanners/boostsecurityio/trivy-sbom/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom/module.yaml
@@ -97,15 +97,27 @@ steps:
           NO_COLOR: "true"
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1
-        run: >
-          $SETUP_PATH/trivy fs
-          --format=cyclonedx
-          --license-full
-          --no-progress
-          --scanners vuln
-          --cache-dir=/tmp/trivy/
-          --skip-version-check 
-          . 2>&1
+          TRIVY_SCANNERS: ${TRIVY_SCANNERS:-vuln}
+          TRIVY_ADDITIONAL_ARGS: ${TRIVY_ADDITIONAL_ARGS:-}
+          TRIVY_CACHE_DIR: ${TRIVY_CACHE_DIR:-/tmp/trivy/}
+          SCANNER_LOGS: ${SCANNER_LOGS:-scanner.log}
+          SCANNER_REPORT_PATH: ${SCANNER_REPORT_PATH:-report.cdx.json}
+        run: |
+          $SETUP_PATH/trivy fs ${TRIVY_ADDITIONAL_ARGS} \
+                               --no-progress \
+                               --skip-version-check \
+                               --debug \
+                               --license-full \
+                               --format=cyclonedx \
+                               --output ${SCANNER_REPORT_PATH} \
+                               --scanners ${TRIVY_SCANNERS} \
+                               . > ${SCANNER_LOGS} 2>&1 && exit_code=$? || exit_code=$?
+          if [ "$exit_code" != "0" ]
+          then 
+              cat ${SCANNER_LOGS}
+              exit 0
+          fi
+          cat ${SCANNER_REPORT_PATH}
       format: cyclonedx
       post-processor:
         docker:


### PR DESCRIPTION
**Problem statement:**

When an error during a Trivy scan, the error reported to the dashboard doesn't include any meaningful information (see below). Even if the log level of the scanning is increased there is no additional information provided to the dashboard.

```
14:57:26 [ERROR] boost.app: command 'sh -ec $SETUP_PATH/trivy fs  --cache-dir=/tmp...' exited with non-zero exit status: 1
Error: Process completed with exit code 1.
```

**What it is in this PR:**

This PR modify Trivy based scanner modules to do the follow (boost-sca, trivy-fs, trivy-sbom, trivy-image, trivy-image-sbom):
- Increase the output level of Trivy to debug.
- Capture the Trivy output to a scanner log file.
- Output the scans results to a report file.
- Check if the Trivy scan fail. If it fails output the scanner logs to stdout. If it pass output the report file to stdout.