### PR TITLE
Add the cicd-gha-unpinned-action rule to the catalog

### DIFF
--- a/scanners/boostsecurityio/baseline/module.yaml
+++ b/scanners/boostsecurityio/baseline/module.yaml
@@ -41,7 +41,7 @@ steps:
     - scan:
         command:
           docker:
-            image: ghcr.io/boostsecurityio/scanner-publishing/boost-scanner-native:6b6cf90@sha256:285e3bd9b11cf47c5e28d501eca0dd70a139f8c02ec1d9a469ba69d3d77dd8f9
+            image: ghcr.io/boostsecurityio/scanner-publishing/boost-scanner-native:8f8a409@sha256:7254ed0df115e4fb5bbf362db17bd87b6c28d7ee8a815f73645bfec217676aa6
             command: scanner scan
             workdir: /src
           name: scanner

--- a/scanners/boostsecurityio/scanner/rules.yaml
+++ b/scanners/boostsecurityio/scanner/rules.yaml
@@ -107,6 +107,22 @@ rules:
     pretty_name: CI/CD - GitHub Action Unsecure Commands
     ref: '{BOOSTSEC_DOC_BASE_URL}/rules/cicd-gha-unsecure-commands.html'
     recommended: true
+  cicd-gha-unpinned-action:
+    categories:
+      - ALL
+      - supply-chain
+      - supply-chain-missing-artifact-integrity-verification
+      - boost-baseline
+      - boost-hardened
+    description: Checks for GitHub Action workflows and composite actions referencing
+      actions or reusable workflows that are not pinned to a full commit SHA. A
+      mutable reference such as a branch or a tag can be repointed at different code
+      after review, so the pinned artifact is not the one that was audited.
+    group: supply-chain-missing-artifact-integrity-verification
+    name: cicd-gha-unpinned-action
+    pretty_name: CI/CD - GitHub Action Unpinned Action
+    ref: '{BOOSTSEC_DOC_BASE_URL}/rules/cicd-gha-unpinned-action.html'
+    recommended: true
   cicd-unpinned-dependencies:
     categories:
       - ALL


### PR DESCRIPTION
Registers `cicd-gha-unpinned-action` in the catalog and rolls the baseline image
pin forward to the build that emits it, so the entry and the image that backs it
land together.

The rule itself shipped in
[boostsec-scanner-native#96](https://github.com/boostsecurityio/boostsec-scanner-native/pull/96);
this makes it reachable by customers.

## The catalog entry

Categorized under `supply-chain-missing-artifact-integrity-verification`, matching
`cicd-unpinned-dependencies` rather than the `supply-chain-cicd-weak-configuration`
of its closest analogue `cicd-circleci-unversioned-orb`. An unpinned `uses:` is a
download without integrity verification — the same failure mode as a missing
lockfile — so it groups with the other pinning rule.

`recommended: true`, matching every sibling `cicd-*` rule. Worth being explicit
about what that flag does and does not do: its only consumer is `policy-service`'s
`recommendedRules` resolver, which populates the dashboard's "Suggested Rules"
button. Rule enablement comes from a policy's own `enabled_rules` and never reads
this flag, so this does not enable the rule for anyone or change finding volume.

## The pin bump is bigger than this rule

The pin moves `6b6cf90` → `8f8a409`, which is **19 commits**, not one. Eighteen of
them are the `#190` lockfile rework, so this also changes `cicd-unpinned-dependencies`
here: eight more ecosystems, and lock files resolved from the repository root, which
stops it reporting every member of a cargo or uv workspace. Unavoidable — the new
rule exists only in the newer build — but it should be reviewed as part of this
change, not discovered later.

## Known gap

`ref:` points at `rules/cicd-gha-unpinned-action.html`, which does not exist yet —
the docs page is
[workspace#274](https://github.com/boostsecurityio/workspace/issues/274). The link
404s until that ships.

Tracked by https://github.com/boostsecurityio/workspace/issues/296
